### PR TITLE
feat: channel data foundation (Story 1A)

### DIFF
--- a/app/lib/providers/channel_provider.dart
+++ b/app/lib/providers/channel_provider.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/message_model.dart';
+import '../models/session_model.dart';
+import '../theme/program_colors.dart';
+import 'messages_provider.dart';
+import 'sessions_provider.dart';
+
+/// Represents a single channel (one per program) with aggregated data
+class ChannelData {
+  final String programId;
+  final ProgramMeta meta;
+  final List<MessageModel> messages;
+  final SessionModel? activeSession;
+  final int unreadCount;
+  final DateTime? lastActivity;
+
+  const ChannelData({
+    required this.programId,
+    required this.meta,
+    required this.messages,
+    this.activeSession,
+    this.unreadCount = 0,
+    this.lastActivity,
+  });
+
+  /// Whether this channel has pending questions needing response
+  bool get hasPendingQuestions => messages.any((m) => m.needsResponse);
+
+  /// Count of pending questions
+  int get pendingQuestionCount => messages.where((m) => m.needsResponse).length;
+
+  /// Whether the program has an active (non-stale, non-archived) session
+  bool get hasActiveSession => activeSession != null && activeSession!.isActive;
+
+  /// Whether the program is blocked
+  bool get isBlocked => activeSession?.isBlocked ?? false;
+
+  /// Program state string for display
+  String get displayState {
+    if (activeSession == null) return 'offline';
+    return activeSession!.displayState;
+  }
+}
+
+/// Provides a list of all channels, sorted by activity priority
+final channelListProvider = Provider<AsyncValue<List<ChannelData>>>((ref) {
+  final messagesAsync = ref.watch(activeMessagesProvider);
+  final sessionsAsync = ref.watch(activeSessionsProvider);
+
+  // Combine async states
+  if (messagesAsync.isLoading || sessionsAsync.isLoading) {
+    return const AsyncValue.loading();
+  }
+
+  final messages = messagesAsync.valueOrNull ?? [];
+  final sessions = sessionsAsync.valueOrNull ?? [];
+
+  // Collect all program IDs from sessions
+  final programIds = <String>{};
+  for (final session in sessions) {
+    if (session.programId != null) {
+      programIds.add(session.programId!.toLowerCase());
+    }
+  }
+
+  // Always include all known programs so channels exist even without activity
+  programIds.addAll(ProgramRegistry.knownIds);
+
+  // Build channel data for each program
+  final channels = programIds.map((id) {
+    final meta = ProgramRegistry.get(id);
+
+    // Find active session for this program
+    final programSessions = sessions
+        .where((s) => s.programId?.toLowerCase() == id)
+        .toList()
+      ..sort((a, b) => b.lastUpdate.compareTo(a.lastUpdate));
+    final activeSession = programSessions.isNotEmpty ? programSessions.first : null;
+
+    // Filter messages relevant to this program
+    // Messages are associated via sessionId which contains the program name
+    final programMessages = messages.where((m) {
+      final sid = m.sessionId?.toLowerCase() ?? '';
+      return sid.contains(id);
+    }).toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    // Calculate last activity
+    DateTime? lastActivity;
+    if (programMessages.isNotEmpty) {
+      lastActivity = programMessages.first.createdAt;
+    }
+    if (activeSession != null) {
+      final sessionTime = activeSession.lastUpdate;
+      if (lastActivity == null || sessionTime.isAfter(lastActivity)) {
+        lastActivity = sessionTime;
+      }
+    }
+
+    return ChannelData(
+      programId: id,
+      meta: meta,
+      messages: programMessages,
+      activeSession: activeSession,
+      unreadCount: programMessages.where((m) => m.isPending).length,
+      lastActivity: lastActivity,
+    );
+  }).toList();
+
+  // Sort: pending questions first, then active sessions, then by last activity
+  channels.sort((a, b) {
+    // Pending questions always on top
+    if (a.hasPendingQuestions && !b.hasPendingQuestions) return -1;
+    if (!a.hasPendingQuestions && b.hasPendingQuestions) return 1;
+
+    // Active sessions next
+    if (a.hasActiveSession && !b.hasActiveSession) return -1;
+    if (!a.hasActiveSession && b.hasActiveSession) return 1;
+
+    // Then by last activity
+    final aTime = a.lastActivity ?? DateTime(2000);
+    final bTime = b.lastActivity ?? DateTime(2000);
+    return bTime.compareTo(aTime);
+  });
+
+  return AsyncValue.data(channels);
+});
+
+/// Provides channel data for a specific program
+final channelDetailProvider = Provider.family<AsyncValue<ChannelData>, String>((ref, programId) {
+  final channelList = ref.watch(channelListProvider);
+  return channelList.when(
+    data: (channels) {
+      final channel = channels.firstWhere(
+        (c) => c.programId == programId.toLowerCase(),
+        orElse: () => ChannelData(
+          programId: programId.toLowerCase(),
+          meta: ProgramRegistry.get(programId),
+          messages: [],
+        ),
+      );
+      return AsyncValue.data(channel);
+    },
+    loading: () => const AsyncValue.loading(),
+    error: (e, st) => AsyncValue.error(e, st),
+  );
+});

