### PR TITLE
feat: channel detail view + event tiles + compose (Story 3A)

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -8,6 +8,7 @@ import 'screens/auth/login_screen.dart';
 import 'screens/auth/register_screen.dart';
 import 'screens/auth/api_key_screen.dart';
 import 'screens/channels/channel_list_screen.dart';
+import 'screens/channels/channel_detail_screen.dart';
 import 'screens/activity/activity_screen.dart';
 import 'screens/questions/question_detail_screen.dart';
 import 'screens/settings/settings_screen.dart';
@@ -81,10 +82,7 @@ final routerProvider = Provider<GoRouter>((ref) {
             path: '/channels/:programId',
             builder: (context, state) {
               final programId = state.pathParameters['programId']!;
-              return Scaffold(
-                appBar: AppBar(title: Text(programId.toUpperCase())),
-                body: const Center(child: Text('Channel detail coming in Story 3A')),
-              );
+              return ChannelDetailScreen(programId: programId);
             },
           ),
           

--- a/app/lib/screens/channels/channel_detail_screen.dart
+++ b/app/lib/screens/channels/channel_detail_screen.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../providers/channel_provider.dart';
+import '../../theme/program_colors.dart';
+import '../../widgets/channel_event_tile.dart';
+import '../../widgets/session_pinned_card.dart';
+import '../../widgets/inline_compose.dart';
+import '../../widgets/program_avatar.dart';
+import '../../services/haptic_service.dart';
+
+class ChannelDetailScreen extends ConsumerWidget {
+  final String programId;
+
+  const ChannelDetailScreen({
+    super.key,
+    required this.programId,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final channelAsync = ref.watch(channelDetailProvider(programId));
+    final meta = ProgramRegistry.get(programId);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            HapticService.light();
+            context.pop();
+          },
+        ),
+        title: Row(
+          children: [
+            ProgramAvatar(
+              programId: programId,
+              size: 28,
+              showStatusDot: false,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    meta.displayName,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  channelAsync.when(
+                    data: (channel) => Text(
+                      channel.hasActiveSession
+                          ? channel.activeSession!.state.toUpperCase()
+                          : 'Offline',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                        color: channel.hasActiveSession
+                            ? (channel.isBlocked ? const Color(0xFFFBBF24) : const Color(0xFF4ADE80))
+                            : Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    loading: () => const SizedBox.shrink(),
+                    error: (_, __) => const SizedBox.shrink(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        centerTitle: false,
+      ),
+      body: channelAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(
+          child: Text('Error: $error'),
+        ),
+        data: (channel) => Column(
+          children: [
+            // Pinned session card (if active)
+            if (channel.activeSession != null)
+              SessionPinnedCard(
+                session: channel.activeSession!,
+                programId: programId,
+                onTap: () {
+                  HapticService.light();
+                  context.push('/sessions/${channel.activeSession!.id}');
+                },
+              ),
+
+            // Event feed
+            Expanded(
+              child: channel.messages.isEmpty
+                  ? Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ProgramAvatar(programId: programId, size: 64),
+                          const SizedBox(height: 16),
+                          Text(
+                            'No messages with ${meta.displayName}',
+                            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'Send a message to start a conversation',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.7),
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.only(top: 8, bottom: 8),
+                      reverse: true, // newest at bottom like a chat
+                      itemCount: channel.messages.length,
+                      itemBuilder: (context, index) {
+                        // Reverse index since ListView is reversed
+                        final message = channel.messages[channel.messages.length - 1 - index];
+                        return ChannelEventTile(
+                          message: message,
+                          onQuickReply: (reply) {
+                            // TODO: Wire to answer question service in Story 4A
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Reply: $reply')),
+                            );
+                          },
+                        );
+                      },
+                    ),
+            ),
+
+            // Inline compose bar
+            InlineCompose(
+              targetProgramId: programId,
+              onSend: (payload) {
+                // TODO: Wire to create message/task service in Story 4A
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text('Sent to ${meta.displayName}: ${payload.content}'),
+                    behavior: SnackBarBehavior.floating,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/channel_event_tile.dart
+++ b/app/lib/widgets/channel_event_tile.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+
+import '../models/message_model.dart';
+import '../services/haptic_service.dart';
+
+/// Renders a single event in a channel's chronological feed
+class ChannelEventTile extends StatelessWidget {
+  final MessageModel message;
+  final VoidCallback? onTap;
+  final ValueChanged<String>? onQuickReply;
+
+  const ChannelEventTile({
+    super.key,
+    required this.message,
+    this.onTap,
+    this.onQuickReply,
+  });
+
+  Color _typeColor() {
+    // Alert colors
+    if (message.isAlert) {
+      switch (message.alertType) {
+        case AlertType.error:
+          return const Color(0xFFEF4444);
+        case AlertType.warning:
+          return const Color(0xFFFBBF24);
+        case AlertType.success:
+          return const Color(0xFF4ADE80);
+        default:
+          return const Color(0xFF38BDF8);
+      }
+    }
+
+    // Task/message direction
+    if (message.isToClaude) {
+      if (message.isInterrupt) return const Color(0xFFEF4444);
+      return const Color(0xFF7B68EE); // purple for outgoing tasks
+    }
+
+    // Question needing response
+    if (message.needsResponse) return const Color(0xFFFBBF24);
+
+    // Default incoming
+    return const Color(0xFF4ECDC4);
+  }
+
+  String _typeLabel() {
+    if (message.isAlert) return message.alertType?.displayName ?? 'Alert';
+    if (message.isToClaude) return message.action?.displayName ?? 'Task';
+    if (message.isQuestion) return 'Question';
+    return 'Message';
+  }
+
+  IconData _typeIcon() {
+    if (message.isAlert) {
+      switch (message.alertType) {
+        case AlertType.error:
+          return Icons.error_outline;
+        case AlertType.warning:
+          return Icons.warning_amber_outlined;
+        case AlertType.success:
+          return Icons.check_circle_outline;
+        default:
+          return Icons.info_outline;
+      }
+    }
+    if (message.isToClaude) return Icons.send;
+    if (message.needsResponse) return Icons.help_outline;
+    if (message.isAnswered) return Icons.question_answer_outlined;
+    return Icons.chat_bubble_outline;
+  }
+
+  String _statusLabel() {
+    if (message.isPending && message.isToUser) return 'Waiting';
+    if (message.isAnswered) return 'Answered';
+    if (message.isComplete) return 'Done';
+    if (message.isInProgress) return 'In Progress';
+    if (message.isCancelled) return 'Cancelled';
+    if (message.isExpired) return 'Expired';
+    return '';
+  }
+
+  String _timeStr(DateTime time) {
+    final hour = time.hour.toString().padLeft(2, '0');
+    final min = time.minute.toString().padLeft(2, '0');
+    return '$hour:$min';
+  }
+
+  String _dateStr(DateTime time) {
+    final diff = DateTime.now().difference(time);
+    if (diff.inDays == 0) return 'Today';
+    if (diff.inDays == 1) return 'Yesterday';
+    return '${time.month}/${time.day}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typeColor = _typeColor();
+    final isIncoming = message.isToUser;
+
+    return GestureDetector(
+      onTap: () {
+        if (onTap != null) {
+          HapticService.light();
+          onTap!();
+        }
+      },
+      child: Container(
+        margin: EdgeInsets.fromLTRB(
+          isIncoming ? 12 : 48,
+          4,
+          isIncoming ? 48 : 12,
+          4,
+        ),
+        child: Column(
+          crossAxisAlignment: isIncoming ? CrossAxisAlignment.start : CrossAxisAlignment.end,
+          children: [
+            // Type badge + time
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(_typeIcon(), size: 12, color: typeColor),
+                  const SizedBox(width: 4),
+                  Text(
+                    _typeLabel(),
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                      color: typeColor,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${_dateStr(message.createdAt)} ${_timeStr(message.createdAt)}',
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Message bubble
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: isIncoming
+                    ? Theme.of(context).colorScheme.surfaceContainerHighest
+                    : typeColor.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(
+                  color: typeColor.withOpacity(0.2),
+                  width: 0.5,
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Title (for tasks)
+                  if (message.title != null && message.title!.isNotEmpty) ...[
+                    Text(
+                      message.title!,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                  ],
+
+                  // Content
+                  Text(
+                    message.content,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.9),
+                      height: 1.4,
+                    ),
+                  ),
+
+                  // Status
+                  if (_statusLabel().isNotEmpty) ...[
+                    const SizedBox(height: 6),
+                    Text(
+                      _statusLabel(),
+                      style: TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 10,
+                        color: typeColor.withOpacity(0.8),
+                      ),
+                    ),
+                  ],
+
+                  // Response (for answered questions)
+                  if (message.hasResponse) ...[
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF4ADE80).withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        children: [
+                          const Icon(Icons.check, size: 14, color: Color(0xFF4ADE80)),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              message.response!,
+                              style: const TextStyle(fontSize: 13),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+
+                  // Quick reply options for pending questions
+                  if (message.needsResponse && message.hasOptions) ...[
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: message.options!.map((option) => InkWell(
+                        onTap: () {
+                          HapticService.medium();
+                          onQuickReply?.call(option);
+                        },
+                        borderRadius: BorderRadius.circular(16),
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                            borderRadius: BorderRadius.circular(16),
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
+                            ),
+                          ),
+                          child: Text(
+                            option,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: Theme.of(context).colorScheme.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      )).toList(),
+                    ),
+                  ],
+
+                  // Priority badge for high-priority items
+                  if (message.isHighPriority) ...[
+                    const SizedBox(height: 6),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFEF4444).withOpacity(0.15),
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: const Text(
+                        'HIGH PRIORITY',
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 9,
+                          fontWeight: FontWeight.bold,
+                          color: Color(0xFFEF4444),
+                          letterSpacing: 0.5,
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/inline_compose.dart
+++ b/app/lib/widgets/inline_compose.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+
+import '../models/message_model.dart';
+import '../services/haptic_service.dart';
+
+/// Inline compose bar at the bottom of channel detail
+class InlineCompose extends StatefulWidget {
+  final String targetProgramId;
+  final ValueChanged<ComposePayload> onSend;
+
+  const InlineCompose({
+    super.key,
+    required this.targetProgramId,
+    required this.onSend,
+  });
+
+  @override
+  State<InlineCompose> createState() => _InlineComposeState();
+}
+
+class ComposePayload {
+  final String content;
+  final String? title;
+  final MessageAction action;
+  final String priority;
+
+  const ComposePayload({
+    required this.content,
+    this.title,
+    this.action = MessageAction.queue,
+    this.priority = 'normal',
+  });
+}
+
+class _InlineComposeState extends State<InlineCompose> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+  MessageAction _action = MessageAction.queue;
+  bool _showOptions = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _send() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    HapticService.medium();
+    widget.onSend(ComposePayload(
+      content: text,
+      action: _action,
+    ));
+
+    _controller.clear();
+    _focusNode.unfocus();
+    setState(() {
+      _showOptions = false;
+      _action = MessageAction.queue;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border(
+          top: BorderSide(
+            color: Theme.of(context).colorScheme.outlineVariant,
+            width: 0.5,
+          ),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Action picker (expandable)
+            if (_showOptions)
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                child: Row(
+                  children: [
+                    const Text(
+                      'Action:',
+                      style: TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    ...MessageAction.values.map((action) => Padding(
+                      padding: const EdgeInsets.only(right: 4),
+                      child: ChoiceChip(
+                        label: Text(
+                          action.displayName,
+                          style: const TextStyle(fontSize: 11),
+                        ),
+                        selected: _action == action,
+                        onSelected: (selected) {
+                          if (selected) {
+                            HapticService.light();
+                            setState(() => _action = action);
+                          }
+                        },
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    )),
+                  ],
+                ),
+              ),
+
+            // Text input + send
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
+              child: Row(
+                children: [
+                  // Options toggle
+                  IconButton(
+                    onPressed: () {
+                      HapticService.light();
+                      setState(() => _showOptions = !_showOptions);
+                    },
+                    icon: Icon(
+                      _showOptions ? Icons.expand_more : Icons.add_circle_outline,
+                      color: _showOptions
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    iconSize: 22,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                  ),
+
+                  // Text field
+                  Expanded(
+                    child: Container(
+                      constraints: const BoxConstraints(maxHeight: 100),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: TextField(
+                        controller: _controller,
+                        focusNode: _focusNode,
+                        maxLines: null,
+                        textInputAction: TextInputAction.newline,
+                        style: const TextStyle(fontSize: 14),
+                        decoration: InputDecoration(
+                          hintText: 'Message ${widget.targetProgramId.toUpperCase()}...',
+                          hintStyle: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            fontSize: 14,
+                          ),
+                          border: InputBorder.none,
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                          isDense: true,
+                        ),
+                        onChanged: (_) => setState(() {}),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(width: 4),
+
+                  // Send button
+                  IconButton(
+                    onPressed: _controller.text.trim().isNotEmpty ? _send : null,
+                    icon: Icon(
+                      Icons.send,
+                      color: _controller.text.trim().isNotEmpty
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.5),
+                    ),
+                    iconSize: 22,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/widgets/session_pinned_card.dart
+++ b/app/lib/widgets/session_pinned_card.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+import '../models/session_model.dart';
+import '../theme/program_colors.dart';
+
+/// Persistent session status card pinned at top of channel detail
+class SessionPinnedCard extends StatelessWidget {
+  final SessionModel session;
+  final String programId;
+  final VoidCallback? onTap;
+
+  const SessionPinnedCard({
+    super.key,
+    required this.session,
+    required this.programId,
+    this.onTap,
+  });
+
+  Color _stateColor() {
+    if (session.isBlocked) return const Color(0xFFFBBF24);
+    if (session.isWorking) return const Color(0xFF4ADE80);
+    if (session.isPinned) return const Color(0xFF38BDF8);
+    if (session.isComplete) return const Color(0xFF64748B);
+    return const Color(0xFF64748B);
+  }
+
+  String _stateLabel() {
+    if (session.isStale) return 'INACTIVE';
+    return session.state.toUpperCase();
+  }
+
+  String _timeAgo(DateTime time) {
+    final diff = DateTime.now().difference(time);
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = ProgramRegistry.get(programId);
+    final stateColor = _stateColor();
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: stateColor.withOpacity(0.3),
+            width: 1,
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // State badge + last update
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: stateColor.withOpacity(0.15),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    _stateLabel(),
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                      color: stateColor,
+                      letterSpacing: 1,
+                    ),
+                  ),
+                ),
+                if (session.projectName != null) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      session.projectName!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: meta.color.withOpacity(0.7),
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ),
+                ] else
+                  const Spacer(),
+                Text(
+                  _timeAgo(session.lastUpdate),
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: session.isStale
+                        ? const Color(0xFFFBBF24)
+                        : Theme.of(context).colorScheme.onSurfaceVariant,
+                    fontWeight: session.isStale ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ],
+            ),
+
+            // Progress bar (if applicable)
+            if (session.progress != null && session.progress! > 0) ...[
+              const SizedBox(height: 8),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(2),
+                child: LinearProgressIndicator(
+                  value: session.progress! / 100,
+                  minHeight: 3,
+                  backgroundColor: stateColor.withOpacity(0.1),
+                  valueColor: AlwaysStoppedAnimation(stateColor),
+                ),
+              ),
+            ],
+
+            // Status message
+            if (session.status.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                session.status,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- ChannelDetailScreen: chronological event feed with chat-style layout (newest at bottom)
- SessionPinnedCard: sticky program status card at top of channel with state, progress, timestamps
- ChannelEventTile: renders messages, tasks, questions, alerts with type badges, inline quick-reply options
- InlineCompose: bottom compose bar with expandable action picker (queue/interrupt/parallel/backlog)
- Updated app.dart to wire real ChannelDetailScreen (replaces placeholder)

## Sprint
Story 3A of CacheBash channel-first redesign (Decision #16)

## Test plan
- [ ] flutter analyze passes
- [ ] Tapping channel from list opens detail view
- [ ] Session pinned card shows at top when program has active session
- [ ] Messages render with correct type badges and colors
- [ ] Quick reply options show for pending questions
- [ ] Compose bar expands to show action picker

Generated with [Claude Code](https://claude.com/claude-code)