### PR TITLE
fix(gap-007): State Decay — pattern aging + context TTL

### DIFF
--- a/mcp-server/src/modules/events.ts
+++ b/mcp-server/src/modules/events.ts
@@ -24,7 +24,6 @@ export type EventType =
   | "SESSION_ENDED"
   | "PROGRAM_WAKE"
   | "STATE_DECAY";
-
 export type TaskClass = "WORK" | "CONTROL";
 
 export type CompletedStatus = "SUCCESS" | "FAILED" | "SKIPPED" | "CANCELLED";


### PR DESCRIPTION
## Summary
- Implements applyDecay() with 3 rules: context TTL, pattern max age, max unpromoted cap
- Called inside getProgramStateHandler before returning state
- Decayed state written back to Firestore via merge update
- STATE_DECAY event emitted with counts

Sprint: 2M2rMfSJ1CvAXx9ye2YZ | Story: GAP-007

## Test Plan
- [x] npm test passes
- [x] TypeScript compiles
- [x] Decay is idempotent
- [x] Promoted patterns never marked stale