### PR TITLE
fix(mobile): cached data indicators + settings screen polish

### DIFF
--- a/mobile/src/hooks/useMessages.ts
+++ b/mobile/src/hooks/useMessages.ts
@@ -108,5 +108,6 @@ export function useMessages() {
     isLoading: result.isLoading,
     refetch: result.refetch,
     lastUpdated: result.lastUpdated,
+    isCached: result.isCached,
   };
 }

--- a/mobile/src/hooks/useSessions.ts
+++ b/mobile/src/hooks/useSessions.ts
@@ -87,5 +87,6 @@ export function useSessions() {
     isLoading: result.isLoading,
     refetch: result.refetch,
     lastUpdated: result.lastUpdated,
+    isCached: result.isCached,
   };
 }

--- a/mobile/src/hooks/useTasks.ts
+++ b/mobile/src/hooks/useTasks.ts
@@ -102,5 +102,6 @@ export function useTasks(filter?: UseTasksOptions) {
     isLoading: result.isLoading,
     refetch: result.refetch,
     lastUpdated: result.lastUpdated,
+    isCached: result.isCached,
   };
 }

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 export default function HomeScreen({ navigation }: Props) {
   const insets = useSafeAreaInsets();
-  const { sessions, programs, isLoading, refetch, error } = useSessions();
+  const { sessions, programs, isLoading, refetch, error, isCached } = useSessions();
   const { tasks, pendingCount } = useTasks();
   const { messages, unreadCount } = useMessages();
   const { isConnected, isInternetReachable } = useConnectivity();
@@ -91,7 +91,7 @@ export default function HomeScreen({ navigation }: Props) {
             </View>
           </View>
           <Text style={styles.lastUpdate}>
-            {(isConnected && isInternetReachable !== false) ? 'Connected' : 'Offline'} • Updated {lastUpdateStr}
+            {(isConnected && isInternetReachable !== false) ? 'Connected' : 'Offline'} • Updated {lastUpdateStr}{isCached ? ' • Cached' : ''}
           </Text>
         </View>
 

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -6,18 +6,18 @@ import { useNotifications } from '../contexts/NotificationContext';
 import { theme } from '../theme';
 
 export default function SettingsScreen() {
-  const { signOut, apiKey } = useAuth();
+  const { signOut, user } = useAuth();
   const { error: sessionsError } = useSessions();
   const { permissionStatus, preferences, updatePreferences, requestPermissions } = useNotifications();
 
   const handleDisconnect = () => {
     Alert.alert(
-      'Disconnect',
-      'Are you sure you want to disconnect? You will need to re-enter your API key to reconnect.',
+      'Sign Out',
+      'Are you sure you want to sign out?',
       [
         { text: 'Cancel', style: 'cancel' },
         {
-          text: 'Disconnect',
+          text: 'Sign Out',
           style: 'destructive',
           onPress: signOut,
         },
@@ -36,17 +36,17 @@ export default function SettingsScreen() {
         <Text style={styles.sectionTitle} accessibilityRole="header">Account</Text>
         <View style={styles.card}>
           <View style={styles.row}>
-            <Text style={styles.rowLabel}>API Key</Text>
-            <Text style={styles.rowValue}>••••{apiKey?.slice(-4) || '????'}</Text>
+            <Text style={styles.rowLabel}>Account</Text>
+            <Text style={styles.rowValue}>{user?.email || 'Unknown'}</Text>
           </View>
           <View style={styles.divider} />
           <TouchableOpacity
             style={styles.buttonRow}
             onPress={handleDisconnect}
             activeOpacity={0.7}
-            accessibilityLabel="Disconnect from Grid"
+            accessibilityLabel="Sign out of CacheBash"
           >
-            <Text style={styles.disconnectText}>Disconnect</Text>
+            <Text style={styles.disconnectText}>Sign Out</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -13,7 +13,7 @@ type FilterType = 'all' | 'created' | 'active' | 'done';
 
 export default function TasksScreen({ navigation }: Props) {
   const [filter, setFilter] = useState<FilterType>('all');
-  const { tasks, isLoading, refetch, error } = useTasks();
+  const { tasks, isLoading, refetch, error, isCached } = useTasks();
 
   const filteredTasks = useMemo(() => {
     if (filter === 'all') return tasks;
@@ -125,7 +125,14 @@ export default function TasksScreen({ navigation }: Props) {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>Tasks</Text>
+        <View style={styles.headerRow}>
+          <Text style={styles.headerTitle}>Tasks</Text>
+          {isCached && (
+            <View style={styles.cachedBadge}>
+              <Text style={styles.cachedBadgeText}>CACHED</Text>
+            </View>
+          )}
+        </View>
       </View>
 
       <ScrollView
@@ -171,10 +178,27 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+  },
   headerTitle: {
     fontSize: theme.fontSize.xxl,
     fontWeight: '700',
     color: theme.colors.text,
+  },
+  cachedBadge: {
+    backgroundColor: theme.colors.surfaceElevated,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: 4,
+    borderRadius: theme.borderRadius.sm,
+  },
+  cachedBadgeText: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: '600',
+    color: theme.colors.textMuted,
+    letterSpacing: 0.5,
   },
   filterContainer: {
     flexGrow: 0,


### PR DESCRIPTION
## Summary
- Expose `isCached` flag from `usePolling` through `useSessions`, `useTasks`, and `useMessages` hooks
- Add "Cached" indicator to HomeScreen header when displaying cached session data
- Add "CACHED" pill badge to TasksScreen header when showing cached task data
- Update SettingsScreen to use Firebase Auth (`user.email` instead of `apiKey`)
- Update disconnect flow to "Sign Out" terminology with updated alert messages

## Test plan
- [ ] Verify cached indicator appears on HomeScreen when offline/using cached data
- [ ] Verify cached badge appears on TasksScreen when offline/using cached data
- [ ] Verify SettingsScreen displays user email instead of API key
- [ ] Verify "Sign Out" button and dialog work correctly
- [ ] Test all screens transition smoothly between cached and live data states

🤖 Generated with [Claude Code](https://claude.com/claude-code)