### PR TITLE
fix: add ASC composite indexes for cost summary queries

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -288,9 +288,26 @@
       "collectionGroup": "tasks",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "completedAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "source", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "completedAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "completedAt", "order": "ASCENDING" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- `get_cost_summary` has been returning `FAILED_PRECONDITION` since deployment — the query uses `completedAt >=` (ascending) but only descending indexes existed
- Adds two new composite indexes for the `tasks` collection:
  - `status ASC, completedAt ASC` — time-filtered cost queries
  - `status ASC, source ASC, completedAt ASC` — time + program-filtered queries
- Indexes already deployed to Firestore via `firebase deploy --only firestore:indexes`

## Test plan
- [x] Deployed indexes to `cachebash-app` project
- [ ] Verify `get_cost_summary` returns data once indexes finish building (~5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)