### PR TITLE
feat: SARK F2 — Budget enforcement (3 kill mechanisms)

### DIFF
--- a/firebase/functions/src/enforcement/enforceDreamTimeouts.ts
+++ b/firebase/functions/src/enforcement/enforceDreamTimeouts.ts
@@ -1,0 +1,68 @@
+/**
+ * Kill Mechanism 3: Dream timeout enforcement.
+ * Scheduled function that checks for active dreams exceeding their timeout_hours.
+ * Runs every 5 minutes.
+ */
+
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+
+export const enforceDreamTimeouts = functions.pubsub
+  .schedule("every 5 minutes")
+  .onRun(async () => {
+    const db = admin.firestore();
+    const now = Date.now();
+
+    functions.logger.info("[enforceDreamTimeouts] Checking active dreams for timeout violations");
+
+    try {
+      // Iterate all users — dreams are in users/{uid}/tasks
+      const usersSnapshot = await db.collection("users").listDocuments();
+      let timedOut = 0;
+
+      for (const userRef of usersSnapshot) {
+        const dreamsSnapshot = await userRef
+          .collection("tasks")
+          .where("type", "==", "dream")
+          .where("status", "==", "active")
+          .get();
+
+        if (dreamsSnapshot.empty) continue;
+
+        for (const doc of dreamsSnapshot.docs) {
+          const data = doc.data();
+          const startedAt = data.startedAt?.toMillis?.();
+          const timeoutHours = data.dream?.timeout_hours || 4; // Default 4h
+
+          if (!startedAt) {
+            functions.logger.warn(`Dream ${doc.id} is active but has no startedAt`);
+            continue;
+          }
+
+          const elapsedMs = now - startedAt;
+          const timeoutMs = timeoutHours * 60 * 60 * 1000;
+
+          if (elapsedMs >= timeoutMs) {
+            const elapsedHours = (elapsedMs / (60 * 60 * 1000)).toFixed(1);
+            functions.logger.warn(
+              `[enforceDreamTimeouts] Dream ${doc.id} timed out: ${elapsedHours}h elapsed >= ${timeoutHours}h limit. Killing.`
+            );
+
+            await doc.ref.update({
+              status: "failed",
+              "dream.outcome": `Timeout: ${elapsedHours}h elapsed, ${timeoutHours}h limit`,
+              completedAt: admin.firestore.FieldValue.serverTimestamp(),
+            });
+
+            timedOut++;
+          }
+        }
+      }
+
+      functions.logger.info(`[enforceDreamTimeouts] Complete. ${timedOut} dream(s) timed out.`);
+      return { timedOut };
+    } catch (error) {
+      functions.logger.error("[enforceDreamTimeouts] Error:", error);
+      throw error;
+    }
+  });

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -17,3 +17,6 @@ export { cleanupExpiredRelay } from "./cleanup/cleanupExpiredRelay";
 export { cleanupLedger } from "./cleanup/cleanupLedger";
 export { processDeadLetters } from "./cleanup/processDeadLetters";
 export { cleanupAudit } from "./cleanup/cleanupAudit";
+
+// Budget enforcement
+export { enforceDreamTimeouts } from "./enforcement/enforceDreamTimeouts";

