### PR TITLE
fix: P0 model-agnostic — remove Claude-specific references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CacheBash v2
 
-MCP server + mobile app for the Grid. Bridges Claude Code sessions with a Flutter mobile interface for real-time monitoring, question answering, and task management.
+MCP server + mobile app for AI agent orchestration. Bridges MCP-compatible clients with a Flutter mobile interface for real-time monitoring, question answering, and task management.
 
 ## Structure
 

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cachebash
-description: Mobile companion app for Claude Code
+description: Mobile companion app for AI agents
 publish_to: 'none'
 version: 1.0.0+23
 

--- a/firebase/functions/src/notifications/onTaskCreate.ts
+++ b/firebase/functions/src/notifications/onTaskCreate.ts
@@ -77,7 +77,7 @@ export const onTaskCreate = functions.firestore
 
       switch (taskType) {
         case "question":
-          title = "Claude needs your input";
+          title = "Your agent needs input";
           body = truncate(task.preview || task.title || "New question", 100);
           channelId = "questions";
           break;

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,8 +6,8 @@ Model Context Protocol server for the Grid. Provides 18 tools across 6 modules w
 
 ```
                     +-----------------+
-                    |   Claude Code   |
-                    |   (MCP Client)  |
+                    |   MCP Client    |
+                    | (Any AI Agent)  |
                     +--------+--------+
                              |
                     Streamable HTTP (Bearer auth)


### PR DESCRIPTION
## Summary
- Push notification title: "Claude needs your input" → "Your agent needs input"
- pubspec.yaml description: "companion for Claude Code" → "companion for AI agents"
- README: model-agnostic product description
- mcp-server README: architecture diagram uses generic "MCP Client"

Per SARK audit findings #6-8 (critical) and #1-3 (high). All P0 items from `sark-assessment-model-agnostic-audit.md`.

Note: Android `MainActivity.kt` notification channel name also fixed locally but `app/android/` is not tracked in this repo.

## Test plan
- [ ] Verify push notification displays "Your agent needs input" on question tasks
- [ ] Verify README reads correctly with model-agnostic framing
- [ ] Deploy Cloud Functions: `cd firebase && firebase deploy --only functions --project cachebash-app`