### PR TITLE
feat(auth): Firebase ID token validation for mobile

### DIFF
--- a/mcp-server/src/auth/apiKeyValidator.ts
+++ b/mcp-server/src/auth/apiKeyValidator.ts
@@ -53,3 +53,16 @@ export async function validateApiKey(
 }
 
 export { hashApiKey };
+
+import { validateFirebaseToken, isFirebaseToken } from "./firebaseAuthValidator.js";
+
+/**
+ * Combined auth validator — tries Firebase token first (if JWT),
+ * then falls back to API key validation.
+ */
+export async function validateAuth(token: string): Promise<AuthContext | null> {
+  if (isFirebaseToken(token)) {
+    return validateFirebaseToken(token);
+  }
+  return validateApiKey(token);
+}

--- a/mcp-server/src/auth/firebaseAuthValidator.ts
+++ b/mcp-server/src/auth/firebaseAuthValidator.ts
@@ -1,0 +1,45 @@
+import admin from "firebase-admin";
+import * as crypto from "crypto";
+import type { AuthContext } from "./apiKeyValidator.js";
+
+/**
+ * Validate a Firebase ID token and return an AuthContext.
+ * Used for mobile app authentication (OAuth 2.0 + PKCE flow).
+ */
+export async function validateFirebaseToken(
+  idToken: string
+): Promise<AuthContext | null> {
+  try {
+    const decoded = await admin.auth().verifyIdToken(idToken);
+
+    // Create a deterministic encryption key from the Firebase UID
+    // (needed for AuthContext compatibility)
+    const encryptionKey = crypto.pbkdf2Sync(
+      decoded.uid,
+      "cachebash_firebase_v1",
+      100000,
+      32,
+      "sha256"
+    );
+
+    return {
+      userId: decoded.uid,
+      apiKeyHash: `firebase:${decoded.uid}`,
+      encryptionKey,
+      programId: "mobile",
+    };
+  } catch (error) {
+    // Token expired, invalid, or revoked
+    console.error("[Auth] Firebase token validation failed:", error instanceof Error ? error.message : String(error));
+    return null;
+  }
+}
+
+/**
+ * Detect whether a Bearer token is a Firebase ID token or an API key.
+ * Firebase tokens are JWTs (start with "eyJ").
+ * API keys start with "cb_".
+ */
+export function isFirebaseToken(token: string): boolean {
+  return token.startsWith("eyJ");
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,7 +10,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { CustomHTTPTransport } from "./transport/CustomHTTPTransport.js";
 import { initializeFirebase } from "./firebase/client.js";
-import { validateApiKey, type AuthContext } from "./auth/apiKeyValidator.js";
+import { validateAuth, type AuthContext } from "./auth/apiKeyValidator.js";
 import { generateCorrelationId, createAuditLogger } from "./middleware/gate.js";
 import { checkRateLimit, getRateLimitResetIn, checkAuthRateLimit, cleanupRateLimits } from "./middleware/rateLimiter.js";
 import { cleanupExpiredRelayMessages } from "./modules/relay.js";
@@ -152,7 +152,7 @@ async function main() {
     if (url === "/v1/iso/mcp") {
       const token = extractBearerToken(req.headers.authorization);
       if (!token) return sendJson(res, 401, { error: "Missing Authorization header" });
-      const auth = await validateApiKey(token);
+      const auth = await validateAuth(token);
       if (!auth) return sendJson(res, 401, { error: "Invalid API key" });
 
       const clientIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown';
@@ -175,7 +175,7 @@ async function main() {
     if (url === "/v1/mcp" || url === "/mcp") {
       const token = extractBearerToken(req.headers.authorization);
       if (!token) return sendJson(res, 401, { error: "Missing Authorization header" });
-      const auth = await validateApiKey(token);
+      const auth = await validateAuth(token);
       if (!auth) return sendJson(res, 401, { error: "Invalid API key" });
 
       const clientIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown';

--- a/mcp-server/src/transport/rest.ts
+++ b/mcp-server/src/transport/rest.ts
@@ -5,7 +5,7 @@
 
 import http from "http";
 import { ZodError } from "zod";
-import { validateApiKey, type AuthContext } from "../auth/apiKeyValidator.js";
+import { validateAuth, type AuthContext } from "../auth/apiKeyValidator.js";
 import { TOOL_HANDLERS } from "../tools.js";
 import { logToolCall } from "../modules/ledger.js";
 import { traceToolCall } from "../modules/trace.js";
@@ -370,7 +370,7 @@ export function createRestRouter(): (req: http.IncomingMessage, res: http.Server
     // Auth
     const token = extractBearerToken(req.headers.authorization);
     if (!token) return restResponse(res, false, { code: "UNAUTHORIZED", message: "Missing Authorization header" }, 401);
-    const auth = await validateApiKey(token);
+    const auth = await validateAuth(token);
     if (!auth) return restResponse(res, false, { code: "UNAUTHORIZED", message: "Invalid API key" }, 401);
 
     const clientIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown';


### PR DESCRIPTION
## Summary
- Implements SARK R-01: Firebase Auth for mobile app
- Adds Firebase ID token verification via firebase-admin
- Combined `validateAuth()` function auto-detects token type
- API key auth preserved for Grid programs (no breaking changes)
- Mobile users authenticated as programId: "mobile"

## Test plan
- [ ] Existing API key auth still works
- [ ] Firebase ID token returns valid AuthContext
- [ ] Invalid/expired Firebase tokens return 401
- [ ] Mobile programId set correctly
- [ ] MCP and REST endpoints both support Firebase tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)