### PR TITLE
feat(mobile): program detail health integration and send task

### DIFF
--- a/mobile/src/screens/CreateTaskScreen.tsx
+++ b/mobile/src/screens/CreateTaskScreen.tsx
@@ -10,7 +10,7 @@ import {
   Platform,
   Alert,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { theme } from '../theme';
 import { useAuth } from '../contexts/AuthContext';
 import { haptic } from '../utils/haptics';
@@ -37,9 +37,11 @@ const PROGRAMS: Program[] = [
 
 const CreateTaskScreen = () => {
   const navigation = useNavigation();
+  const route = useRoute<any>();
+  const initialTarget = route.params?.initialTarget || null;
   const { api } = useAuth();
   const [title, setTitle] = useState('');
-  const [target, setTarget] = useState<string | null>(null);
+  const [target, setTarget] = useState<string | null>(initialTarget);
   const [priority, setPriority] = useState<Priority>('normal');
   const [action, setAction] = useState<Action>('queue');
   const [instructions, setInstructions] = useState('');


### PR DESCRIPTION
## Summary
- Integrates `useFleetHealth` hook into ProgramDetailScreen for per-program health data
- Adds pending messages and pending tasks info cards to the info grid
- Color-codes heartbeat value by age (green <60s, yellow 60-120s, red >120s)
- Adds health indicator dot next to heartbeat
- Adds 'Send Task' button alongside 'Send Message' in the footer
- CreateTaskScreen now accepts optional `initialTarget` route param for pre-filled target

## Test plan
- [ ] Verify ProgramDetailScreen shows pending message/task counts from fleet health
- [ ] Verify heartbeat color coding (green/yellow/red) matches thresholds
- [ ] Verify 'Send Task' navigates to CreateTask with target pre-selected
- [ ] Verify CreateTaskScreen still works without initialTarget param

🤖 Generated with [Claude Code](https://claude.com/claude-code)