### PR TITLE
fix: correct Firestore path segments for program state and programs

### DIFF
--- a/mcp-server/src/modules/programState.ts
+++ b/mcp-server/src/modules/programState.ts
@@ -1,6 +1,6 @@
 /**
  * Program State Module — Persistent operational memory for Grid programs.
- * Collection: users/{uid}/sessions/_program_state/{programId}
+ * Collection: users/{uid}/sessions/_meta/program_state/{programId}
  */
 
 import { getFirestore } from "../firebase/client.js";
@@ -137,7 +137,7 @@ export async function getProgramStateHandler(auth: AuthContext, rawArgs: unknown
   }
 
   const db = getFirestore();
-  const doc = await db.doc(`users/${auth.userId}/sessions/_program_state/${args.programId}`).get();
+  const doc = await db.doc(`users/${auth.userId}/sessions/_meta/program_state/${args.programId}`).get();
 
   if (!doc.exists) {
     return jsonResult({
@@ -170,7 +170,7 @@ export async function updateProgramStateHandler(auth: AuthContext, rawArgs: unkn
   }
 
   const db = getFirestore();
-  const docRef = db.doc(`users/${auth.userId}/sessions/_program_state/${args.programId}`);
+  const docRef = db.doc(`users/${auth.userId}/sessions/_meta/program_state/${args.programId}`);
   const existing = await docRef.get();
 
   const now = new Date().toISOString();

--- a/mcp-server/src/modules/pulse.ts
+++ b/mcp-server/src/modules/pulse.ts
@@ -98,7 +98,7 @@ export async function createSessionHandler(auth: AuthContext, rawArgs: unknown):
       programData.color = meta.color;
       programData.role = meta.role;
     }
-    await db.doc(`users/${auth.userId}/sessions/_programs/${programId}`).set(programData, { merge: true });
+    await db.doc(`users/${auth.userId}/sessions/_meta/programs/${programId}`).set(programData, { merge: true });
   }
 
   return jsonResult({ success: true, sessionId, message: `Session created: "${args.name}"` });
@@ -149,7 +149,7 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
       programData.color = meta.color;
       programData.role = meta.role;
     }
-    await db.doc(`users/${auth.userId}/sessions/_programs/${programId}`).set(programData, { merge: true });
+    await db.doc(`users/${auth.userId}/sessions/_meta/programs/${programId}`).set(programData, { merge: true });
   }
 
   return jsonResult({ success: true, sessionId, message: `Status updated: "${args.status}"` });
@@ -169,7 +169,7 @@ export async function getFleetHealthHandler(auth: AuthContext, _rawArgs: unknown
 
   // 3 parallel Firestore queries
   const [programsSnap, pendingRelaySnap, pendingTasksSnap] = await Promise.all([
-    db.collection(`users/${auth.userId}/sessions/_programs`).get(),
+    db.collection(`users/${auth.userId}/sessions/_meta/programs`).get(),
     db.collection(`users/${auth.userId}/relay`).where("status", "==", "pending").get(),
     db.collection(`users/${auth.userId}/tasks`).where("status", "==", "created").get(),
   ]);

--- a/mcp-server/src/types/programState.ts
+++ b/mcp-server/src/types/programState.ts
@@ -1,6 +1,6 @@
 /**
  * Program State Schema — Persistent operational memory for Grid programs.
- * Collection: users/{uid}/sessions/_program_state/{programId}
+ * Collection: users/{uid}/sessions/_meta/program_state/{programId}
  * Designed by ALAN (Decision #15b), safety requirements from SARK (Decision #15c).
  */
 


### PR DESCRIPTION
## Summary

- Fixes invalid Firestore path segment counts in program state and programs collections
- Changes `sessions/_program_state` → `sessions/_meta/program_state`
- Changes `sessions/_programs` → `sessions/_meta/programs`
- Updates migration script to use corrected paths and adds batch optimization

## Problem

Firestore requires:
- **Odd** segment counts for `collection()` references
- **Even** segment counts for `doc()` references

The paths `sessions/_program_state/{id}` and `sessions/_programs/{id}` had even collection segments and odd doc segments, which is invalid.

## Solution

Insert `_meta` sentinel document to maintain valid segment counts:
- `sessions/_meta/program_state/{programId}` → 3 segments (collection), 4 segments (doc)
- `sessions/_meta/programs/{programId}` → 3 segments (collection), 4 segments (doc)

## Files Changed

- `src/modules/programState.ts` — 3 path references updated
- `src/modules/pulse.ts` — 3 path references updated
- `src/types/programState.ts` — 1 doc comment updated
- `scripts/migrate-cycle1.ts` — Migration paths + batch optimization

## Test Plan

- [x] TypeScript build passes (`npx tsc --noEmit`)
- [ ] Deploy to staging
- [ ] Run migration script with `--dry-run`
- [ ] Verify program state and pulse operations work correctly

Generated with [Claude Code](https://claude.com/claude-code)