### PR TITLE
feat(mobile): multicast group messaging

### DIFF
--- a/mobile/src/hooks/useGroups.ts
+++ b/mobile/src/hooks/useGroups.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+
+export interface Group {
+  name: string;
+  members: string[];
+}
+
+export function useGroups() {
+  const { api } = useAuth();
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!api) return;
+
+    const fetchGroups = async () => {
+      setIsLoading(true);
+      try {
+        const data = await api.listGroups();
+        // Response shape may vary — be defensive
+        const groupList = data.groups || data || [];
+        setGroups(
+          groupList.map((g: any) => ({
+            name: g.name || g.id || 'unknown',
+            members: g.members || g.programs || [],
+          }))
+        );
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to load groups'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchGroups();
+  }, [api]);
+
+  return { groups, isLoading, error };
+}


### PR DESCRIPTION
## Summary
- New useGroups hook fetching available multicast groups via listGroups() API
- Groups section added to MessagesScreen above individual channels
- Tappable group cards showing name, member count, and member list
- Groups navigate to ChannelDetail for broadcasting messages
- Visual separation between Groups and Channels sections

## Test plan
- [ ] Open Messages tab, verify Groups section appears above channels
- [ ] Verify group cards show name, member count, member names
- [ ] Tap a group card, verify navigation to ChannelDetail
- [ ] Send a message from group channel, verify it sends to the group target
- [ ] Verify groups still work when API returns empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)