### PR TITLE
feat: Grid Portal prerequisites

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,7 +1,9 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Users can read/write their own data
+    // Users can read/write their own data.
+    // Grid Portal (web client SDK) authenticates via Firebase Auth as Flynn.
+    // Subcollections: sessions, tasks, relay, programs, questions, dream_sessions, audit, ledger, devices
     match /users/{userId}/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }

--- a/mcp-server/src/config/programs.ts
+++ b/mcp-server/src/config/programs.ts
@@ -49,3 +49,21 @@ export function resolveTargets(target: string): string[] {
   }
   return [target];
 }
+
+/** Program display metadata for Grid Portal */
+export interface ProgramMeta {
+  displayName: string;
+  color: string;
+  role: string;
+}
+
+export const PROGRAM_REGISTRY: Partial<Record<GridProgramId, ProgramMeta>> = {
+  iso:    { displayName: "ISO",    color: "#6FC3DF", role: "Orchestrator" },
+  basher: { displayName: "BASHER", color: "#E87040", role: "Execution Engine" },
+  alan:   { displayName: "ALAN",   color: "#4A8ED4", role: "Architecture" },
+  quorra: { displayName: "QUORRA", color: "#9B6FC0", role: "Design" },
+  sark:   { displayName: "SARK",   color: "#C44040", role: "Audit" },
+  able:   { displayName: "ABLE",   color: "#4DB870", role: "Growth" },
+  beck:   { displayName: "BECK",   color: "#40A8A0", role: "Operations" },
+  radia:  { displayName: "RADIA",  color: "#E8E0D0", role: "Vision" },
+};

