### PR TITLE
fix: resolve pre-existing Flutter type errors from Phase 2 migration

### DIFF
--- a/app/lib/providers/search_provider.dart
+++ b/app/lib/providers/search_provider.dart
@@ -276,7 +276,7 @@ class SearchNotifier extends StateNotifier<SearchState> {
           type: 'task',
           title: task.title,
           subtitle: task.instructions,
-          status: task.status,
+          status: task.status.value,
           timestamp: task.createdAt,
           originalItem: task,
         ));

--- a/app/lib/providers/tasks_provider.dart
+++ b/app/lib/providers/tasks_provider.dart
@@ -107,6 +107,8 @@ class TasksService {
     bool encrypt = false,
     String? target,
     String? source,
+    String? threadId,
+    String? inReplyTo,
   }) async {
     _log('Creating task: $title (action: ${action.value})');
 
@@ -144,6 +146,8 @@ class TasksService {
       'encrypted': isEncrypted,
       'target': target,
       'source': source ?? 'flynn',
+      'threadId': threadId,
+      'replyTo': inReplyTo,
       'archived': false,
     });
 

--- a/app/lib/screens/messages/create_message_screen.dart
+++ b/app/lib/screens/messages/create_message_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../models/message_model.dart';
+import '../../models/task_model.dart';
 import '../../providers/auth_provider.dart';
