### PR TITLE
v2 cycle 1: consolidate program state into sessions collection

### DIFF
--- a/mcp-server/src/modules/programState.ts
+++ b/mcp-server/src/modules/programState.ts
@@ -1,6 +1,6 @@
 /**
  * Program State Module — Persistent operational memory for Grid programs.
- * Collection: users/{uid}/program_state/{programId}
+ * Collection: users/{uid}/sessions/_program_state/{programId}
  */
 
 import { getFirestore } from "../firebase/client.js";
@@ -137,7 +137,7 @@ export async function getProgramStateHandler(auth: AuthContext, rawArgs: unknown
   }
 
   const db = getFirestore();
-  const doc = await db.doc(`users/${auth.userId}/program_state/${args.programId}`).get();
+  const doc = await db.doc(`users/${auth.userId}/sessions/_program_state/${args.programId}`).get();
 
   if (!doc.exists) {
     return jsonResult({
@@ -170,7 +170,7 @@ export async function updateProgramStateHandler(auth: AuthContext, rawArgs: unkn
   }
 
   const db = getFirestore();
-  const docRef = db.doc(`users/${auth.userId}/program_state/${args.programId}`);
+  const docRef = db.doc(`users/${auth.userId}/sessions/_program_state/${args.programId}`);
   const existing = await docRef.get();
 
   const now = new Date().toISOString();

--- a/mcp-server/src/modules/pulse.ts
+++ b/mcp-server/src/modules/pulse.ts
@@ -98,7 +98,7 @@ export async function createSessionHandler(auth: AuthContext, rawArgs: unknown):
       programData.color = meta.color;
       programData.role = meta.role;
     }
-    await db.doc(`users/${auth.userId}/programs/${programId}`).set(programData, { merge: true });
+    await db.doc(`users/${auth.userId}/sessions/_programs/${programId}`).set(programData, { merge: true });
   }
 
   return jsonResult({ success: true, sessionId, message: `Session created: "${args.name}"` });
@@ -149,7 +149,7 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
       programData.color = meta.color;
       programData.role = meta.role;
     }
-    await db.doc(`users/${auth.userId}/programs/${programId}`).set(programData, { merge: true });
+    await db.doc(`users/${auth.userId}/sessions/_programs/${programId}`).set(programData, { merge: true });
   }
 
   return jsonResult({ success: true, sessionId, message: `Status updated: "${args.status}"` });
@@ -169,7 +169,7 @@ export async function getFleetHealthHandler(auth: AuthContext, _rawArgs: unknown
 
   // 3 parallel Firestore queries
   const [programsSnap, pendingRelaySnap, pendingTasksSnap] = await Promise.all([
-    db.collection(`users/${auth.userId}/programs`).get(),
+    db.collection(`users/${auth.userId}/sessions/_programs`).get(),
     db.collection(`users/${auth.userId}/relay`).where("status", "==", "pending").get(),
     db.collection(`users/${auth.userId}/tasks`).where("status", "==", "created").get(),
   ]);


### PR DESCRIPTION
## Summary

- Moved `program_state/{programId}` to `sessions/_program_state/{programId}` in programState.ts
- Moved `programs/{programId}` piggyback writes to `sessions/_programs/{programId}` in pulse.ts
- Updated `getFleetHealthHandler` to query `sessions/_programs` instead of `programs`

All program data now lives under the `sessions` top-level collection. Pure path reorganization — no schema or logic changes.

Part of v2 Cycle 1 collection consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)