--- a/app/lib/theme/program_colors.dart
+++ b/app/lib/theme/program_colors.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// Metadata for a Grid program — used in channel list, avatars, and status indicators
+class ProgramMeta {
+  final String id;
+  final String displayName;
+  final Color color;
+  final String initial;
+
+  const ProgramMeta({
+    required this.id,
+    required this.displayName,
+    required this.color,
+    required this.initial,
+  });
+}
+
+/// Registry of all known Grid programs with their visual identity
+class ProgramRegistry {
+  ProgramRegistry._();
+
+  static const Map<String, ProgramMeta> _programs = {
+    'iso': ProgramMeta(id: 'iso', displayName: 'ISO', color: Color(0xFF4ECDC4), initial: 'I'),
+    'basher': ProgramMeta(id: 'basher', displayName: 'BASHER', color: Color(0xFFFBBF24), initial: 'B'),
+    'alan': ProgramMeta(id: 'alan', displayName: 'ALAN', color: Color(0xFF60A5FA), initial: 'A'),
+    'quorra': ProgramMeta(id: 'quorra', displayName: 'QUORRA', color: Color(0xFF8B5CF6), initial: 'Q'),
+    'sark': ProgramMeta(id: 'sark', displayName: 'SARK', color: Color(0xFFEF4444), initial: 'S'),
+    'radia': ProgramMeta(id: 'radia', displayName: 'RADIA', color: Color(0xFFF472B6), initial: 'R'),
+    'able': ProgramMeta(id: 'able', displayName: 'ABLE', color: Color(0xFF34D399), initial: 'A'),
+    'beck': ProgramMeta(id: 'beck', displayName: 'BECK', color: Color(0xFFFB923C), initial: 'B'),
+    'ram': ProgramMeta(id: 'ram', displayName: 'RAM', color: Color(0xFF818CF8), initial: 'R'),
+    'casp': ProgramMeta(id: 'casp', displayName: 'CASP', color: Color(0xFF2DD4BF), initial: 'C'),
+    'bit': ProgramMeta(id: 'bit', displayName: 'BIT', color: Color(0xFF9CA3AF), initial: 'B'),
+    'flynn': ProgramMeta(id: 'flynn', displayName: 'Flynn', color: Color(0xFFF59E0B), initial: 'F'),
+  };
+
+  static const _unknown = ProgramMeta(
+    id: 'unknown',
+    displayName: 'Unknown',
+    color: Color(0xFF64748B),
+    initial: '?',
+  );
+
+  /// Get program metadata by ID (case-insensitive)
+  static ProgramMeta get(String? programId) {
+    if (programId == null) return _unknown;
+    return _programs[programId.toLowerCase()] ?? _unknown;
+  }
+
+  /// Get all known programs
+  static List<ProgramMeta> get all => _programs.values.toList();
+
+  /// Get all known program IDs
+  static Set<String> get knownIds => _programs.keys.toSet();
+}

--- a/app/lib/widgets/program_avatar.dart
+++ b/app/lib/widgets/program_avatar.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../theme/program_colors.dart';
+
+/// Circular avatar showing a program's identity color and initial
+class ProgramAvatar extends StatelessWidget {
+  final String programId;
+  final double size;
+  final bool showStatusDot;
+  final String? statusState; // 'working', 'blocked', 'complete', 'pinned', 'offline'
+
+  const ProgramAvatar({
+    super.key,
+    required this.programId,
+    this.size = 40,
+    this.showStatusDot = false,
+    this.statusState,
+  });
+
+  Color _statusColor() {
+    switch (statusState) {
+      case 'working':
+        return const Color(0xFF4ADE80); // green
+      case 'blocked':
+        return const Color(0xFFFBBF24); // orange
+      case 'complete':
+      case 'done':
+        return const Color(0xFF64748B); // slate
+      case 'pinned':
+        return const Color(0xFF38BDF8); // blue
+      default:
+        return const Color(0xFF64748B); // slate / offline
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = ProgramRegistry.get(programId);
+    final dotSize = size * 0.3;
+
+    return SizedBox(
+      width: size + (showStatusDot ? dotSize * 0.4 : 0),
+      height: size + (showStatusDot ? dotSize * 0.4 : 0),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: meta.color.withValues(alpha: 0.15),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: meta.color.withValues(alpha: 0.3),
+                width: 1.5,
+              ),
+            ),
+            child: Center(
+              child: Text(
+                meta.initial,
+                style: TextStyle(
+                  color: meta.color,
+                  fontSize: size * 0.4,
+                  fontWeight: FontWeight.bold,
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ),
+          ),
+          if (showStatusDot)
+            Positioned(
+              right: 0,
+              bottom: 0,
+              child: Container(
+                width: dotSize,
+                height: dotSize,
+                decoration: BoxDecoration(
+                  color: _statusColor(),
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.surface,
+                    width: 2,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- ProgramRegistry with color/metadata map for all 12 Grid programs
- channelListProvider aggregates messages + sessions per program, sorted by priority
- channelDetailProvider for single-program filtered view
- ProgramAvatar widget with colored circle, initial letter, and optional status dot

## Sprint
Story 1A of CacheBash channel-first redesign (Decision #16)

## Test plan
- [x] flutter analyze passes
- [ ] ProgramRegistry.get returns correct metadata for known programs
- [ ] ProgramRegistry.get returns unknown fallback for unrecognized IDs

Generated with [Claude Code](https://claude.com/claude-code)