-import '../../providers/messages_provider.dart';
+import '../../providers/tasks_provider.dart';
 import '../../services/haptic_service.dart';
 
 class CreateMessageScreen extends ConsumerStatefulWidget {
@@ -16,7 +16,7 @@ class CreateMessageScreen extends ConsumerStatefulWidget {
 
 class _CreateMessageScreenState extends ConsumerState<CreateMessageScreen> {
   final _instructionsController = TextEditingController();
-  MessageAction _action = MessageAction.queue;
+  TaskAction _action = TaskAction.queue;
   String? _selectedTarget;
   bool _isSubmitting = false;
 
@@ -30,15 +30,17 @@ class _CreateMessageScreenState extends ConsumerState<CreateMessageScreen> {
     super.dispose();
   }
 
-  IconData _getIconForAction(MessageAction action) {
+  IconData _getIconForAction(TaskAction action) {
     switch (action) {
-      case MessageAction.interrupt:
+      case TaskAction.interrupt:
         return Icons.bolt;
-      case MessageAction.parallel:
+      case TaskAction.sprint:
+        return Icons.flash_on;
+      case TaskAction.parallel:
         return Icons.call_split;
-      case MessageAction.queue:
+      case TaskAction.queue:
         return Icons.playlist_play;
-      case MessageAction.backlog:
+      case TaskAction.backlog:
         return Icons.inventory_2_outlined;
     }
   }
@@ -67,7 +69,7 @@ class _CreateMessageScreenState extends ConsumerState<CreateMessageScreen> {
     HapticService.medium();
 
     try {
-      await ref.read(messagesServiceProvider).createTask(
+      await ref.read(tasksServiceProvider).createTask(
             userId: user.uid,
             title: title,
             instructions: instructions,
@@ -136,8 +138,8 @@ class _CreateMessageScreenState extends ConsumerState<CreateMessageScreen> {
             // Action flags at top
             SizedBox(
               width: double.infinity,
-              child: SegmentedButton<MessageAction>(
-                segments: MessageAction.values.map((action) {
+              child: SegmentedButton<TaskAction>(
+                segments: TaskAction.values.map((action) {
                   return ButtonSegment(
                     value: action,
                     icon: Icon(_getIconForAction(action)),

--- a/app/lib/screens/tasks/create_task_screen.dart
+++ b/app/lib/screens/tasks/create_task_screen.dart
@@ -34,6 +34,8 @@ class _CreateTaskScreenState extends ConsumerState<CreateTaskScreen> {
     switch (action) {
       case TaskAction.interrupt:
         return Icons.bolt;
+      case TaskAction.sprint:
+        return Icons.rocket_launch;
       case TaskAction.parallel:
         return Icons.call_split;
       case TaskAction.queue:

--- a/app/lib/screens/tasks/tasks_screen.dart
+++ b/app/lib/screens/tasks/tasks_screen.dart
@@ -329,7 +329,7 @@ class TasksScreen extends ConsumerWidget {
                     final inProgressTasks =
                         tasks.where((t) => t.isInProgress).toList();
                     final completedTasks = tasks.where((t) => t.isComplete).toList();
-                    final cancelledTasks = tasks.where((t) => t.isCancelled).toList();
+                    final cancelledTasks = tasks.where((t) => t.isFailed).toList();
 
                     int animationIndex = 0;
                     return ListView(
@@ -754,30 +754,34 @@ class TasksScreen extends ConsumerWidget {
     IconData icon;
 
     switch (task.status) {
-      case 'pending':
+      case LifecycleStatus.created:
         color = Colors.orange;
         label = 'Pending';
         icon = Icons.hourglass_empty;
-        break;
-      case 'in_progress':
+      case LifecycleStatus.active:
         color = Colors.blue;
         label = 'In Progress';
         icon = Icons.play_circle;
-        break;
-      case 'complete':
+      case LifecycleStatus.done:
         color = Colors.green;
         label = 'Complete';
         icon = Icons.check_circle;
-        break;
-      case 'cancelled':
+      case LifecycleStatus.failed:
+        color = Colors.red;
+        label = 'Failed';
+        icon = Icons.error;
+      case LifecycleStatus.blocked:
+        color = Colors.amber;
+        label = 'Blocked';
+        icon = Icons.block;
+      case LifecycleStatus.completing:
+        color = Colors.teal;
+        label = 'Completing';
+        icon = Icons.hourglass_top;
+      case LifecycleStatus.derezzed:
         color = Colors.grey;
-        label = 'Cancelled';
+        label = 'Derezzed';
         icon = Icons.cancel;
-        break;
-      default:
-        color = Colors.grey;
-        label = task.status;
-        icon = Icons.circle;
     }
 
     return Container(

--- a/app/lib/widgets/reply_sheet.dart
+++ b/app/lib/widgets/reply_sheet.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/message_model.dart';
+import '../models/task_model.dart';
 import '../providers/auth_provider.dart';
-import '../providers/messages_provider.dart';
+import '../providers/tasks_provider.dart';
 import '../services/haptic_service.dart';
 
 /// Bottom sheet for creating a reply to an existing message
@@ -36,7 +37,7 @@ class _ReplySheetState extends ConsumerState<ReplySheet> {
   final _titleController = TextEditingController();
   final _instructionsController = TextEditingController();
   bool _isSubmitting = false;
-  MessageAction _selectedAction = MessageAction.queue;
+  TaskAction _selectedAction = TaskAction.queue;
   String _selectedPriority = 'normal';
 
   @override
@@ -64,7 +65,7 @@ class _ReplySheetState extends ConsumerState<ReplySheet> {
       // Determine threadId - use parent's threadId if it exists, otherwise parent's id
       final threadId = widget.parentMessage.threadId ?? widget.parentMessage.id;
 
-      await ref.read(messagesServiceProvider).createTask(
+      await ref.read(tasksServiceProvider).createTask(
             userId: user.uid,
             title: _titleController.text.trim().isEmpty
                 ? 'Reply'
@@ -181,7 +182,7 @@ class _ReplySheetState extends ConsumerState<ReplySheet> {
             const SizedBox(height: 8),
             Wrap(
               spacing: 8,
-              children: MessageAction.values.map((action) {
+              children: TaskAction.values.map((action) {
                 final isSelected = _selectedAction == action;
                 return ChoiceChip(
                   label: Text(action.displayName),


### PR DESCRIPTION
## Summary

- **search_provider.dart**: `task.status` → `task.status.value` (LifecycleStatus→String)
- **tasks_screen.dart**: String literal switch → LifecycleStatus enum cases; `isCancelled` → `isFailed`
- **create_task_screen.dart**: Add missing `TaskAction.sprint` switch case
- **create_message_screen.dart + reply_sheet.dart**: Use `tasksServiceProvider.createTask()` instead of non-existent `messagesServiceProvider.createTask()`; migrate `MessageAction` → `TaskAction`
- **tasks_provider.dart**: Add `threadId`/`inReplyTo` optional params to `createTask()` for reply support

## Context

Pre-existing type errors surfaced during Phase 3 work. All from Phase 2 type migration (String→enum). No refactoring — just type fixes.

## Verification

`flutter analyze` passes with 0 errors (3 pre-existing info-level lints in unrelated files).