### PR TITLE
feat: enhance GitHub Projects sync with robust field mapping

### DIFF
--- a/mcp-server/src/modules/dispatch.ts
+++ b/mcp-server/src/modules/dispatch.ts
@@ -188,7 +188,20 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
   const ref = await db.collection(`users/${auth.userId}/tasks`).add(taskData);
 
   // Fire-and-forget: sync to GitHub Issues + Project board
-  syncTaskCreated(auth.userId, ref.id, args.title, args.instructions || "", verifiedSource, args.priority, args.projectId, args.action);
+  syncTaskCreated(
+    auth.userId,
+    ref.id,
+    args.title,
+    args.instructions || "",
+    args.target,
+    args.priority,
+    args.projectId,
+    args.action,
+    args.type,
+    verifiedSource,
+    null, // sessionId - not tracked at task creation
+    new Date().toISOString()
+  );
 
   return jsonResult({
     success: true,

--- a/mcp-server/src/modules/sprint.ts
+++ b/mcp-server/src/modules/sprint.ts
@@ -174,7 +174,7 @@ export async function createSprintHandler(auth: AuthContext, rawArgs: unknown): 
   await batch.commit();
 
   // Fire-and-forget: sync sprint to GitHub Milestone + Issues
-  syncSprintCreated(auth.userId, sprintId, args.projectName, args.stories);
+  syncSprintCreated(auth.userId, sprintId, args.projectName, args.stories, null);
 
   return jsonResult({
     success: true,


### PR DESCRIPTION
## Summary
- Add repo routing based on projectId (tasks go to correct repo: cachebash, grid, reach, etc.)
- Map task type to Kind field (task→Feature, question→Idea, sprint→Chore, interrupt→Bug)
- Add sprint stories and parent sprint issue to Projects board with correct fields
- Enrich issue bodies with CacheBash metadata (taskId, source, target, session, timestamp)
- Expand label taxonomy (type, source, priority, sprint)

## Implementation Details

### Repo Routing
New `mapRepo(projectId)` function routes issues to the correct repository:
- cachebash → `rezzedai/cachebash`
- grid → `rezzedai/grid`
- reach → `rezzedai/reach`
- drivehub → `rezzedai/drive-hub`
- cb.com → `rezzedai/cachebash-com`
- optimeasure → `rezzedai/optimeasure`
- Default: `rezzedai/grid`

### Kind Field Mapping
New `mapKind(type, action)` function maps task types to GitHub Projects Kind field:
- task → Feature
- question → Idea
- dream → Idea
- sprint → Chore
- sprint-story → Chore
- action=interrupt → Bug (overrides type)

### Sprint Board Integration
- Parent sprint issue now appears on board with Status=InProgress, Kind=Chore, Priority=P1
- Story issues appear on board with Status=TODO, Kind=Chore, Priority=P2
- All linked via milestone

### Issue Body Enrichment
Task issues include metadata:
```
> **CacheBash Task:** `{taskId}` | **Source:** {source} | **Target:** {target}
> **Session:** {sessionId} | **Created:** {timestamp}
---
{instructions}
```

Sprint story issues include:
```
> **Sprint:** `{sprintId}` | **Story:** `{storyId}` | **Wave:** {wave}
---
{title}
```

### Label Taxonomy
Task labels: `grid-task`, `program:{target}`, `type:{type}`, `source:{source}`, `priority:{priority}`

Sprint story labels: `grid-task`, `sprint-story`, `sprint:{sprintId}`, `type:sprint-story`

## Backwards Compatibility
All new parameters are optional. Existing callers without new params continue to work with default behavior (grid repo, Feature kind, minimal labels).

## Test Plan
- [x] `npm run build` passes
- [x] `npm test` passes (126 tests)
- [x] Fire-and-forget pattern maintained (all sync functions wrapped in try/catch)
- [x] No breaking changes to existing sync function call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)