### PR TITLE
feat: ns-2 — message filtering + priority sort for get_messages

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -43,6 +43,34 @@
       ]
     },
     {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "message_type", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "message_type", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "sessions",
       "queryScope": "COLLECTION",
       "fields": [

--- a/mcp-server/src/iso/toolDefinitions.ts
+++ b/mcp-server/src/iso/toolDefinitions.ts
@@ -26,6 +26,8 @@ export const ISO_TOOL_DEFINITIONS = [
         sessionId: { type: "string", description: "Session ID to check messages for" },
         target: { type: "string", description: "Target program ID to filter by" },
         markAsRead: { type: "boolean", default: true },
+        message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"], description: "Filter by message type" },
+        priority: { type: "string", enum: ["low", "normal", "high"], description: "Filter by priority level" },
       },
       required: ["sessionId"],
     },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -148,6 +148,8 @@ export const TOOL_DEFINITIONS = [
         sessionId: { type: "string" },
         target: { type: "string", description: "Filter by target program ID" },
         markAsRead: { type: "boolean", default: true },
+        message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"], description: "Filter by message type" },
+        priority: { type: "string", enum: ["low", "normal", "high"], description: "Filter by priority level" },
       },
       required: ["sessionId"],
     },


### PR DESCRIPTION
## Summary
- Adds optional `message_type` filter to `get_messages` — programs can request only DIRECTIVE, QUERY, RESULT, etc.
- Adds optional `priority` filter — allows filtering by high/normal/low
- Results sorted by priority (high → normal → low), then newest first within each priority level
- Backward compatible — omitting filters returns all messages as before
- Updated MCP tool schema, ISO tool definitions, and REST endpoint (pass-through)
- Added 3 composite Firestore indexes for new query patterns

## Sprint
CacheBash Nervous System Hardening — Story ns-2

## Test plan
- [ ] Verify `get_messages` without filters returns all messages (backward compat)
- [ ] Verify `message_type` filter returns only matching messages
- [ ] Verify `priority` filter returns only matching messages
- [ ] Verify both filters together work correctly
- [ ] Verify sort order: high priority first, newest first within same priority
- [ ] Deploy and test REST endpoint with query params
- [ ] Deploy Firestore indexes