### PR TITLE
feat: activity screen + threading + reply wiring (Story 4A)

### DIFF
--- a/app/lib/screens/activity/activity_screen.dart
+++ b/app/lib/screens/activity/activity_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../providers/channel_provider.dart';
+import '../../providers/sprints_provider.dart';
 import '../../widgets/program_avatar.dart';
 import '../../services/haptic_service.dart';
 
@@ -12,6 +13,7 @@ class ActivityScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final channelsAsync = ref.watch(channelListProvider);
+    final sprintsAsync = ref.watch(activeSprintsProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -35,81 +37,152 @@ class ActivityScreen extends ConsumerWidget {
           final blocked = channels.where((c) => c.isBlocked).toList();
           final active = channels.where((c) => c.hasActiveSession && !c.isBlocked).toList();
 
-          final hasContent = needsResponse.isNotEmpty || blocked.isNotEmpty || active.isNotEmpty;
-
-          if (!hasContent) {
-            return Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.check_circle_outline,
-                    size: 64,
-                    color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'All clear',
-                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontFamily: 'monospace',
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'No items need your attention',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
-            );
-          }
-
-          return ListView(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            children: [
-              if (needsResponse.isNotEmpty) ...[
-                _SectionHeader(
-                  title: 'Needs Response',
-                  icon: Icons.help_outline,
-                  color: Theme.of(context).colorScheme.error,
-                ),
-                ...needsResponse.map((channel) => _ActivityTile(
-                  channel: channel,
-                  subtitle: '${channel.pendingQuestionCount} question${channel.pendingQuestionCount > 1 ? 's' : ''} waiting',
-                  accentColor: Theme.of(context).colorScheme.error,
-                )),
-              ],
-              if (blocked.isNotEmpty) ...[
-                _SectionHeader(
-                  title: 'Blocked',
-                  icon: Icons.pause_circle_outline,
-                  color: const Color(0xFFFBBF24),
-                ),
-                ...blocked.map((channel) => _ActivityTile(
-                  channel: channel,
-                  subtitle: channel.activeSession?.status ?? 'Blocked',
-                  accentColor: const Color(0xFFFBBF24),
-                )),
-              ],
-              if (active.isNotEmpty) ...[
-                _SectionHeader(
-                  title: 'Working',
-                  icon: Icons.play_circle_outline,
-                  color: const Color(0xFF4ADE80),
-                ),
-                ...active.map((channel) => _ActivityTile(
-                  channel: channel,
-                  subtitle: channel.activeSession?.status ?? 'Active',
-                  accentColor: const Color(0xFF4ADE80),
-                )),
-              ],
-            ],
+          return RefreshIndicator(
+            onRefresh: () async {
+              HapticService.light();
+              ref.invalidate(channelListProvider);
+              ref.invalidate(activeSprintsProvider);
+              await Future.delayed(const Duration(milliseconds: 500));
+            },
+            child: _buildContent(
+              context, 
+              needsResponse, 
+              blocked, 
+              active,
+              sprintsAsync,
+            ),
           );
         },
       ),
     );
