### PR TITLE
feat(metrics): cost aggregation endpoint

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -277,6 +277,23 @@
       ]
     },
     {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "completedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "completedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "questions",
       "queryScope": "COLLECTION",
       "fields": [

--- a/mcp-server/src/iso/isoServer.ts
+++ b/mcp-server/src/iso/isoServer.ts
@@ -16,6 +16,7 @@ import { updateSessionHandler } from "../modules/pulse.js";
 import { sendAlertHandler } from "../modules/signal.js";
 import { listKeysHandler } from "../modules/keys.js";
 import { getAuditHandler } from "../modules/audit.js";
+import { getCostSummaryHandler } from "../modules/metrics.js";
 import { checkRateLimit, getRateLimitResetIn } from "../middleware/rateLimiter.js";
 import { generateCorrelationId, createAuditLogger } from "../middleware/gate.js";
 import { logToolCall } from "../modules/ledger.js";
@@ -33,6 +34,7 @@ const ISO_TOOL_HANDLERS: Record<string, (auth: AuthContext, args: any) => Promis
   send_alert: sendAlertHandler,
   list_keys: listKeysHandler,
   get_audit: getAuditHandler,
+  get_cost_summary: getCostSummaryHandler,
 };
 
 const isoSessions = new Map<string, { authContext: AuthContext; lastActivity: number }>();

--- a/mcp-server/src/iso/toolDefinitions.ts
+++ b/mcp-server/src/iso/toolDefinitions.ts
@@ -154,4 +154,16 @@ export const ISO_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    name: "get_cost_summary",
+    description: "Get aggregated cost/token spend for completed tasks. Supports period filtering and grouping by program or type.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        period: { type: "string", enum: ["today", "this_week", "this_month", "all"], default: "this_month", description: "Time period to aggregate" },
+        groupBy: { type: "string", enum: ["program", "type", "none"], default: "none", description: "Group results by program (source) or task type" },
+        programFilter: { type: "string", maxLength: 100, description: "Filter to a specific program (source field)" },
+      },
+    },
+  },
 ];

--- a/mcp-server/src/modules/metrics.ts
+++ b/mcp-server/src/modules/metrics.ts
@@ -1,0 +1,128 @@
+/**
+ * Metrics Module — Cost aggregation endpoints for ISO.
+ * Queries completed tasks and returns spend totals with optional grouping.
+ */
+
+import { z } from "zod";
+import { getFirestore } from "../firebase/client.js";
+import * as admin from "firebase-admin";
+import { AuthContext } from "../auth/apiKeyValidator.js";
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+function jsonResult(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+const CostSummarySchema = z.object({
+  period: z.enum(["today", "this_week", "this_month", "all"]).default("this_month"),
+  groupBy: z.enum(["program", "type", "none"]).default("none"),
+  programFilter: z.string().optional(),
+});
+
+function startOfDay(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function startOfWeek(): Date {
+  const d = startOfDay();
+  d.setDate(d.getDate() - d.getDay());
+  return d;
+}
+
+function startOfMonth(): Date {
+  const d = startOfDay();
+  d.setDate(1);
+  return d;
+}
+
+function periodStart(period: string): Date | null {
+  switch (period) {
+    case "today": return startOfDay();
+    case "this_week": return startOfWeek();
+    case "this_month": return startOfMonth();
+    case "all": return null;
+    default: return startOfMonth();
+  }
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+export async function getCostSummaryHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
+  const args = CostSummarySchema.parse(rawArgs || {});
+  const db = getFirestore();
+  const tasksRef = db.collection(`users/${auth.userId}/tasks`);
+
+  // Build query: status == "done", optionally filtered by completedAt and source
+  let query: admin.firestore.Query = tasksRef.where("status", "==", "done");
+
+  const start = periodStart(args.period);
+  if (start) {
+    query = query.where("completedAt", ">=", admin.firestore.Timestamp.fromDate(start));
+  }
+
+  if (args.programFilter) {
+    query = query.where("source", "==", args.programFilter);
+  }
+
+  const snap = await query.get();
+
+  let totalTokensIn = 0;
+  let totalTokensOut = 0;
+  let totalCostUsd = 0;
+  let taskCount = 0;
+  const groups = new Map<string, { tokens_in: number; tokens_out: number; cost_usd: number; task_count: number }>();
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const tokensIn = data.tokens_in || 0;
+    const tokensOut = data.tokens_out || 0;
+    const costUsd = data.cost_usd || 0;
+
+    totalTokensIn += tokensIn;
+    totalTokensOut += tokensOut;
+    totalCostUsd += costUsd;
+    taskCount++;
+
+    if (args.groupBy !== "none") {
+      const key = args.groupBy === "program"
+        ? (data.source || "unknown")
+        : (data.type || "unknown");
+
+      const group = groups.get(key) || { tokens_in: 0, tokens_out: 0, cost_usd: 0, task_count: 0 };
+      group.tokens_in += tokensIn;
+      group.tokens_out += tokensOut;
+      group.cost_usd += costUsd;
+      group.task_count++;
+      groups.set(key, group);
+    }
+  }
+
+  const breakdown = args.groupBy !== "none"
+    ? Array.from(groups.entries())
+        .map(([key, g]) => ({
+          key,
+          tokens_in: g.tokens_in,
+          tokens_out: g.tokens_out,
+          cost_usd: round4(g.cost_usd),
+          task_count: g.task_count,
+        }))
+        .sort((a, b) => b.cost_usd - a.cost_usd)
+    : [];
+
+  return jsonResult({
+    success: true,
+    total_tokens_in: totalTokensIn,
+    total_tokens_out: totalTokensOut,
+    total_cost_usd: round4(totalCostUsd),
+    task_count: taskCount,
+    period: args.period,
+    groupBy: args.groupBy,
+    programFilter: args.programFilter || null,
+    breakdown,
+  });
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -13,6 +13,7 @@ import { createSprintHandler, updateStoryHandler, addStoryHandler, completeSprin
 import { createKeyHandler, revokeKeyHandler, listKeysHandler } from "./modules/keys.js";
 import { getAuditHandler } from "./modules/audit.js";
 import { getProgramStateHandler, updateProgramStateHandler } from "./modules/programState.js";
+import { getCostSummaryHandler } from "./modules/metrics.js";
 
 type Handler = (auth: AuthContext, args: any) => Promise<any>;
 
@@ -54,6 +55,9 @@ export const TOOL_HANDLERS: Record<string, Handler> = {
   // Program State
   get_program_state: getProgramStateHandler,
   update_program_state: updateProgramStateHandler,
+
+  // Metrics
+  get_cost_summary: getCostSummaryHandler,
 };
 
 export const TOOL_DEFINITIONS = [
@@ -510,6 +514,19 @@ export const TOOL_DEFINITIONS = [
         },
       },
       required: ["programId"],
+    },
+  },
+  // === Metrics ===
+  {
+    name: "get_cost_summary",
+    description: "Get aggregated cost/token spend for completed tasks. Supports period filtering and grouping by program or type.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        period: { type: "string", enum: ["today", "this_week", "this_month", "all"], default: "this_month", description: "Time period to aggregate" },
+        groupBy: { type: "string", enum: ["program", "type", "none"], default: "none", description: "Group results by program (source) or task type" },
+        programFilter: { type: "string", maxLength: 100, description: "Filter to a specific program (source field)" },
+      },
     },
   },
 ];

