### PR TITLE
fix(gap-002): MCP session keepalive + telemetry

### DIFF
--- a/mcp-server/src/modules/events.ts
+++ b/mcp-server/src/modules/events.ts
@@ -18,7 +18,9 @@ export type EventType =
   | "SUBAGENT_SPAWNED"
   | "PR_OPENED"
   | "PR_MERGED"
-  | "CLEANUP_RUN";
+  | "CLEANUP_RUN"
+  | "SESSION_DEATH"
+  | "SESSION_ENDED";
 
 export type TaskClass = "WORK" | "CONTROL";
 

--- a/mcp-server/src/transport/rest.ts
+++ b/mcp-server/src/transport/rest.ts
@@ -284,6 +284,12 @@ const routes: Route[] = [
     const data = await callTool(auth, "get_comms_metrics", query);
     restResponse(res, true, data);
   }),
+
+  route("GET", "/v1/metrics/operational", async (auth, req, res) => {
+    const query = coerceQueryParams(parseQuery(req.url || ""));
+    const data = await callTool(auth, "get_operational_metrics", query);
+    restResponse(res, true, data);
+  }),
   // Fleet
   route("GET", "/v1/fleet/health", async (auth, req, res) => {
     const data = await callTool(auth, "get_fleet_health", {});


### PR DESCRIPTION
## Summary
- Adds POST /v1/mcp/heartbeat endpoint (out-of-band session keepalive with Bearer auth + Mcp-Session-Id)
- Recognizes notifications/heartbeat JSON-RPC messages in CustomHTTPTransport (in-band keepalive)
- Emits SESSION_DEATH event when expired session is accessed
- Emits SESSION_ENDED event on explicit session delete (DELETE method)
- Adds missing GET /v1/metrics/operational REST route for parity
- Heartbeat returns session_expires_in_ms for client monitoring

## Test plan
- [ ] Build passes (tsc --noEmit)
- [ ] POST /v1/mcp/heartbeat with valid session returns 200 + session_expires_in_ms
- [ ] POST /v1/mcp/heartbeat with expired session returns 410 + SESSION_DEATH event emitted
- [ ] notifications/heartbeat through MCP transport returns 204 (no processing)
- [ ] Session DELETE emits SESSION_ENDED event
- [ ] GET /v1/metrics/operational returns operational metrics

Sprint: Gap Remediation Sprint 1 | Story: GAP-002a