### PR TITLE
feat(gap-001b): wake monitoring + scheduler setup

### DIFF
--- a/mcp-server/scripts/setup-schedulers.sh
+++ b/mcp-server/scripts/setup-schedulers.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Cloud Scheduler setup for CacheBash internal jobs
+# Run once per environment. Requires gcloud CLI authenticated to cachebash-app project.
+
+set -euo pipefail
+
+PROJECT="cachebash-app"
+REGION="us-central1"
+SERVICE_URL="https://cachebash-mcp-922749444863.us-central1.run.app"
+
+# Create service account for scheduler (if not exists)
+SA_NAME="cachebash-scheduler"
+SA_EMAIL="${SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+
+echo "=== Setting up Cloud Scheduler service account ==="
+gcloud iam service-accounts create "$SA_NAME" \
+  --display-name="CacheBash Scheduler" \
+  --project="$PROJECT" 2>/dev/null || echo "Service account already exists"
+
+# Grant invoker role on Cloud Run
+gcloud run services add-iam-policy-binding cachebash-mcp \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/run.invoker" \
+  --region="$REGION" \
+  --project="$PROJECT"
+
+echo ""
+echo "=== Creating wake daemon scheduler (every 60s) ==="
+gcloud scheduler jobs create http cachebash-wake-daemon \
+  --schedule="* * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/wake" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="Wake daemon: polls for orphaned tasks and spawns idle programs" \
+  --attempt-deadline="30s" 2>/dev/null || \
+gcloud scheduler jobs update http cachebash-wake-daemon \
+  --schedule="* * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/wake" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="Wake daemon: polls for orphaned tasks and spawns idle programs" \
+  --attempt-deadline="30s"
+
+echo ""
+echo "=== Creating TTL reaper scheduler (every 5min) ==="
+gcloud scheduler jobs create http cachebash-ttl-reaper \
+  --schedule="*/5 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/cleanup" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="TTL Reaper: cleans expired sessions, relay messages, idempotency keys" \
+  --attempt-deadline="60s" 2>/dev/null || \
+gcloud scheduler jobs update http cachebash-ttl-reaper \
+  --schedule="*/5 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/cleanup" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="TTL Reaper: cleans expired sessions, relay messages, idempotency keys" \
+  --attempt-deadline="60s"
+
+echo ""
+echo "=== Done. Verify with: ==="
+echo "gcloud scheduler jobs list --location=$REGION --project=$PROJECT"


### PR DESCRIPTION
## Summary
- Per-program spawn failure tracking in wake daemon (GRIDBOT monitoring hook)
- Alert to Flynn's device after 3+ consecutive spawn failures for same program
- Cloud Scheduler setup script for wake daemon (every 60s) and TTL reaper (every 5min)

## GAP-001b Requirements
- [x] GRIDBOT alert fires within 60s of 3 consecutive failed wake attempts
- [x] Cloud Scheduler job config for wake daemon
- [x] Cloud Scheduler job config for TTL reaper

## Test plan
- [ ] Verify tsc build passes
- [ ] Run setup-schedulers.sh against cachebash-app GCP project
- [ ] Verify wake daemon sends alert after 3 spawn failures
- [ ] Verify failure counters reset on successful spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)