### PR TITLE
fix(gap-003): implement TTL reaper with internal cleanup endpoint

### DIFF
--- a/mcp-server/src/modules/events.ts
+++ b/mcp-server/src/modules/events.ts
@@ -17,7 +17,8 @@ export type EventType =
   | "GUARDIAN_CHECK"
   | "SUBAGENT_SPAWNED"
   | "PR_OPENED"
-  | "PR_MERGED";
+  | "PR_MERGED"
+  | "CLEANUP_RUN";
 
 export type TaskClass = "WORK" | "CONTROL";
 


### PR DESCRIPTION
## Summary
- Wires existing `cleanupExpiredRelayMessages()` and `cleanupExpiredSessions()` to `POST /v1/internal/cleanup`
- Cleanup functions now return metrics: `{ expired, cleaned }`
- Emits `CLEANUP_RUN` telemetry event with relay/session counts and duration
- Queries active users from apiKeys collection (lastUsedAt within 7 days)
- Added TODO comment for Cloud Scheduler service account auth restriction in production

## Sprint
Gap Remediation Sprint 1, Story: gap-003

## Test plan
- [ ] Endpoint responds to POST /v1/internal/cleanup
- [ ] Cleanup functions return correct metrics
- [ ] CLEANUP_RUN event emitted to events collection
- [ ] No regressions in existing relay or session behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)