+  }
+
+  Widget _buildContent(
+    BuildContext context,
+    List<ChannelData> needsResponse,
+    List<ChannelData> blocked,
+    List<ChannelData> active,
+    AsyncValue sprints,
+  ) {
+    final hasChannelContent = needsResponse.isNotEmpty || blocked.isNotEmpty || active.isNotEmpty;
+    final hasSprintContent = sprints.maybeWhen(
+      data: (list) => list.isNotEmpty,
+      orElse: () => false,
+    );
+
+    if (!hasChannelContent && !hasSprintContent) {
+      return ListView(
+        children: [
+          SizedBox(height: MediaQuery.of(context).size.height * 0.3),
+          Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.check_circle_outline,
+                  size: 64,
+                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'All clear',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    fontFamily: 'monospace',
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'No items need your attention',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        if (needsResponse.isNotEmpty) ...[
+          _SectionHeader(
+            title: 'Needs Response',
+            icon: Icons.help_outline,
+            color: Theme.of(context).colorScheme.error,
+          ),
+          ...needsResponse.map((channel) => _ActivityTile(
+            channel: channel,
+            subtitle: '${channel.pendingQuestionCount} question${channel.pendingQuestionCount > 1 ? 's' : ''} waiting',
+            accentColor: Theme.of(context).colorScheme.error,
+            showProgress: false,
+          )),
+        ],
+        if (blocked.isNotEmpty) ...[
+          _SectionHeader(
+            title: 'Blocked',
+            icon: Icons.pause_circle_outline,
+            color: const Color(0xFFFBBF24),
+          ),
+          ...blocked.map((channel) => _ActivityTile(
+            channel: channel,
+            subtitle: channel.activeSession?.status ?? 'Blocked',
+            accentColor: const Color(0xFFFBBF24),
+            showProgress: false,
+          )),
+        ],
+        if (hasSprintContent) ...[
+          _SectionHeader(
+            title: 'Active Sprints',
+            icon: Icons.rocket_launch_outlined,
+            color: const Color(0xFF7B68EE),
+          ),
+          sprints.when(
+            data: (sprintList) => Column(
+              children: sprintList.map((sprint) => _SprintTile(sprint: sprint)).toList(),
+            ),
+            loading: () => const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (_, __) => const SizedBox.shrink(),
+          ),
+        ],
+        if (active.isNotEmpty) ...[
+          _SectionHeader(
+            title: 'Working',
+            icon: Icons.play_circle_outline,
+            color: const Color(0xFF4ADE80),
+          ),
+          ...active.map((channel) => _ActivityTile(
+            channel: channel,
+            subtitle: channel.activeSession?.status ?? 'Active',
+            accentColor: const Color(0xFF4ADE80),
+            showProgress: true,
+            progress: _estimateProgress(channel),
+          )),
+        ],
+      ],
+    );
+  }
+
+  double _estimateProgress(ChannelData channel) {
+    // Simple heuristic: if session has recent activity, show partial progress
+    final session = channel.activeSession;
+    if (session == null) return 0.0;
+    
+    // If status contains indicators like "step", "phase", etc., could parse here
+    // For now, show 0.3 for active, 0.7 for in-progress mentions
+    if (session.status.toLowerCase().contains('finish') || 
+        session.status.toLowerCase().contains('complete')) {
+      return 0.9;
+    } else if (session.status.toLowerCase().contains('progress') ||
+               session.status.toLowerCase().contains('working')) {
+      return 0.6;
+    }
+    return 0.3; // Just started
   }
 }
 