--- a/mcp-server/src/transport/rest.ts
+++ b/mcp-server/src/transport/rest.ts
@@ -209,6 +209,13 @@ const routes: Route[] = [
     restResponse(res, true, text ? JSON.parse(text) : result);
   }),
 
+  // Metrics
+  route("GET", "/v1/metrics/cost-summary", async (auth, req, res) => {
+    const query = coerceQueryParams(parseQuery(req.url || ""));
+    const data = await callTool(auth, "get_cost_summary", query);
+    restResponse(res, true, data);
+  }),
+
   // Dream
   route("GET", "/v1/dreams", async (auth, req, res) => {
     const result = await dreamPeekHandler(auth, {});


### PR DESCRIPTION
## Summary
- New `get_cost_summary` MCP tool + REST endpoint (`GET /v1/metrics/cost-summary`)
- Queries completed tasks for token/cost spend with period filtering (today, this_week, this_month, all)
- Supports `groupBy` (program, type, none) and `programFilter` for targeted queries
- Null cost fields treated as 0 for historical data compatibility
- Added to ISO MCP whitelist for claude.ai access
- Two new Firestore composite indexes: `(status, completedAt)` and `(source, status, completedAt)`

## Files Changed
- `mcp-server/src/modules/metrics.ts` — new module with `getCostSummaryHandler`
- `mcp-server/src/tools.ts` — tool handler + definition registration
- `mcp-server/src/iso/isoServer.ts` — ISO handler registration
- `mcp-server/src/iso/toolDefinitions.ts` — ISO tool schema
- `mcp-server/src/transport/rest.ts` — REST route
- `firebase/firestore.indexes.json` — composite indexes

## Test plan
- [ ] `tsc --noEmit` passes clean
- [ ] Deploy to Cloud Run — verify service starts
- [ ] `GET /v1/metrics/cost-summary` returns JSON with totals
- [ ] `?groupBy=program` returns per-program breakdown
- [ ] `?groupBy=type` returns per-type breakdown
- [ ] `?period=all` returns all-time data
- [ ] `?programFilter=iso` filters to ISO tasks only
- [ ] ISO can call `get_cost_summary` via MCP
- [ ] Deploy Firestore indexes via `firebase deploy --only firestore:indexes`