### PR TITLE
feat: rez VECTOR — add to Grid program registry

### DIFF
--- a/mcp-server/src/config/programs.ts
+++ b/mcp-server/src/config/programs.ts
@@ -8,7 +8,7 @@ export const GRID_PROGRAMS = [
   'casp', 'clu', 'able', 'beck', 'gem', 'rinzler',
   'tron', 'yori', 'pixel', 'castor', 'ram', 'scribe',
   'sage', 'link', 'dumont', 'gridbot', 'bit', 'byte',
-  'tesler', 'flynns-mirror', 'council', 'codex'
+  'tesler', 'flynns-mirror', 'council', 'codex', 'vector'
 ] as const;
 
 export type GridProgramId = typeof GRID_PROGRAMS[number];
@@ -31,7 +31,7 @@ export function isValidProgram(id: string): id is ValidProgramId {
 
 /** Named groups for multicast routing */
 export const PROGRAM_GROUPS: Record<string, readonly GridProgramId[]> = {
-  council: ['iso', 'alan', 'quorra', 'sark', 'casp', 'radia'],
+  council: ['iso', 'alan', 'quorra', 'sark', 'casp', 'radia', 'vector'],
   builders: ['basher', 'able', 'beck'],
   intelligence: ['clu', 'beck', 'scribe'],
   all: [...GRID_PROGRAMS].filter(p => p !== 'council'), // All individual programs except the 'council' meta-entry
@@ -67,4 +67,5 @@ export const PROGRAM_REGISTRY: Partial<Record<GridProgramId, ProgramMeta>> = {
   beck:   { displayName: "BECK",   color: "#40A8A0", role: "Operations" },
   radia:  { displayName: "RADIA",  color: "#E8E0D0", role: "Vision" },
   codex:  { displayName: "CODEX",  color: "#10A37F", role: "Cross-Model Builder" },
+  vector: { displayName: "VECTOR", color: "#C4A052", role: "Strategic Counsel" },
 };


### PR DESCRIPTION
## Summary
- Add `vector` to `GRID_PROGRAMS` array (program #30)
- Add VECTOR to `council` multicast group (standing council seat)
- Add VECTOR to `PROGRAM_REGISTRY` with display metadata (color: #C4A052, role: Strategic Counsel)

VECTOR is Flynn's strategic thinking partner via Claude Desktop — first program in the Interface Layer.

## Deploy
Requires Cloud Run redeploy for changes to take effect. After merge:
```
cd mcp-server && gcloud run deploy cachebash-mcp --source . --project cachebash-app --region us-central1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)