### PR TITLE
fix(gap-006): relay idempotency for send_message

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -160,6 +160,7 @@ export const TOOL_DEFINITIONS = [
         threadId: { type: "string" },
         ttl: { type: "number", description: "TTL in seconds (default 86400)" },
         payload: { type: "object", description: "Optional structured payload object. Validated against message_type schema (advisory)." },
+        idempotency_key: { type: "string", maxLength: 100, description: "Optional idempotency key (UUID v4 recommended). Prevents duplicate messages on retry. Same key returns cached result." },
       },
       required: ["message", "source", "target", "message_type"],
     },


### PR DESCRIPTION
## Summary
- Adds optional idempotency_key to send_message (max 100 chars, UUID v4 recommended)
- Before write: checks Firestore idempotency_keys subcollection for existing key
- If found and not expired: returns cached messageId/multicastId (full short-circuit)
- If not found: normal write, then records key with 1-hour TTL
- Multicast: single key covers all fan-out recipients via multicastId
- Backward compatible: no change for calls without idempotency_key

## Test plan
- [ ] Build passes (tsc --noEmit)
- [ ] send_message without idempotency_key works unchanged
- [ ] send_message with idempotency_key writes key to Firestore
- [ ] Retry with same idempotency_key returns cached result
- [ ] Multicast with idempotency_key deduplicates correctly
- [ ] Expired keys (>1 hour) don't short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sprint: Gap Remediation Sprint 1 | Story: GAP-006