### PR TITLE
fix: BUG-004 — pre-populate session auth before transport.handleRequest()

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -142,11 +142,11 @@ async function main() {
       const auth = await validateApiKey(token);
       if (!auth) return sendJson(res, 401, { error: "Invalid API key" });
 
+      const isoMcpSessionId = req.headers['mcp-session-id'] as string | undefined;
+      if (isoMcpSessionId) setIsoSessionAuth(isoMcpSessionId, auth);
+
       const webReq = await nodeToWebRequest(req);
       const webRes = await iso.transport.handleRequest(webReq, auth);
-
-      const sessionId = webRes.headers.get("Mcp-Session-Id");
-      if (sessionId) setIsoSessionAuth(sessionId, auth);
 
       res.writeHead(webRes.status, Object.fromEntries(webRes.headers.entries()));
       const body = await webRes.text();
@@ -160,11 +160,13 @@ async function main() {
       const auth = await validateApiKey(token);
       if (!auth) return sendJson(res, 401, { error: "Invalid API key" });
 
+      const mcpSessionId = req.headers['mcp-session-id'] as string | undefined;
+      if (mcpSessionId) {
+        sessions.set(mcpSessionId, { authContext: auth, lastActivity: Date.now() });
+      }
+
       const webReq = await nodeToWebRequest(req);
       const webRes = await transport.handleRequest(webReq, auth);
-
-      const sessionId = webRes.headers.get("Mcp-Session-Id");
-      if (sessionId) sessions.set(sessionId, { authContext: auth, lastActivity: Date.now() });
 
       res.writeHead(webRes.status, Object.fromEntries(webRes.headers.entries()));
       const body = await webRes.text();


### PR DESCRIPTION
## Summary
- Pre-populate MCP session auth context from Bearer token BEFORE calling `transport.handleRequest()`, fixing "Not authenticated" errors after Cloud Run instance recycle
- Applies to both main MCP (`/v1/mcp`) and ISO MCP (`/v1/iso/mcp`) endpoints
- Removes redundant post-transport auth storage (was too late — tool handlers already ran)

## Root Cause
Both endpoints validated the Bearer token and called `transport.handleRequest()`, but only stored auth in the sessions Map AFTER the transport call returned. On a fresh Cloud Run instance, the in-memory Map is empty, so tool handlers inside `handleRequest()` found no auth context and returned "Not authenticated".

## Fix
Read the `Mcp-Session-Id` header from the incoming request and pre-populate the sessions Map BEFORE calling `transport.handleRequest()`. On init requests (no session ID header), this is a no-op.

## Test plan
- [x] `npm run build` passes clean
- [ ] Deploy to Cloud Run
- [ ] Verify: scale to 0, scale back to 1, confirm existing MCP sessions survive without auth errors