### PR TITLE
fix: raise AUTH_LIMIT from 10 to 60 for fleet-scale MCP ops

### DIFF
--- a/mcp-server/src/middleware/rateLimiter.ts
+++ b/mcp-server/src/middleware/rateLimiter.ts
@@ -26,7 +26,7 @@ export const READ_TOOLS = new Set([
 
 const READ_LIMIT = 120; // requests per minute
 const WRITE_LIMIT = 60; // requests per minute
-const AUTH_LIMIT = 10; // attempts per minute per IP
+const AUTH_LIMIT = 60; // attempts per minute per IP (raised from 10 for fleet-scale ops)
 const WINDOW_MS = 60 * 1000; // 1 minute
 const CLEANUP_WINDOW_MS = 2 * 60 * 1000; // 2 minutes
 


### PR DESCRIPTION
## Summary
- Raises `AUTH_LIMIT` in `rateLimiter.ts` from 10 to 60 attempts per minute per IP
- Fixes BUG-007: Grid fleet programs were hitting auth rate limits during normal fleet-scale operations (multiple programs authenticating from same IP)

## Test plan
- [x] TypeScript build passes (`npm run build`)
- [x] Single-line change verified via `git diff`
- [ ] Monitor auth rate limit errors in production after deploy

Generated with [Claude Code](https://claude.com/claude-code)