--- a/mcp-server/src/middleware/budgetGuard.ts
+++ b/mcp-server/src/middleware/budgetGuard.ts
@@ -1,0 +1,85 @@
+/**
+ * Budget Guard — Dream Mode budget enforcement.
+ * Kill Mechanism 1: Gate-level check before tool execution.
+ *
+ * Queries active dreams for the calling program and rejects
+ * tool calls when budget_consumed_usd >= budget_cap_usd.
+ *
+ * Uses a 60-second TTL cache to avoid per-call Firestore reads.
+ */
+
+import { getFirestore } from "../firebase/client.js";
+import type { AuthContext } from "../auth/apiKeyValidator.js";
+
+interface BudgetCheckResult {
+  allowed: boolean;
+  dreamId?: string;
+  reason?: string;
+}
+
+interface CacheEntry extends BudgetCheckResult {
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, CacheEntry>();
+
+export async function checkDreamBudget(auth: AuthContext): Promise<BudgetCheckResult> {
+  const cacheKey = `${auth.userId}:${auth.programId}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return { allowed: cached.allowed, dreamId: cached.dreamId, reason: cached.reason };
+  }
+
+  try {
+    const db = getFirestore();
+    // Uses existing type+status composite index
+    const snapshot = await db
+      .collection(`users/${auth.userId}/tasks`)
+      .where("type", "==", "dream")
+      .where("status", "==", "active")
+      .limit(5)
+      .get();
+
+    if (snapshot.empty) {
+      const result: BudgetCheckResult = { allowed: true };
+      cache.set(cacheKey, { ...result, expiresAt: Date.now() + CACHE_TTL_MS });
+      return result;
+    }
+
+    // Client-side filter for this program's dream
+    const dreamDoc = snapshot.docs.find(d => d.data().dream?.agent === auth.programId);
+    if (!dreamDoc) {
+      const result: BudgetCheckResult = { allowed: true };
+      cache.set(cacheKey, { ...result, expiresAt: Date.now() + CACHE_TTL_MS });
+      return result;
+    }
+
+    const dream = dreamDoc.data().dream;
+    const consumed = dream?.budget_consumed_usd || 0;
+    const cap = dream?.budget_cap_usd || 0;
+
+    if (cap > 0 && consumed >= cap) {
+      const result: BudgetCheckResult = {
+        allowed: false,
+        dreamId: dreamDoc.id,
+        reason: `Dream budget exceeded: $${consumed.toFixed(4)} >= $${cap.toFixed(2)} cap`,
+      };
+      cache.set(cacheKey, { ...result, expiresAt: Date.now() + CACHE_TTL_MS });
+      return result;
+    }
+
+    const result: BudgetCheckResult = { allowed: true, dreamId: dreamDoc.id };
+    cache.set(cacheKey, { ...result, expiresAt: Date.now() + CACHE_TTL_MS });
+    return result;
+  } catch (err) {
+    // On error, allow the call but log — fail-open for availability
+    console.error("[BudgetGuard] Check failed:", err);
+    return { allowed: true };
+  }
+}
+
+/** Invalidate cache for a user/program (call after dream activation/deactivation) */
+export function invalidateBudgetCache(userId: string, programId: string): void {
+  cache.delete(`${userId}:${programId}`);
+}


### PR DESCRIPTION
## Summary
- **Kill Mechanism 1**: Gate-level budget check in MCP server — rejects tool calls when `budget_consumed_usd >= budget_cap_usd` with 60-second TTL cache (fail-open)
- **Kill Mechanism 2**: Firestore trigger safety net in `onTaskUpdate` — catches budget violations on any dream document update, transitions to `failed`
- **Kill Mechanism 3**: Scheduled Cloud Function (`enforceDreamTimeouts`, every 5 min) — enforces `timeout_hours` wall-clock limit on active dreams
- **Ledger integration**: `logToolCall` atomically increments dream budget counter via `FieldValue.increment()` on each tool call

SARK Finding F2 (HIGH severity) — Dream Mode prerequisite. No Dream Mode launches until budget enforcement is live.

## Files Changed
| File | Change |
|------|--------|
| `mcp-server/src/middleware/budgetGuard.ts` | **NEW** — Gate-level budget check with cache |
| `mcp-server/src/index.ts` | Add budget check between rate limit and handler dispatch |
| `mcp-server/src/modules/ledger.ts` | Add dreamId param, atomic budget increment |
| `firebase/functions/src/notifications/onTaskUpdate.ts` | Budget enforcement safety net before status-change check |
| `firebase/functions/src/enforcement/enforceDreamTimeouts.ts` | **NEW** — Scheduled timeout enforcement |
| `firebase/functions/src/index.ts` | Export new function |

## Test plan
- [ ] MCP server build passes (verified locally)
- [ ] Cloud Functions build passes (verified locally)
- [ ] Deploy to Cloud Run and verify budget check rejects tool calls when budget exceeded
- [ ] Deploy Cloud Functions and verify enforceDreamTimeouts scheduled function runs
- [ ] Create test dream with low budget cap, verify kill mechanism 2 triggers on budget_consumed_usd update
- [ ] Create test dream with short timeout, verify kill mechanism 3 terminates it