### PR TITLE
feat(mcp): v2.1 — tracing, schemas, retry, tests

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -456,6 +456,30 @@
         { "fieldPath": "target", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "traces",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "programId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "traces",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "context.sprintId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "traces",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "tool", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/mcp-server/jest.config.js
+++ b/mcp-server/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
   roots: ["<rootDir>/src"],
   testMatch: ["**/__tests__/**/*.test.ts"],
   moduleFileExtensions: ["ts", "js", "json"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };

--- a/mcp-server/src/__tests__/helpers.ts
+++ b/mcp-server/src/__tests__/helpers.ts
@@ -1,0 +1,11 @@
+import { AuthContext } from "../auth/apiKeyValidator";
+
+export function mockAuth(overrides?: Partial<AuthContext>): AuthContext {
+  return {
+    userId: "test-user-123",
+    programId: "iso",
+    apiKeyHash: "test-hash",
+    encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    ...overrides,
+  };
+}

--- a/mcp-server/src/__tests__/relay-schemas.test.ts
+++ b/mcp-server/src/__tests__/relay-schemas.test.ts
@@ -1,0 +1,119 @@
+import { validatePayload, RELAY_PAYLOAD_SCHEMAS } from "../types/relay-schemas";
+
+describe("Relay Payload Schemas", () => {
+  describe("RESULT schema", () => {
+    it("validates a complete RESULT payload", () => {
+      const result = validatePayload("RESULT", {
+        taskId: "task-1",
+        outcome: "success",
+        prUrl: "https://github.com/org/repo/pull/1",
+        summary: "All stories completed",
+      });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+
+    it("validates empty RESULT payload", () => {
+      expect(validatePayload("RESULT", {}).valid).toBe(true);
+    });
+
+    it("rejects invalid outcome value", () => {
+      const result = validatePayload("RESULT", { outcome: "unknown" });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("DIRECTIVE schema", () => {
+    it("validates a complete DIRECTIVE payload", () => {
+      const result = validatePayload("DIRECTIVE", {
+        action: "deploy",
+        priority: "high",
+        instructions: "Deploy to production",
+        taskId: "task-2",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("validates empty DIRECTIVE payload", () => {
+      expect(validatePayload("DIRECTIVE", {}).valid).toBe(true);
+    });
+  });
+
+  describe("QUERY schema", () => {
+    it("validates a QUERY payload", () => {
+      const result = validatePayload("QUERY", {
+        question: "What is the status?",
+        context: "Sprint v2.1",
+        responseFormat: "json",
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("STATUS schema", () => {
+    it("validates a STATUS payload", () => {
+      const result = validatePayload("STATUS", {
+        state: "working",
+        progress: 75,
+        currentTask: "Implementing tracing",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("validates STATUS payload with error string", () => {
+      const result = validatePayload("STATUS", {
+        state: "blocked",
+        error: "Network timeout",
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("HANDSHAKE schema", () => {
+    it("validates a HANDSHAKE payload", () => {
+      const result = validatePayload("HANDSHAKE", {
+        version: "2.1",
+        capabilities: ["relay", "sprint", "trace"],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("ACK schema", () => {
+    it("validates an ACK payload", () => {
+      const result = validatePayload("ACK", {
+        messageId: "msg-123",
+        acknowledged: true,
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("PING/PONG schemas", () => {
+    it("validates empty PING payload", () => {
+      expect(validatePayload("PING", {}).valid).toBe(true);
+    });
+
+    it("validates empty PONG payload", () => {
+      expect(validatePayload("PONG", {}).valid).toBe(true);
+    });
+  });
+
+  describe("unknown message type", () => {
+    it("returns invalid for unknown type", () => {
+      const result = validatePayload("UNKNOWN_TYPE", {});
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain("Unknown message type: UNKNOWN_TYPE");
+    });
+  });
+
+  describe("all 8 schemas are registered", () => {
+    const expectedTypes = ["RESULT", "DIRECTIVE", "QUERY", "STATUS", "HANDSHAKE", "ACK", "PING", "PONG"];
+
+    it.each(expectedTypes)("has schema for %s", (type) => {
+      expect(RELAY_PAYLOAD_SCHEMAS[type]).toBeDefined();
+    });
+  });
+});

--- a/mcp-server/src/__tests__/sprint-retry.test.ts
+++ b/mcp-server/src/__tests__/sprint-retry.test.ts
@@ -1,0 +1,31 @@
+// Mock external dependencies before importing sprint module
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn(),
+}));
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(),
+  serverTimestamp: jest.fn(),
+}));
+
+import { storyStatusToLifecycle } from "../modules/sprint";
+
+describe("Sprint Retry", () => {
+  describe("storyStatusToLifecycle", () => {
+    const mappings: [string, string][] = [
+      ["queued", "created"],
+      ["active", "active"],
+      ["complete", "done"],
+      ["failed", "failed"],
+      ["skipped", "derezzed"],
+    ];
+
+    it.each(mappings)("maps %s to %s", (input, expected) => {
+      expect(storyStatusToLifecycle(input)).toBe(expected);
+    });
+
+    it("maps unknown status to created", () => {
+      expect(storyStatusToLifecycle("bogus")).toBe("created");
+    });
+  });
+});

--- a/mcp-server/src/__tests__/trace.test.ts
+++ b/mcp-server/src/__tests__/trace.test.ts
@@ -1,0 +1,67 @@
+import { extractContext, sanitizeArgs } from "../modules/trace";
+
+describe("Trace Module", () => {
+  describe("extractContext", () => {
+    it("extracts sprintId from args", () => {
+      const ctx = extractContext("update_sprint_story", { sprintId: "sp-1", storyId: "st-1" });
+      expect(ctx).toEqual({ sprintId: "sp-1", storyId: "st-1" });
+    });
+
+    it("extracts taskId from args", () => {
+      const ctx = extractContext("claim_task", { taskId: "task-42" });
+      expect(ctx).toEqual({ taskId: "task-42" });
+    });
+
+    it("extracts all three context fields", () => {
+      const ctx = extractContext("test", { sprintId: "sp-1", taskId: "t-1", storyId: "st-1" });
+      expect(ctx).toEqual({ sprintId: "sp-1", taskId: "t-1", storyId: "st-1" });
+    });
+
+    it("returns empty object for args without context fields", () => {
+      const ctx = extractContext("send_message", { message: "hello", target: "basher" });
+      expect(ctx).toEqual({});
+    });
+
+    it("ignores non-string values for context fields", () => {
+      const ctx = extractContext("test", { sprintId: 123, taskId: null, storyId: undefined });
+      expect(ctx).toEqual({});
+    });
+
+    it("handles null/undefined args", () => {
+      expect(extractContext("test", null)).toEqual({});
+      expect(extractContext("test", undefined)).toEqual({});
+    });
+  });
+
+  describe("sanitizeArgs", () => {
+    it("truncates strings over 200 chars", () => {
+      const long = "a".repeat(250);
+      const result = sanitizeArgs(long) as string;
+      expect(result.length).toBe(203); // 200 + "..."
+      expect(result.endsWith("...")).toBe(true);
+    });
+
+    it("preserves short strings", () => {
+      expect(sanitizeArgs("hello")).toBe("hello");
+    });
+
+    it("handles nested objects", () => {
+      const input = { message: "a".repeat(250), nested: { value: "short" } };
+      const result = sanitizeArgs(input) as Record<string, unknown>;
+      expect((result.message as string).length).toBe(203);
+      expect((result.nested as Record<string, unknown>).value).toBe("short");
+    });
+
+    it("handles null and undefined", () => {
+      expect(sanitizeArgs(null)).toBeNull();
+      expect(sanitizeArgs(undefined)).toBeUndefined();
+    });
+
+    it("handles arrays", () => {
+      const input = ["short", "a".repeat(250)];
+      const result = sanitizeArgs(input) as string[];
+      expect(result[0]).toBe("short");
+      expect(result[1].length).toBe(203);
+    });
+  });
+});

--- a/mcp-server/src/iso/toolDefinitions.ts
+++ b/mcp-server/src/iso/toolDefinitions.ts
@@ -73,6 +73,7 @@ export const ISO_TOOL_DEFINITIONS = [
         context: { type: "string", maxLength: 500 },
         sessionId: { type: "string" },
         reply_to: { type: "string" },
+        payload: { type: "object", description: "Optional structured payload. Validated against message_type schema." },
       },
       required: ["message", "source", "target", "message_type"],
     },
@@ -213,6 +214,33 @@ export const ISO_TOOL_DEFINITIONS = [
         groupBy: { type: "string", enum: ["program", "type", "none"], default: "none", description: "Group results by program (source) or task type" },
         programFilter: { type: "string", maxLength: 100, description: "Filter to a specific program (source field)" },
       },
+    },
+  },
+  {
+    name: "query_traces",
+    description: "Query execution traces for debugging. Filters: sprintId, taskId, programId, tool, since/until.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        sprintId: { type: "string", description: "Filter by sprint ID" },
+        taskId: { type: "string", description: "Filter by task ID" },
+        programId: { type: "string", maxLength: 100, description: "Filter by program ID" },
+        tool: { type: "string", description: "Filter by tool name" },
+        since: { type: "string", description: "Start date (ISO 8601)" },
+        until: { type: "string", description: "End date (ISO 8601)" },
+        limit: { type: "number", minimum: 1, maximum: 100, default: 50 },
+      },
+    },
+  },
+  {
+    name: "get_sprint",
+    description: "Get a sprint's full state including definition, stories, and stats.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        sprintId: { type: "string", description: "The sprint ID to fetch" },
+      },
+      required: ["sprintId"],
     },
   },
 ];

--- a/mcp-server/src/modules/ledger.ts
+++ b/mcp-server/src/modules/ledger.ts
@@ -38,6 +38,9 @@ const BASE_COSTS: Record<string, number> = {
   get_comms_metrics: 0.001,
   get_fleet_health: 0.001,
   query_message_history: 0.001,
+  query_traces: 0.001,
+  get_sprint: 0.001,
+  list_groups: 0.0002,
 };
 
 function estimateCost(tool: string): number {

--- a/mcp-server/src/modules/sprint.ts
+++ b/mcp-server/src/modules/sprint.ts
@@ -16,6 +16,8 @@ const StorySchema = z.object({
   wave: z.number().optional(),
   dependencies: z.array(z.string()).optional(),
   complexity: z.enum(["normal", "high"]).optional(),
+  retryPolicy: z.enum(["none", "auto_retry", "escalate"]).default("none"),
+  maxRetries: z.number().min(0).max(5).default(1),
 });
 
 const CreateSprintSchema = z.object({
@@ -61,8 +63,33 @@ function jsonResult(data: unknown): ToolResult {
   return { content: [{ type: "text", text: JSON.stringify(data) }] };
 }
 
+/** Fire-and-forget escalation to ISO via relay */
+function escalateToIso(
+  auth: AuthContext,
+  sprintId: string,
+  storyId: string,
+  storyTitle: string
+): void {
+  (async () => {
+    const { sendMessageHandler } = await import("./relay.js");
+    await sendMessageHandler(auth, {
+      message: `Sprint story failed after retries exhausted. Sprint: ${sprintId}, Story: ${storyId} (${storyTitle})`,
+      source: "sprint-engine",
+      target: "iso",
+      message_type: "RESULT",
+      priority: "high",
+      action: "interrupt",
+      payload: {
+        outcome: "failure",
+        taskId: storyId,
+        summary: `Story "${storyTitle}" failed in sprint ${sprintId} — retries exhausted or escalation policy triggered`,
+      },
+    });
+  })().catch((err) => console.error("[Sprint] Escalation to ISO failed:", err));
+}
+
 /** Map sprint story status to lifecycle */
-function storyStatusToLifecycle(status: string): string {
+export function storyStatusToLifecycle(status: string): string {
   switch (status) {
     case "queued": return "created";
     case "active": return "active";
@@ -92,6 +119,15 @@ export async function createSprintHandler(auth: AuthContext, rawArgs: unknown): 
       projectName: args.projectName,
       branch: args.branch,
       config: args.config || null,
+      definition: args.stories.map((s) => ({
+        id: s.id,
+        title: s.title,
+        wave: s.wave || 1,
+        dependencies: s.dependencies || [],
+        complexity: s.complexity || "normal",
+        retryPolicy: s.retryPolicy || "none",
+        maxRetries: s.maxRetries ?? 1,
+      })),
     },
     sessionId: args.sessionId || null,
     createdAt: now,
@@ -123,6 +159,12 @@ export async function createSprintHandler(auth: AuthContext, rawArgs: unknown): 
         wave: story.wave || 1,
         dependencies: story.dependencies || [],
         complexity: story.complexity || "normal",
+      },
+      retry: {
+        policy: story.retryPolicy || "none",
+        maxRetries: story.maxRetries ?? 1,
+        retryCount: 0,
+        retryHistory: [],
       },
       createdAt: now,
       encrypted: false,
@@ -175,6 +217,27 @@ export async function updateStoryHandler(auth: AuthContext, rawArgs: unknown): P
   if (args.progress !== undefined) updateData["sprint.currentAction"] = args.currentAction || null;
   if (args.currentAction) updateData["sprint.currentAction"] = args.currentAction;
   if (args.model) updateData.model = args.model;
+
+  // Retry/escalation logic
+  if (args.status === "failed") {
+    const storyData = storyDoc.data();
+    const retry = storyData.retry || { policy: "none", maxRetries: 1, retryCount: 0, retryHistory: [] };
+
+    if (retry.policy === "auto_retry" && retry.retryCount < retry.maxRetries) {
+      // Auto-retry: reset to created, increment count
+      updateData.status = "created";
+      updateData["retry.retryCount"] = retry.retryCount + 1;
+      updateData["retry.retryHistory"] = [
+        ...(retry.retryHistory || []),
+        { attempt: retry.retryCount + 1, failedAt: new Date().toISOString() },
+      ];
+      delete updateData.completedAt;
+    } else if (retry.policy === "escalate" || (retry.policy === "auto_retry" && retry.retryCount >= retry.maxRetries)) {
+      // Escalate to ISO
+      escalateToIso(auth, args.sprintId, args.storyId, storyData.title || args.storyId);
+    }
+    // "none" policy: default behavior, just mark failed (already set above)
+  }
 
   await storyDoc.ref.update(updateData);
 
@@ -264,5 +327,75 @@ export async function completeSprintHandler(auth: AuthContext, rawArgs: unknown)
     sprintId: args.sprintId,
     summary,
     message: "Sprint completed",
+  });
+}
+
+const GetSprintSchema = z.object({
+  sprintId: z.string(),
+});
+
+export async function getSprintHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
+  const args = GetSprintSchema.parse(rawArgs || {});
+  const db = getFirestore();
+
+  // Fetch sprint doc
+  const sprintDoc = await db.doc(`users/${auth.userId}/tasks/${args.sprintId}`).get();
+  if (!sprintDoc.exists) {
+    return jsonResult({ success: false, error: "Sprint not found" });
+  }
+
+  const sprintData = sprintDoc.data()!;
+  if (sprintData.type !== "sprint") {
+    return jsonResult({ success: false, error: "Document is not a sprint" });
+  }
+
+  // Fetch all child stories
+  const storiesSnapshot = await db
+    .collection(`users/${auth.userId}/tasks`)
+    .where("type", "==", "sprint-story")
+    .where("sprint.parentId", "==", args.sprintId)
+    .get();
+
+  const stories = storiesSnapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      title: data.title,
+      status: data.status,
+      wave: data.sprint?.wave || 1,
+      dependencies: data.sprint?.dependencies || [],
+      complexity: data.sprint?.complexity || "normal",
+      currentAction: data.sprint?.currentAction || null,
+      retry: data.retry || null,
+      startedAt: data.startedAt?.toDate?.()?.toISOString() || null,
+      completedAt: data.completedAt?.toDate?.()?.toISOString() || null,
+    };
+  });
+
+  // Calculate stats
+  const stats = {
+    total: stories.length,
+    completed: stories.filter((s) => s.status === "done").length,
+    failed: stories.filter((s) => s.status === "failed").length,
+    active: stories.filter((s) => s.status === "active").length,
+    queued: stories.filter((s) => s.status === "created").length,
+  };
+
+  return jsonResult({
+    success: true,
+    sprint: {
+      id: sprintDoc.id,
+      title: sprintData.title,
+      status: sprintData.status,
+      projectName: sprintData.sprint?.projectName,
+      branch: sprintData.sprint?.branch,
+      config: sprintData.sprint?.config || null,
+      definition: sprintData.sprint?.definition || null,
+      createdAt: sprintData.createdAt?.toDate?.()?.toISOString() || null,
+      startedAt: sprintData.startedAt?.toDate?.()?.toISOString() || null,
+      completedAt: sprintData.completedAt?.toDate?.()?.toISOString() || null,
+    },
+    stories,
+    stats,
   });
 }

--- a/mcp-server/src/modules/trace.ts
+++ b/mcp-server/src/modules/trace.ts
@@ -1,0 +1,149 @@
+/**
+ * Trace Module — Execution tracing for debugging sprints.
+ * Collection: users/{uid}/traces
+ * Fire-and-forget writes — never blocks the response.
+ */
+
+import { getFirestore, serverTimestamp } from "../firebase/client.js";
+import * as admin from "firebase-admin";
+import { AuthContext } from "../auth/apiKeyValidator.js";
+import { z } from "zod";
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+function jsonResult(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+/** Extract correlation context from tool args */
+export function extractContext(tool: string, args: unknown): Record<string, string> {
+  const ctx: Record<string, string> = {};
+  if (args && typeof args === "object") {
+    const a = args as Record<string, unknown>;
+    if (typeof a.sprintId === "string") ctx.sprintId = a.sprintId;
+    if (typeof a.taskId === "string") ctx.taskId = a.taskId;
+    if (typeof a.storyId === "string") ctx.storyId = a.storyId;
+  }
+  return ctx;
+}
+
+/** Truncate long string values for storage */
+export function sanitizeArgs(args: unknown): unknown {
+  if (args === null || args === undefined) return args;
+  if (typeof args === "string") return args.length > 200 ? args.substring(0, 200) + "..." : args;
+  if (Array.isArray(args)) return args.map(sanitizeArgs);
+  if (typeof args === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+      result[key] = sanitizeArgs(value);
+    }
+    return result;
+  }
+  return args;
+}
+
+/** Fire-and-forget trace write */
+export function traceToolCall(
+  userId: string,
+  tool: string,
+  programId: string,
+  endpoint: string,
+  sessionId: string | undefined,
+  args: unknown,
+  resultSummary: string,
+  durationMs: number,
+  success: boolean,
+  error?: string
+): void {
+  const db = getFirestore();
+  const context = extractContext(tool, args);
+  const truncatedResult = resultSummary.length > 500 ? resultSummary.substring(0, 500) + "..." : resultSummary;
+
+  db.collection(`users/${userId}/traces`).add({
+    tool,
+    programId,
+    endpoint,
+    sessionId: sessionId || null,
+    args: sanitizeArgs(args),
+    resultSummary: truncatedResult,
+    context,
+    durationMs,
+    success,
+    error: error || null,
+    createdAt: serverTimestamp(),
+  }).catch((err) => {
+    console.error("[Trace] Failed to write trace:", err);
+  });
+}
+
+const QueryTracesSchema = z.object({
+  sprintId: z.string().optional(),
+  taskId: z.string().optional(),
+  programId: z.string().max(100).optional(),
+  tool: z.string().optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+  limit: z.number().min(1).max(100).default(50),
+});
+
+export async function queryTracesHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
+  // ISO/Flynn gate
+  if (!["iso", "flynn", "legacy", "mobile"].includes(auth.programId)) {
+    return jsonResult({
+      success: false,
+      error: "query_traces is only accessible by ISO and Flynn.",
+    });
+  }
+
+  const args = QueryTracesSchema.parse(rawArgs || {});
+  const db = getFirestore();
+  let query: admin.firestore.Query = db.collection(`users/${auth.userId}/traces`);
+
+  if (args.sprintId) {
+    query = query.where("context.sprintId", "==", args.sprintId);
+  }
+  if (args.taskId) {
+    query = query.where("context.taskId", "==", args.taskId);
+  }
+  if (args.programId) {
+    query = query.where("programId", "==", args.programId);
+  }
+  if (args.tool) {
+    query = query.where("tool", "==", args.tool);
+  }
+
+  query = query.orderBy("createdAt", "desc");
+
+  if (args.since) {
+    query = query.where("createdAt", ">=", admin.firestore.Timestamp.fromDate(new Date(args.since)));
+  }
+  if (args.until) {
+    query = query.where("createdAt", "<=", admin.firestore.Timestamp.fromDate(new Date(args.until)));
+  }
+
+  query = query.limit(args.limit);
+
+  const snapshot = await query.get();
+  const traces = snapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      tool: data.tool,
+      programId: data.programId,
+      endpoint: data.endpoint,
+      sessionId: data.sessionId,
+      context: data.context,
+      durationMs: data.durationMs,
+      success: data.success,
+      error: data.error,
+      resultSummary: data.resultSummary,
+      createdAt: data.createdAt?.toDate?.()?.toISOString() || null,
+    };
+  });
+
+  return jsonResult({
+    success: true,
+    count: traces.length,
+    traces,
+  });
+}

--- a/mcp-server/src/types/relay-schemas.ts
+++ b/mcp-server/src/types/relay-schemas.ts
@@ -1,0 +1,76 @@
+/**
+ * Relay Schemas — Zod schemas for structured relay message payloads.
+ * Advisory validation: invalid payloads are logged as warnings, message still sent.
+ */
+
+import { z } from "zod";
+
+const ResultPayloadSchema = z.object({
+  taskId: z.string().optional(),
+  outcome: z.enum(["success", "failure", "partial"]).optional(),
+  prUrl: z.string().optional(),
+  summary: z.string().optional(),
+});
+
+const DirectivePayloadSchema = z.object({
+  action: z.string().optional(),
+  priority: z.string().optional(),
+  instructions: z.string().optional(),
+  taskId: z.string().optional(),
+});
+
+const QueryPayloadSchema = z.object({
+  question: z.string().optional(),
+  context: z.string().optional(),
+  responseFormat: z.string().optional(),
+});
+
+const StatusPayloadSchema = z.object({
+  state: z.string().optional(),
+  progress: z.number().optional(),
+  currentTask: z.string().optional(),
+  error: z.string().optional(),
+});
+
+const HandshakePayloadSchema = z.object({
+  version: z.string().optional(),
+  capabilities: z.array(z.string()).optional(),
+});
+
+const AckPayloadSchema = z.object({
+  messageId: z.string().optional(),
+  acknowledged: z.boolean().optional(),
+});
+
+const EmptyPayloadSchema = z.object({});
+
+export const RELAY_PAYLOAD_SCHEMAS: Record<string, z.ZodType> = {
+  RESULT: ResultPayloadSchema,
+  DIRECTIVE: DirectivePayloadSchema,
+  QUERY: QueryPayloadSchema,
+  STATUS: StatusPayloadSchema,
+  HANDSHAKE: HandshakePayloadSchema,
+  ACK: AckPayloadSchema,
+  PING: EmptyPayloadSchema,
+  PONG: EmptyPayloadSchema,
+};
+
+export function validatePayload(
+  messageType: string,
+  payload: unknown
+): { valid: boolean; errors?: string[] } {
+  const schema = RELAY_PAYLOAD_SCHEMAS[messageType];
+  if (!schema) {
+    return { valid: false, errors: [`Unknown message type: ${messageType}`] };
+  }
+
+  const result = schema.safeParse(payload);
+  if (result.success) {
+    return { valid: true };
+  }
+
+  const errors = result.error.issues.map(
+    (issue) => `${issue.path.join(".")}: ${issue.message}`
+  );
+  return { valid: false, errors };
+}

--- a/mcp-server/src/types/relay.ts
+++ b/mcp-server/src/types/relay.ts
@@ -33,6 +33,10 @@ export interface RelayMessage extends Omit<Envelope, "action"> {
   // Session
   sessionId?: string;
 
+  // Structured payload (optional)
+  structuredPayload?: unknown;
+  schemaValid?: boolean | null;
+
   // Delivery
   status: RelayStatus;
   ttl: number;

--- a/mcp-server/src/types/task.ts
+++ b/mcp-server/src/types/task.ts
@@ -59,6 +59,15 @@ export interface SprintData {
   config?: SprintConfig;
   currentAction?: string;
   summary?: SprintSummary;
+  definition?: Array<{
+    id: string;
+    title: string;
+    wave: number;
+    dependencies: string[];
+    complexity: string;
+    retryPolicy: string;
+    maxRetries: number;
+  }>;
 }
 
 /** The Task document — lives in users/{uid}/tasks/{id} */
@@ -75,6 +84,12 @@ export interface Task extends Envelope {
   question?: QuestionData;
   dream?: DreamData;
   sprint?: SprintData;
+  retry?: {
+    policy: string;
+    maxRetries: number;
+    retryCount: number;
+    retryHistory: Array<{ attempt: number; failedAt: string }>;
+  };
 
   // Lifecycle
   status: LifecycleStatus;


### PR DESCRIPTION
## Summary

- **Execution tracing**: Fire-and-forget trace writes to `users/{uid}/traces` collection. New `query_traces` tool (ISO/Flynn gated) with filters for sprintId, taskId, programId, tool, since/until. Traces wired into all 3 endpoints (MCP, REST, ISO).
- **Relay schema enforcement**: Zod schemas per `message_type` for optional `payload` field. Advisory validation — invalid payloads logged as warnings, message still sent. `schemaValid` boolean stored on relay doc. Fully backwards compatible.
- **Sprint retry & escalation**: `retryPolicy` (none/auto_retry/escalate) and `maxRetries` on stories. Auto-retry resets failed stories to "created". Escalation fires relay RESULT to ISO with priority: high. Retry history tracked per story.
- **Sprint definitions + get_sprint**: Full story definitions stored on sprint doc. New `get_sprint` tool returns sprint metadata, definition, all stories with statuses, stats.
- **Test suite**: 3 new test files (trace, relay-schemas, sprint-retry) — 126 tests passing across 4 suites
- **Ledger + Indexes**: 3 BASE_COSTS entries, 3 Firestore composite indexes for traces collection

## Files Changed

| Category | Files |
|----------|-------|
| New modules | `src/modules/trace.ts`, `src/types/relay-schemas.ts` |
| New tests | `src/__tests__/helpers.ts`, `trace.test.ts`, `relay-schemas.test.ts`, `sprint-retry.test.ts` |
| Modified | `index.ts`, `tools.ts`, `rest.ts`, `isoServer.ts`, `toolDefinitions.ts`, `relay.ts`, `sprint.ts`, `ledger.ts`, `types/relay.ts`, `types/task.ts` |
| Config | `jest.config.js`, `firebase/firestore.indexes.json` |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 126 tests passing (4 suites)
- [ ] Deploy indexes: `firebase deploy --only firestore:indexes --project cachebash-app`
- [ ] Deploy: `gcloud run deploy cachebash-mcp --source mcp-server/ --project cachebash-app --region us-central1`
- [ ] Smoke test `query_traces`: run any tool, then call query_traces — verify trace returned
- [ ] Smoke test relay schemas: `send_message` with `payload: {outcome: "success"}` + `message_type: "RESULT"` — verify `schemaValid: true`
- [ ] Smoke test sprint retry: create sprint with `retryPolicy: "auto_retry"`, fail story, verify reset to "created"
- [ ] Smoke test `get_sprint`: create sprint, call `get_sprint(sprintId)` — verify definition + stories + stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)