### PR TITLE
feat: register CODEX as Grid program

### DIFF
--- a/mcp-server/src/config/programs.ts
+++ b/mcp-server/src/config/programs.ts
@@ -8,7 +8,7 @@ export const GRID_PROGRAMS = [
   'casp', 'clu', 'able', 'beck', 'gem', 'rinzler',
   'tron', 'yori', 'pixel', 'castor', 'ram', 'scribe',
   'sage', 'link', 'dumont', 'gridbot', 'bit', 'byte',
-  'tesler', 'flynns-mirror', 'council'
+  'tesler', 'flynns-mirror', 'council', 'codex'
 ] as const;
 
 export type GridProgramId = typeof GRID_PROGRAMS[number];
@@ -66,4 +66,5 @@ export const PROGRAM_REGISTRY: Partial<Record<GridProgramId, ProgramMeta>> = {
   able:   { displayName: "ABLE",   color: "#4DB870", role: "Growth" },
   beck:   { displayName: "BECK",   color: "#40A8A0", role: "Operations" },
   radia:  { displayName: "RADIA",  color: "#E8E0D0", role: "Vision" },
+  codex:  { displayName: "CODEX",  color: "#10A37F", role: "Cross-Model Builder" },
 };


### PR DESCRIPTION
## Summary
- Add `codex` to `GRID_PROGRAMS` allowlist in `mcp-server/src/config/programs.ts`
- Add CODEX to `PROGRAM_REGISTRY` with OpenAI green (#10A37F) accent color
- Enables API key creation and CacheBash relay comms for the first non-Claude Grid program

## Context
Part of the Codex-as-Grid-Program initiative. Grid-side infrastructure (program spec, AGENTS.md, cb CLI, launch alias) is in a parallel PR in rezzedai/grid.

## Test plan
- [ ] Deploy to Cloud Run
- [ ] `create_key(programId: "codex")` succeeds
- [ ] `send_message(source: "codex", target: "iso")` routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)