### PR TITLE
feat(relay): multicast discoverability

### DIFF
--- a/mcp-server/src/modules/relay.ts
+++ b/mcp-server/src/modules/relay.ts
@@ -8,7 +8,7 @@ import { verifySource } from "../middleware/gate.js";
 import * as admin from "firebase-admin";
 import { AuthContext } from "../auth/apiKeyValidator.js";
 import { RELAY_DEFAULT_TTL_SECONDS } from "../types/relay.js";
-import { resolveTargets, isGroupTarget } from "../config/programs.js";
+import { resolveTargets, isGroupTarget, PROGRAM_GROUPS } from "../config/programs.js";
 import { z } from "zod";
 
 const SendMessageSchema = z.object({
@@ -344,4 +344,14 @@ export async function getDeadLettersHandler(auth: AuthContext, rawArgs: unknown)
       ? `Found ${deadLetters.length} dead letter(s)`
       : "No dead letters found",
   });
+}
+
+export async function listGroupsHandler(_auth: AuthContext, _rawArgs: unknown): Promise<ToolResult> {
+  const groups: Record<string, string[]> = {};
+  for (const [name, members] of Object.entries(PROGRAM_GROUPS)) {
+    groups[name] = [...members];
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify({ success: true, groups, message: `${Object.keys(groups).length} groups available` }) }],
+  };
 }

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -5,7 +5,7 @@
 
 import { AuthContext } from "./auth/apiKeyValidator.js";
 import { getTasksHandler, createTaskHandler, claimTaskHandler, completeTaskHandler } from "./modules/dispatch.js";
-import { sendMessageHandler, getMessagesHandler, getDeadLettersHandler } from "./modules/relay.js";
+import { sendMessageHandler, getMessagesHandler, getDeadLettersHandler, listGroupsHandler } from "./modules/relay.js";
 import { createSessionHandler, updateSessionHandler, listSessionsHandler } from "./modules/pulse.js";
 import { askQuestionHandler, getResponseHandler, sendAlertHandler } from "./modules/signal.js";
 import { dreamPeekHandler, dreamActivateHandler } from "./modules/dream.js";
@@ -27,6 +27,7 @@ export const TOOL_HANDLERS: Record<string, Handler> = {
   send_message: sendMessageHandler,
   get_messages: getMessagesHandler,
   get_dead_letters: getDeadLettersHandler,
+  list_groups: listGroupsHandler,
   // Pulse
   create_session: createSessionHandler,
   update_session: updateSessionHandler,
@@ -133,7 +134,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         message: { type: "string", maxLength: 2000 },
         source: { type: "string", maxLength: 100 },
-        target: { type: "string", maxLength: 100, description: "Target program ID (required). Use program name or 'all' for broadcast." },
+        target: { type: "string", maxLength: 100, description: "Target program ID or group name (required). Use program name for unicast, or group name for multicast: 'council', 'builders', 'intelligence', 'all'." },
         message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"] },
         priority: { type: "string", enum: ["low", "normal", "high"], default: "normal" },
         action: { type: "string", enum: ["interrupt", "sprint", "parallel", "queue", "backlog"], default: "queue" },
@@ -169,6 +170,14 @@ export const TOOL_DEFINITIONS = [
       properties: {
         limit: { type: "number", minimum: 1, maximum: 50, default: 20, description: "Max results to return" },
       },
+    },
+  },
+  {
+    name: "list_groups",
+    description: "List available multicast groups and their members. Use group names as targets in send_message for multicast.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
     },
   },
   // === Pulse ===

--- a/mcp-server/src/transport/rest.ts
+++ b/mcp-server/src/transport/rest.ts
@@ -149,6 +149,10 @@ const routes: Route[] = [
     const data = await callTool(auth, "get_dead_letters", query);
     restResponse(res, true, data);
   }),
+  route("GET", "/v1/relay/groups", async (auth, req, res) => {
+    const data = await callTool(auth, "list_groups", {});
+    restResponse(res, true, data);
+  }),
   // Pulse
   route("GET", "/v1/sessions", async (auth, req, res) => {
     const query = coerceQueryParams(parseQuery(req.url || ""));


### PR DESCRIPTION
## Summary

- Updated `send_message` tool description to advertise available multicast group names: `council`, `builders`, `intelligence`, `all`
- Added `list_groups` MCP tool for runtime discovery of available multicast groups and their members
- Added REST endpoint `GET /v1/relay/groups` for HTTP clients

## Context

Programs can now discover what multicast groups exist before sending messages. This improves discoverability and makes the multicast feature self-documenting.

## Test plan

- Verify TypeScript compiles (npm run build) — passed
- Call `list_groups` tool via MCP to verify it returns group definitions
- Call `GET /v1/relay/groups` via REST to verify HTTP endpoint works
- Verify `send_message` tool description shows group options in Claude Desktop

Generated with [Claude Code](https://claude.com/claude-code)