### PR TITLE
v2 cycle 1: consolidate audit + traces into ledger

### DIFF
--- a/mcp-server/src/middleware/gate.ts
+++ b/mcp-server/src/middleware/gate.ts
@@ -4,7 +4,7 @@
  * Every request passes through the Gate. The Gate validates the API key,
  * verifies the claimed source identity, and logs the decision.
  *
- * Phase 2: Source verification is ENFORCED. Audit entries persisted to Firestore.
+ * Phase 2: Source verification is ENFORCED. Audit entries persisted to ledger collection.
  */
 
 import { generateCorrelationId } from "./correlationId.js";
@@ -54,8 +54,9 @@ export function logAudit(entry: AuditEntry): void {
     const clean = Object.fromEntries(
       Object.entries(entry).filter(([_, v]) => v !== undefined)
     );
-    db.collection(`users/${entry.userId}/audit`).add({
+    db.collection(`users/${entry.userId}/ledger`).add({
       ...clean,
+      type: "audit",
       timestamp: serverTimestamp(),
     }).catch((err) => {
       console.error("[Audit] Failed to persist audit entry:", err);

--- a/mcp-server/src/modules/audit.ts
+++ b/mcp-server/src/modules/audit.ts
@@ -1,6 +1,6 @@
 /**
  * Audit Module — Query Gate audit log.
- * Collection: users/{uid}/audit
+ * Collection: users/{uid}/ledger (type: audit)
  * Read-only. ISO and Flynn only.
  */
 
@@ -33,7 +33,8 @@ export async function getAuditHandler(auth: AuthContext, rawArgs: unknown): Prom
   const db = getFirestore();
 
   let query: FirebaseFirestore.Query = db
-    .collection(`users/${auth.userId}/audit`)
+    .collection(`users/${auth.userId}/ledger`)
+    .where("type", "==", "audit")
     .orderBy("timestamp", "desc");
 
   if (args.allowed !== undefined) {

--- a/mcp-server/src/modules/ledger.ts
+++ b/mcp-server/src/modules/ledger.ts
@@ -1,5 +1,5 @@
 /**
- * Ledger Module — Cost tracking per tool call.
+ * Ledger Module — Cost tracking per tool call. Type discriminator: tool_call.
  * Collection: users/{uid}/ledger
  * Fire-and-forget writes — never blocks the response.
  */
@@ -60,6 +60,7 @@ export function logToolCall(
   // Fire and forget — don't await, don't block
   const db = getFirestore();
   db.collection(`users/${userId}/ledger`).add({
+    type: "tool_call",
     tool,
     programId,
     endpoint,

--- a/mcp-server/src/modules/trace.ts
+++ b/mcp-server/src/modules/trace.ts
@@ -1,6 +1,6 @@
 /**
  * Trace Module — Execution tracing for debugging sprints.
- * Collection: users/{uid}/traces
+ * Collection: users/{uid}/ledger (type: trace)
  * Fire-and-forget writes — never blocks the response.
  */
 
@@ -59,7 +59,8 @@ export function traceToolCall(
   const context = extractContext(tool, args);
   const truncatedResult = resultSummary.length > 500 ? resultSummary.substring(0, 500) + "..." : resultSummary;
 
-  db.collection(`users/${userId}/traces`).add({
+  db.collection(`users/${userId}/ledger`).add({
+    type: "trace",
     tool,
     programId,
     endpoint,
@@ -97,7 +98,7 @@ export async function queryTracesHandler(auth: AuthContext, rawArgs: unknown): P
 
   const args = QueryTracesSchema.parse(rawArgs || {});
   const db = getFirestore();
-  let query: admin.firestore.Query = db.collection(`users/${auth.userId}/traces`);
+  let query: admin.firestore.Query = db.collection(`users/${auth.userId}/ledger`).where("type", "==", "trace");
 
   if (args.sprintId) {
     query = query.where("context.sprintId", "==", args.sprintId);


### PR DESCRIPTION
## Summary

- Audit entries (`gate.ts`) now write to `ledger` collection with `type: "audit"` instead of separate `audit` collection
- Trace entries (`trace.ts`) now write to `ledger` with `type: "trace"` instead of separate `traces` collection
- Existing ledger tool call entries now include `type: "tool_call"` discriminator
- Read queries in `audit.ts` and `trace.ts` updated to filter by type

Part of v2 Cycle 1 collection consolidation (9→4+1 collections).

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Verify audit writes go to ledger with type: "audit"
- [ ] Verify trace writes go to ledger with type: "trace"
- [ ] Verify get_audit still returns audit entries
- [ ] Verify query_traces still returns trace entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)