### PR TITLE
feat(mobile): push notification token registration

### DIFF
--- a/mobile/src/config/firebase.ts
+++ b/mobile/src/config/firebase.ts
@@ -5,6 +5,7 @@
 
 import { initializeApp } from 'firebase/app';
 import { initializeAuth, getReactNativePersistence } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const firebaseConfig = {
@@ -24,4 +25,7 @@ const auth = initializeAuth(app, {
   persistence: getReactNativePersistence(AsyncStorage),
 });
 
-export { app, auth };
+// Initialize Firestore
+const db = getFirestore(app);
+
+export { app, auth, db };

--- a/mobile/src/services/notifications.ts
+++ b/mobile/src/services/notifications.ts
@@ -33,6 +33,28 @@ export async function requestNotificationPermissions(): Promise<boolean> {
       importance: Notifications.AndroidImportance.DEFAULT,
       sound: null,
     });
+    // Cloud Functions use these channel IDs for FCM pushes
+    await Notifications.setNotificationChannelAsync('questions', {
+      name: 'Questions',
+      importance: Notifications.AndroidImportance.MAX,
+      sound: 'default',
+      vibrationPattern: [0, 250, 250, 250],
+    });
+    await Notifications.setNotificationChannelAsync('dreams', {
+      name: 'Dream Sessions',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+    });
+    await Notifications.setNotificationChannelAsync('tasks', {
+      name: 'Tasks',
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: 'default',
+    });
+    await Notifications.setNotificationChannelAsync('sessions', {
+      name: 'Session Updates',
+      importance: Notifications.AndroidImportance.DEFAULT,
+      sound: null,
+    });
   }
 
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
@@ -50,6 +72,21 @@ export async function requestNotificationPermissions(): Promise<boolean> {
 export async function getNotificationPermissionStatus(): Promise<string> {
   const { status } = await Notifications.getPermissionsAsync();
   return status;
+}
+
+/**
+ * Get the native device push token (FCM/APNs).
+ * Returns null in Expo Go (native tokens not available).
+ */
+export async function getDevicePushToken(): Promise<string | null> {
+  try {
+    const token = await Notifications.getDevicePushTokenAsync();
+    return token.data as string;
+  } catch (error) {
+    // Expected in Expo Go — native push tokens aren't available
+    console.log('Native push token not available (expected in Expo Go):', (error as Error).message);
+    return null;
+  }
 }
 
 // Schedule a local notification


### PR DESCRIPTION
## Summary
- Register native device push token (FCM/APNs) in Firestore `users/{uid}/devices/`
- Cloud Functions already read from this collection to send push notifications
- Gracefully handles Expo Go (native tokens unavailable) — falls back to local notifications
- Adds 4 missing Android notification channels (`questions`, `dreams`, `tasks`, `sessions`) to align with Cloud Functions
- Firestore initialized in `firebase.ts` for direct writes
- Token refresh listener re-registers on token rotation
- Foreground push handler re-schedules critical notifications locally

## Architecture
```
Auth confirmed → Permissions granted → Get native push token
→ Write to Firestore users/{uid}/devices/{deviceId}
→ Cloud Functions read tokens → Send FCM pushes
→ Mobile receives → Handler routes based on tier
```

## Test plan
- [ ] Build with EAS Build (production) to test native push token
- [ ] Verify token appears in Firestore `users/{uid}/devices/` collection
- [ ] Create a question-type task — verify push notification received
- [ ] Verify Expo Go gracefully logs "Native push token not available"
- [ ] Verify Android notification channels include questions, dreams, tasks, sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)