--- a/mcp-server/src/modules/budget.ts
+++ b/mcp-server/src/modules/budget.ts
@@ -1,0 +1,125 @@
+/**
+ * Budget Module — Cost aggregation for Grid Portal.
+ * Aggregates dream budget consumption and per-task costs.
+ */
+
+import { getFirestore } from "../firebase/client.js";
+import * as admin from "firebase-admin";
+import { AuthContext } from "../auth/apiKeyValidator.js";
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+function jsonResult(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+interface PeriodSummary {
+  dream_consumed_usd: number;
+  dream_budget_cap_usd: number;
+  dream_count: number;
+  task_cost_usd: number;
+  task_count: number;
+}
+
+function startOfDay(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function startOfWeek(): Date {
+  const d = startOfDay();
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+function startOfMonth(): Date {
+  const d = startOfDay();
+  d.setDate(1);
+  return d;
+}
+
+function emptyPeriod(): PeriodSummary {
+  return { dream_consumed_usd: 0, dream_budget_cap_usd: 0, dream_count: 0, task_cost_usd: 0, task_count: 0 };
+}
+
+export async function budgetSummaryHandler(auth: AuthContext, _rawArgs: unknown): Promise<ToolResult> {
+  const db = getFirestore();
+  const tasksRef = db.collection(`users/${auth.userId}/tasks`);
+
+  const monthStart = admin.firestore.Timestamp.fromDate(startOfMonth());
+
+  // Fetch dreams from this month (covers day + week + month)
+  const dreamsSnap = await tasksRef
+    .where("type", "==", "dream")
+    .where("status", "in", ["active", "done", "failed"])
+    .where("createdAt", ">=", monthStart)
+    .get();
+
+  // Fetch tasks with cost data from this month
+  const tasksSnap = await tasksRef
+    .where("type", "==", "task")
+    .where("status", "==", "done")
+    .where("completedAt", ">=", monthStart)
+    .get();
+
+  const today = startOfDay();
+  const weekStart = startOfWeek();
+
+  const periods = {
+    today: emptyPeriod(),
+    this_week: emptyPeriod(),
+    this_month: emptyPeriod(),
+  };
+
+  for (const doc of dreamsSnap.docs) {
+    const data = doc.data();
+    const created = data.createdAt?.toDate?.() || new Date(0);
+    const consumed = data.dream?.budget_consumed_usd || 0;
+    const cap = data.dream?.budget_cap_usd || 0;
+
+    // Month (all fetched docs are this month)
+    periods.this_month.dream_consumed_usd += consumed;
+    periods.this_month.dream_budget_cap_usd += cap;
+    periods.this_month.dream_count++;
+
+    if (created >= weekStart) {
+      periods.this_week.dream_consumed_usd += consumed;
+      periods.this_week.dream_budget_cap_usd += cap;
+      periods.this_week.dream_count++;
+    }
+    if (created >= today) {
+      periods.today.dream_consumed_usd += consumed;
+      periods.today.dream_budget_cap_usd += cap;
+      periods.today.dream_count++;
+    }
+  }
+
+  for (const doc of tasksSnap.docs) {
+    const data = doc.data();
+    const completed = data.completedAt?.toDate?.() || new Date(0);
+    const cost = data.cost_usd || 0;
+    if (cost <= 0) continue;
+
+    periods.this_month.task_cost_usd += cost;
+    periods.this_month.task_count++;
+
+    if (completed >= weekStart) {
+      periods.this_week.task_cost_usd += cost;
+      periods.this_week.task_count++;
+    }
+    if (completed >= today) {
+      periods.today.task_cost_usd += cost;
+      periods.today.task_count++;
+    }
+  }
+
+  // Round all USD values to 4 decimal places
+  for (const period of Object.values(periods)) {
+    period.dream_consumed_usd = Math.round(period.dream_consumed_usd * 10000) / 10000;
+    period.dream_budget_cap_usd = Math.round(period.dream_budget_cap_usd * 10000) / 10000;
+    period.task_cost_usd = Math.round(period.task_cost_usd * 10000) / 10000;
+  }
+
+  return jsonResult({ success: true, periods });
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -113,6 +113,9 @@ export const TOOL_DEFINITIONS = [
       type: "object" as const,
       properties: {
         taskId: { type: "string" },
+        tokens_in: { type: "number", description: "Input tokens consumed" },
+        tokens_out: { type: "number", description: "Output tokens consumed" },
+        cost_usd: { type: "number", description: "Estimated cost in USD" },
       },
       required: ["taskId"],
     },

--- a/mcp-server/src/transport/rest.ts
+++ b/mcp-server/src/transport/rest.ts
@@ -201,6 +201,14 @@ const routes: Route[] = [
     const data = await callTool(auth, "complete_sprint", { sprintId: p.id, ...body });
     restResponse(res, true, data);
   }),
+  // Budget
+  route("GET", "/v1/budget/summary", async (auth, req, res) => {
+    const { budgetSummaryHandler } = await import("../modules/budget.js");
+    const result = await budgetSummaryHandler(auth, {});
+    const text = result?.content?.[0]?.text;
+    restResponse(res, true, text ? JSON.parse(text) : result);
+  }),
+
   // Dream
   route("GET", "/v1/dreams", async (auth, req, res) => {
     const result = await dreamPeekHandler(auth, {});


### PR DESCRIPTION
## Summary
- **Program registry**: `PROGRAM_REGISTRY` in `config/programs.ts` with display metadata (name, color, role) for 8 active Grid programs
- **Heartbeat piggyback**: `update_session` and `create_session` now write to `users/{uid}/programs/{programId}` with lastHeartbeat, currentState, currentSessionId
- **Budget aggregation**: `GET /v1/budget/summary` endpoint aggregates dream `budget_consumed_usd` and task `cost_usd` by day/week/month
- **Cost-per-task**: `complete_task` accepts optional `tokens_in`, `tokens_out`, `cost_usd` fields
- **Firestore rules**: Documented Portal web SDK access patterns (existing wildcard rule already covers all subcollections)

## Context
Decision #14 prerequisites for `rezzedai/grid-portal`. Unblocks Program Status panel, Budget Gauge, and cost tracking.

## Test plan
- [ ] Deploy to Cloud Run and verify `update_session` writes to `programs/` subcollection
- [ ] Verify `GET /v1/budget/summary` returns period aggregations
- [ ] Verify `complete_task` with cost fields persists to Firestore
- [ ] Verify Grid Portal can read `programs/` via Firebase Auth client SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)