@@ -152,11 +225,15 @@ class _ActivityTile extends StatelessWidget {
   final ChannelData channel;
   final String subtitle;
   final Color accentColor;
+  final bool showProgress;
+  final double progress;
 
   const _ActivityTile({
     required this.channel,
     required this.subtitle,
     required this.accentColor,
+    this.showProgress = false,
+    this.progress = 0.0,
   });
 
   @override
@@ -168,44 +245,148 @@ class _ActivityTile extends StatelessWidget {
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        child: Row(
+        child: Column(
           children: [
-            ProgramAvatar(
-              programId: channel.programId,
-              size: 40,
-              showStatusDot: true,
-              statusState: channel.displayState,
+            Row(
+              children: [
+                ProgramAvatar(
+                  programId: channel.programId,
+                  size: 40,
+                  showStatusDot: true,
+                  statusState: channel.displayState,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        channel.meta.displayName,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  size: 20,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ],
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    channel.meta.displayName,
-                    style: const TextStyle(
-                      fontFamily: 'monospace',
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    subtitle,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
+            if (showProgress) ...[
+              const SizedBox(height: 8),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: progress,
+                  backgroundColor: accentColor.withValues(alpha: 0.2),
+                  valueColor: AlwaysStoppedAnimation<Color>(accentColor),
+                  minHeight: 4,
+                ),
               ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SprintTile extends StatelessWidget {
+  final dynamic sprint; // SprintModel - using dynamic to avoid import issues
+
+  const _SprintTile({required this.sprint});
+
+  @override
+  Widget build(BuildContext context) {
+    final sprintData = sprint;
+    final title = sprintData.title ?? 'Sprint';
+    final currentWave = sprintData.currentWave ?? 1;
+    final totalWaves = sprintData.totalWaves ?? 1;
+    final progress = totalWaves > 0 ? currentWave / totalWaves : 0.0;
+
+    return InkWell(
+      onTap: () {
+        HapticService.light();
+        context.push('/sprints/${sprintData.id}');
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF7B68EE).withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Icon(
+                    Icons.rocket_launch,
+                    size: 20,
+                    color: Color(0xFF7B68EE),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Wave $currentWave of $totalWaves',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.chevron_right,
+                  size: 20,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ],
             ),
-            Icon(
-              Icons.chevron_right,
-              size: 20,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            const SizedBox(height: 8),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: progress,
+                backgroundColor: const Color(0xFF7B68EE).withValues(alpha: 0.2),
+                valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF7B68EE)),
+                minHeight: 4,
+              ),
             ),
           ],
         ),

--- a/app/lib/screens/channels/channel_detail_screen.dart
+++ b/app/lib/screens/channels/channel_detail_screen.dart
@@ -2,7 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../models/message_model.dart';
+import '../../models/task_model.dart';
 import '../../providers/channel_provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/questions_provider.dart';
+import '../../providers/tasks_provider.dart';
 import '../../theme/program_colors.dart';
 import '../../widgets/channel_event_tile.dart';
 import '../../widgets/session_pinned_card.dart';
@@ -10,7 +15,22 @@ import '../../widgets/inline_compose.dart';
 import '../../widgets/program_avatar.dart';
 import '../../services/haptic_service.dart';
 
-class ChannelDetailScreen extends ConsumerWidget {
+class _DisplayItem {
+  final MessageModel message; // The primary/first message
+  final List<MessageModel> threadReplies; // Additional messages in same thread
+  bool isExpanded;
+
+  _DisplayItem({
+    required this.message, 
+    this.threadReplies = const [], 
+    this.isExpanded = false,
+  });
+
+  bool get isThread => threadReplies.isNotEmpty;
+  int get replyCount => threadReplies.length;
+}
+
+class ChannelDetailScreen extends ConsumerStatefulWidget {
   final String programId;
 
   const ChannelDetailScreen({
@@ -19,9 +39,149 @@ class ChannelDetailScreen extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final channelAsync = ref.watch(channelDetailProvider(programId));
-    final meta = ProgramRegistry.get(programId);
+  ConsumerState<ChannelDetailScreen> createState() => _ChannelDetailScreenState();
+}
+
+class _ChannelDetailScreenState extends ConsumerState<ChannelDetailScreen> {
+  final Map<String, bool> _expandedThreads = {};
+
+  List<_DisplayItem> _buildDisplayItems(List<MessageModel> messages) {
+    final threadMap = <String, List<MessageModel>>{};
+    final standalone = <MessageModel>[];
+
+    for (final msg in messages) {
+      if (msg.threadId != null) {
+        threadMap.putIfAbsent(msg.threadId!, () => []).add(msg);
+      } else {
+        standalone.add(msg);
+      }
+    }
+
+    final items = <_DisplayItem>[];
+
+    // Add threads (sorted by earliest message)
+    for (final entry in threadMap.entries) {
+      final sorted = entry.value..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      items.add(_DisplayItem(
+        message: sorted.first,
+        threadReplies: sorted.skip(1).toList(),
+        isExpanded: _expandedThreads[entry.key] ?? false,
+      ));
+    }
+
+    // Add standalone messages
+    for (final msg in standalone) {
+      items.add(_DisplayItem(message: msg));
+    }
+
+    // Sort all by primary message time
+    items.sort((a, b) => a.message.createdAt.compareTo(b.message.createdAt));
+    return items;
+  }
+
+  void _toggleThread(String threadId) {
+    setState(() {
+      _expandedThreads[threadId] = !(_expandedThreads[threadId] ?? false);
+    });
+    HapticService.light();
+  }
+
+  TaskAction _convertToTaskAction(MessageAction action) {
+    switch (action) {
+      case MessageAction.interrupt:
+        return TaskAction.interrupt;
+      case MessageAction.parallel:
+        return TaskAction.parallel;
+      case MessageAction.queue:
+        return TaskAction.queue;
+      case MessageAction.backlog:
+        return TaskAction.backlog;
+    }
+  }
+
+  Future<void> _handleQuickReply(MessageModel message, String reply) async {
+    final user = ref.read(currentUserProvider);
+    if (user == null) return;
+
+    HapticService.medium();
+
+    try {
+      await ref.read(questionsServiceProvider).answerQuestion(
+        userId: user.uid,
+        questionId: message.id,
+        response: reply,
+      );
+
+      if (mounted) {
+        HapticService.success();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Response sent!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        HapticService.error();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error: $e'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _handleCompose(ComposePayload payload) async {
+    final user = ref.read(currentUserProvider);
+    if (user == null) return;
+
+    HapticService.medium();
+
+    try {
+      // Auto-generate title from first line (max 50 chars)
+      final firstLine = payload.content.split('\n').first;
+      final title = firstLine.length > 50
+          ? '${firstLine.substring(0, 47)}...'
+          : firstLine;
+
+      await ref.read(tasksServiceProvider).createTask(
+        userId: user.uid,
+        title: title,
+        instructions: payload.content,
+        action: _convertToTaskAction(payload.action),
+        target: widget.programId,
+        source: 'flynn',
+      );
+
+      if (mounted) {
+        HapticService.success();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Message sent!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        HapticService.error();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error: $e'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final channelAsync = ref.watch(channelDetailProvider(widget.programId));
+    final meta = ProgramRegistry.get(widget.programId);
 
     return Scaffold(
       appBar: AppBar(
@@ -35,7 +195,7 @@ class ChannelDetailScreen extends ConsumerWidget {
         title: Row(
           children: [
             ProgramAvatar(
-              programId: programId,
+              programId: widget.programId,
               size: 28,
               showStatusDot: false,
             ),
@@ -80,80 +240,164 @@ class ChannelDetailScreen extends ConsumerWidget {
         error: (error, stack) => Center(
           child: Text('Error: $error'),
         ),
-        data: (channel) => Column(
-          children: [
-            // Pinned session card (if active)
-            if (channel.activeSession != null)
-              SessionPinnedCard(
-                session: channel.activeSession!,
-                programId: programId,
-                onTap: () {
-                  HapticService.light();
-                  context.push('/sessions/${channel.activeSession!.id}');
-                },
+        data: (channel) {
+          final displayItems = _buildDisplayItems(channel.messages);
+
+          return Column(
+            children: [
+              // Pinned session card (if active)
+              if (channel.activeSession != null)
+                SessionPinnedCard(
+                  session: channel.activeSession!,
+                  programId: widget.programId,
+                  onTap: () {
+                    HapticService.light();
+                    context.push('/sessions/${channel.activeSession!.id}');
+                  },
+                ),
+
+              // Event feed
+              Expanded(
+                child: displayItems.isEmpty
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ProgramAvatar(programId: widget.programId, size: 64),
+                            const SizedBox(height: 16),
+                            Text(
+                              'No messages with ${meta.displayName}',
+                              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Send a message to start a conversation',
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.only(top: 8, bottom: 8),
+                        reverse: true, // newest at bottom like a chat
+                        itemCount: displayItems.length,
+                        itemBuilder: (context, index) {
+                          // Reverse index since ListView is reversed
+                          final item = displayItems[displayItems.length - 1 - index];
+                          
+                          if (!item.isThread) {
+                            // Standalone message
+                            return ChannelEventTile(
+                              message: item.message,
+                              onQuickReply: (reply) => _handleQuickReply(item.message, reply),
+                            );
+                          }
+
+                          // Thread group
+                          return _ThreadGroup(
+                            item: item,
+                            onToggle: () => _toggleThread(item.message.threadId!),
+                            onQuickReply: (message, reply) => _handleQuickReply(message, reply),
+                          );
+                        },
+                      ),
               ),
 
-            // Event feed
-            Expanded(
-              child: channel.messages.isEmpty
-                  ? Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          ProgramAvatar(programId: programId, size: 64),
-                          const SizedBox(height: 16),
-                          Text(
-                            'No messages with ${meta.displayName}',
-                            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                              color: Theme.of(context).colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            'Send a message to start a conversation',
-                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.7),
-                            ),
-                          ),
-                        ],
-                      ),
-                    )
-                  : ListView.builder(
-                      padding: const EdgeInsets.only(top: 8, bottom: 8),
-                      reverse: true, // newest at bottom like a chat
-                      itemCount: channel.messages.length,
-                      itemBuilder: (context, index) {
-                        // Reverse index since ListView is reversed
-                        final message = channel.messages[channel.messages.length - 1 - index];
-                        return ChannelEventTile(
-                          message: message,
-                          onQuickReply: (reply) {
-                            // TODO: Wire to answer question service in Story 4A
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Reply: $reply')),
-                            );
-                          },
-                        );
-                      },
-                    ),
-            ),
-
-            // Inline compose bar
-            InlineCompose(
-              targetProgramId: programId,
-              onSend: (payload) {
-                // TODO: Wire to create message/task service in Story 4A
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('Sent to ${meta.displayName}: ${payload.content}'),
-                    behavior: SnackBarBehavior.floating,
-                  ),
-                );
-              },
-            ),
-          ],
-        ),
+              // Inline compose bar
+              InlineCompose(
+                targetProgramId: widget.programId,
+                onSend: _handleCompose,
+              ),
+            ],
+          );
+        },
       ),
+    );
+  }
+}
+
+class _ThreadGroup extends StatelessWidget {
+  final _DisplayItem item;
+  final VoidCallback onToggle;
+  final void Function(MessageModel, String) onQuickReply;
+
+  const _ThreadGroup({
+    required this.item,
+    required this.onToggle,
+    required this.onQuickReply,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // First message (always visible)
+        ChannelEventTile(
+          message: item.message,
+          onQuickReply: (reply) => onQuickReply(item.message, reply),
+        ),
+
+        // Reply toggle
+        if (item.replyCount > 0)
+          InkWell(
+            onTap: onToggle,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(56, 0, 16, 8),
+              child: Row(
+                children: [
+                  Icon(
+                    item.isExpanded 
+                        ? Icons.keyboard_arrow_up 
+                        : Icons.keyboard_arrow_down,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    item.isExpanded 
+                        ? 'Hide ${item.replyCount} ${item.replyCount == 1 ? 'reply' : 'replies'}'
+                        : '${item.replyCount} ${item.replyCount == 1 ? 'reply' : 'replies'}',
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+        // Thread replies (when expanded)
+        if (item.isExpanded)
+          Padding(
+            padding: const EdgeInsets.only(left: 24),
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border(
+                  left: BorderSide(
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                    width: 2,
+                  ),
+                ),
+              ),
+              child: Column(
+                children: item.threadReplies.map((reply) {
+                  return ChannelEventTile(
+                    message: reply,
+                    onQuickReply: (replyText) => onQuickReply(reply, replyText),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- Enhanced ActivityScreen with detailed program tiles, progress bars, pull-to-refresh
- Added active sprints section showing wave/cycle progress
- Thread grouping in ChannelDetailScreen — events with same threadId collapse into expandable threads
- Question quick-reply and inline compose fully wired to Firestore (answerQuestion + createTask services)

## Sprint
Story 4A of CacheBash channel-first redesign (Decision #16)

## Changes
**ActivityScreen:**
- Pull-to-refresh support for channels and sprints
- Progress bars for working programs (estimated from status)
- Sprint tiles showing wave progress with visual indicators
- More detailed status messages for blocked/working programs

**ChannelDetailScreen:**
- Thread grouping logic — messages with matching threadId are grouped
- Expandable/collapsible thread UI with reply count indicator
- Visual threading with left border for nested replies
- Fully wired quick-reply to `questionsServiceProvider.answerQuestion()`
- Fully wired inline compose to `tasksServiceProvider.createTask()`

## Test plan
- [ ] flutter analyze passes (20 info warnings, 0 errors)
- [ ] Activity screen shows programs grouped by state (needs response, blocked, sprints, working)
- [ ] Pull-to-refresh works on activity screen
- [ ] Progress bars show for working programs
- [ ] Sprint section appears when active sprints exist
- [ ] Thread groups show collapse/expand with accurate reply count
- [ ] Quick reply triggers Firestore write and shows success/error feedback
- [ ] Inline compose creates task and shows confirmation

Generated with [Claude Code](https://claude.com/claude-code)