### PR TITLE
fix(gap-012): GRIDBOT health monitoring and alerting

### DIFF
--- a/mcp-server/src/__tests__/gridbot-monitor.test.ts
+++ b/mcp-server/src/__tests__/gridbot-monitor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for GRIDBOT Health Monitoring Module
+ */
+
+import { runHealthCheck, HealthCheckResult } from "../modules/gridbot-monitor";
+import * as admin from "firebase-admin";
+
+// Mock Firebase
+jest.mock("../firebase/client", () => ({
+  getFirestore: jest.fn(() => mockDb),
+}));
+
+jest.mock("../modules/events", () => ({
+  emitEvent: jest.fn(),
+}));
+
+const mockDb: any = {
+  collection: jest.fn(),
+};
+
+const mockCollection = {
+  where: jest.fn().mockReturnThis(),
+  get: jest.fn(),
+  add: jest.fn(),
+};
+
+describe("GRIDBOT Health Monitor", () => {
+  const testUserId = "test-user-123";
+  const now = admin.firestore.Timestamp.now();
+  const oneHourAgo = admin.firestore.Timestamp.fromDate(
+    new Date(now.toDate().getTime() - 60 * 60 * 1000)
+  );
+  const thirtyMinAgo = admin.firestore.Timestamp.fromDate(
+    new Date(now.toDate().getTime() - 30 * 60 * 1000)
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.collection.mockReturnValue(mockCollection);
+  });
+
+  it("should return ok status when all indicators are healthy", async () => {
+    // Mock empty/healthy responses
+    mockCollection.get.mockResolvedValue({ size: 0, docs: [], empty: true });
+
+    const result = await runHealthCheck(testUserId);
+
+    expect(result.overall_status).toBe("ok");
+    expect(result.indicators).toHaveLength(6);
+    expect(result.alerts_sent).toHaveLength(0);
+    expect(result.indicators.every((i) => i.status === "ok")).toBe(true);
+  });
+
+  it("should detect task failure rate correctly", async () => {
+    const mockTasks = [
+      { data: () => ({ completed_status: "FAILED" }) },
+      { data: () => ({ completed_status: "SUCCESS" }) },
+      { data: () => ({ completed_status: "FAILED" }) },
+      { data: () => ({ completed_status: "SUCCESS" }) },
+      { data: () => ({ completed_status: "FAILED" }) }, // 3/5 = 60% failure
+    ];
+
+    let callCount = 0;
+    mockCollection.get.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Task completions query
+        return Promise.resolve({ size: 5, docs: mockTasks });
+      }
+      return Promise.resolve({ size: 0, docs: [], empty: true });
+    });
+
+    const result = await runHealthCheck(testUserId);
+
+    const failureIndicator = result.indicators.find((i) => i.name === "task_failure_rate");
+    expect(failureIndicator?.value).toBe(0.6);
+    expect(failureIndicator?.status).toBe("critical");
+    expect(result.overall_status).toBe("critical");
+  });
+
+  it("should detect session deaths correctly", async () => {
+    const mockDeathEvents = Array(8).fill({ data: () => ({ event_type: "SESSION_DEATH" }) });
+
+    let callCount = 0;
+    mockCollection.get.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({ size: 0, docs: [] }); // tasks
+      } else if (callCount === 2) {
+        return Promise.resolve({ size: 8, docs: mockDeathEvents }); // session deaths
+      }
+      return Promise.resolve({ size: 0, docs: [] });
+    });
+
+    const result = await runHealthCheck(testUserId);
+
+    const deathIndicator = result.indicators.find((i) => i.name === "session_death_count");
+    expect(deathIndicator?.value).toBe(8);
+    expect(deathIndicator?.status).toBe("warning");
+  });
+
+  it("should detect stale tasks correctly", async () => {
+    const mockStaleTasks = Array(12).fill({ data: () => ({ status: "created" }) });
+
+    let callCount = 0;
+    mockCollection.get.mockImplementation(() => {
+      callCount++;
+      if (callCount === 3) {
+        // Stale tasks query
+        return Promise.resolve({ size: 12, docs: mockStaleTasks });
+      }
+      return Promise.resolve({ size: 0, docs: [] });
+    });
+
+    const result = await runHealthCheck(testUserId);
+
+    const staleIndicator = result.indicators.find((i) => i.name === "stale_task_count");
+    expect(staleIndicator?.value).toBe(12);
+    expect(staleIndicator?.status).toBe("warning");
+  });
+
+  it("should route critical alerts to Flynn mobile", async () => {
+    // Create critical relay queue depth
+    const mockPendingRelay = Array(60).fill({ data: () => ({ status: "pending" }) });
+
+    let callCount = 0;
+    mockCollection.get.mockImplementation(() => {
+      callCount++;
+      if (callCount === 4) {
+        // Relay queue depth query
+        return Promise.resolve({ size: 60, docs: mockPendingRelay });
+      }
+      return Promise.resolve({ size: 0, docs: [] });
+    });
+
+    mockCollection.add.mockResolvedValue({ id: "mock-alert-id" });
+
+    const result = await runHealthCheck(testUserId);
+
+    expect(result.overall_status).toBe("critical");
+    expect(result.alerts_sent).toContain("HEALTH_CRITICAL alert to Flynn (mobile)");
+    
+    // Verify alert was written to relay and tasks
+    expect(mockCollection.add).toHaveBeenCalledTimes(3); // relay + tasks + health_checks
+  });
+
+  it("should route warning alerts to ISO", async () => {
+    // Create warning-level wake failures
+    const mockWakeEvents = [
+      { data: () => ({ event_type: "PROGRAM_WAKE", wake_result: "failed" }) },
+      { data: () => ({ event_type: "PROGRAM_WAKE", wake_result: "failed" }) },
+      { data: () => ({ event_type: "PROGRAM_WAKE", wake_result: "failed" }) },
+    ];
+
+    let callCount = 0;
+    mockCollection.get.mockImplementation(() => {
+      callCount++;
+      if (callCount === 5) {
+        // Wake events query
+        return Promise.resolve({ size: 3, docs: mockWakeEvents });
+      }
+      return Promise.resolve({ size: 0, docs: [] });
+    });
+
+    mockCollection.add.mockResolvedValue({ id: "mock-warning-id" });
+
+    const result = await runHealthCheck(testUserId);
+
+    expect(result.overall_status).toBe("warning");
+    expect(result.alerts_sent).toContain("HEALTH_WARNING status to ISO");
+
+    // Verify warning was written to relay
+    expect(mockCollection.add).toHaveBeenCalled();
+  });
+
+  it("should write health check results to Firestore", async () => {
+    mockCollection.get.mockResolvedValue({ size: 0, docs: [], empty: true });
+    mockCollection.add.mockResolvedValue({ id: "mock-health-check-id" });
+
+    const result = await runHealthCheck(testUserId);
+
+    expect(mockCollection.add).toHaveBeenCalled();
+    const addCall = mockCollection.add.mock.calls.find((call: any) => 
+      call[0].timestamp && call[0].overall_status
+    );
+    expect(addCall).toBeDefined();
+  });
+
+  it("should calculate all threshold levels correctly", async () => {
+    mockCollection.get.mockResolvedValue({ size: 0, docs: [] });
+
+    const result = await runHealthCheck(testUserId);
+
+    // Verify all 6 indicators exist with proper structure
+    expect(result.indicators).toHaveLength(6);
+    const indicatorNames = result.indicators.map((i) => i.name);
+    expect(indicatorNames).toContain("task_failure_rate");
+    expect(indicatorNames).toContain("session_death_count");
+    expect(indicatorNames).toContain("stale_task_count");
+    expect(indicatorNames).toContain("relay_queue_depth");
+    expect(indicatorNames).toContain("wake_failure_count");
+    expect(indicatorNames).toContain("cleanup_backlog");
+
+    // All indicators should have threshold structure
+    result.indicators.forEach((indicator) => {
+      expect(indicator.threshold).toHaveProperty("warning");
+      expect(indicator.threshold).toHaveProperty("critical");
+      expect(["ok", "warning", "critical"]).toContain(indicator.status);
+    });
+  });
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -137,6 +137,7 @@ async function main() {
           health: "/v1/health",
           cleanup: "/v1/internal/cleanup",
           wake: "/v1/internal/wake",
+          healthCheck: "/v1/internal/health-check",
         },
         restFallback: {
           description: "If MCP session dies, use REST endpoints with the same Bearer auth",
@@ -387,6 +388,50 @@ async function main() {
       res.writeHead(webRes.status, Object.fromEntries(webRes.headers.entries()));
       const body = await webRes.text();
       return res.end(body);
+    }
+
+    // Health check endpoint (scheduled job)
+    if (url === "/v1/internal/health-check" && req.method === "POST") {
+      const startTime = Date.now();
+
+      try {
+        const db = getFirestore();
+        const { runHealthCheck } = await import("./modules/gridbot-monitor.js");
+
+        // Find active users (same pattern as cleanup/wake)
+        const sevenDaysAgo = new Date();
+        sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+        const keysSnapshot = await db
+          .collection("apiKeys")
+          .where("lastUsedAt", ">=", sevenDaysAgo)
+          .get();
+
+        const activeUserIds = new Set<string>();
+        for (const doc of keysSnapshot.docs) {
+          const userId = doc.data().userId;
+          if (userId) activeUserIds.add(userId);
+        }
+
+        const results = [];
+        for (const userId of activeUserIds) {
+          const result = await runHealthCheck(userId);
+          results.push({ userId: userId.substring(0, 8) + "...", ...result });
+        }
+
+        const duration = Date.now() - startTime;
+        return sendJson(res, 200, {
+          success: true,
+          activeUsers: activeUserIds.size,
+          results,
+          duration_ms: duration,
+        });
+      } catch (error) {
+        console.error("[HealthCheck] Health check failed:", error);
+        return sendJson(res, 500, {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     // Main MCP endpoint

--- a/mcp-server/src/modules/events.ts
+++ b/mcp-server/src/modules/events.ts
@@ -27,7 +27,9 @@ export type EventType =
   | "BUDGET_EXCEEDED"
   | "BUDGET_WARNING"
   | "GITHUB_SYNC_FAILED"
-  | "GITHUB_SYNC_RECONCILED";
+  | "GITHUB_SYNC_RECONCILED"
+  | "HEALTH_WARNING"
+  | "HEALTH_CRITICAL";
 export type TaskClass = "WORK" | "CONTROL";
 
 export type CompletedStatus = "SUCCESS" | "FAILED" | "SKIPPED" | "CANCELLED";

--- a/mcp-server/src/modules/gridbot-monitor.ts
+++ b/mcp-server/src/modules/gridbot-monitor.ts
@@ -1,0 +1,237 @@
+/**
+ * GRIDBOT Health Monitoring Module
+ * 
+ * Runs health checks against Firestore data and emits alerts based on thresholds.
+ * Critical alerts route to Flynn's mobile (via relay + tasks mirror).
+ * Warning alerts route to ISO (via relay STATUS message).
+ */
+
+import * as admin from "firebase-admin";
+import { getFirestore } from "../firebase/client.js";
+import { emitEvent } from "./events.js";
+
+export interface HealthIndicator {
+  name: string;
+  value: number;
+  status: "ok" | "warning" | "critical";
+  threshold: { warning: number; critical: number };
+}
+
+export interface HealthCheckResult {
+  timestamp: string;
+  overall_status: "ok" | "warning" | "critical";
+  indicators: HealthIndicator[];
+  alerts_sent: string[];
+}
+
+export async function runHealthCheck(userId: string): Promise<HealthCheckResult> {
+  const db = getFirestore();
+  const now = admin.firestore.Timestamp.now();
+  const oneHourAgo = admin.firestore.Timestamp.fromDate(
+    new Date(now.toDate().getTime() - 60 * 60 * 1000)
+  );
+  const thirtyMinAgo = admin.firestore.Timestamp.fromDate(
+    new Date(now.toDate().getTime() - 30 * 60 * 1000)
+  );
+
+  const indicators: HealthIndicator[] = [];
+  const alertsSent: string[] = [];
+
+  // 1. Task failure rate (failed / total in last hour)
+  const recentTasks = await db
+    .collection(`users/${userId}/tasks`)
+    .where("completedAt", ">=", oneHourAgo)
+    .get();
+
+  const totalTasks = recentTasks.size;
+  const failedTasks = recentTasks.docs.filter(
+    (d) => d.data().completed_status === "FAILED"
+  ).length;
+  const failureRate = totalTasks > 0 ? failedTasks / totalTasks : 0;
+
+  indicators.push({
+    name: "task_failure_rate",
+    value: Math.round(failureRate * 100) / 100,
+    status: failureRate > 0.5 ? "critical" : failureRate > 0.2 ? "warning" : "ok",
+    threshold: { warning: 0.2, critical: 0.5 },
+  });
+
+  // 2. Session death count (SESSION_DEATH events in last hour)
+  const deathEvents = await db
+    .collection(`users/${userId}/events`)
+    .where("event_type", "==", "SESSION_DEATH")
+    .where("timestamp", ">=", oneHourAgo)
+    .get();
+
+  indicators.push({
+    name: "session_death_count",
+    value: deathEvents.size,
+    status: deathEvents.size > 10 ? "critical" : deathEvents.size > 3 ? "warning" : "ok",
+    threshold: { warning: 3, critical: 10 },
+  });
+
+  // 3. Stale task count (tasks in created status > 30 min)
+  const staleTasks = await db
+    .collection(`users/${userId}/tasks`)
+    .where("status", "==", "created")
+    .where("createdAt", "<=", thirtyMinAgo)
+    .get();
+
+  indicators.push({
+    name: "stale_task_count",
+    value: staleTasks.size,
+    status: staleTasks.size > 15 ? "critical" : staleTasks.size > 5 ? "warning" : "ok",
+    threshold: { warning: 5, critical: 15 },
+  });
+
+  // 4. Relay queue depth (pending relay messages)
+  const pendingRelay = await db
+    .collection(`users/${userId}/relay`)
+    .where("status", "==", "pending")
+    .get();
+
+  indicators.push({
+    name: "relay_queue_depth",
+    value: pendingRelay.size,
+    status: pendingRelay.size > 50 ? "critical" : pendingRelay.size > 20 ? "warning" : "ok",
+    threshold: { warning: 20, critical: 50 },
+  });
+
+  // 5. Wake failure rate (failed wake attempts in last hour)
+  const wakeEvents = await db
+    .collection(`users/${userId}/events`)
+    .where("event_type", "==", "PROGRAM_WAKE")
+    .where("timestamp", ">=", oneHourAgo)
+    .get();
+
+  const failedWakes = wakeEvents.docs.filter(
+    (d) => d.data().wake_result === "failed" || d.data().error
+  ).length;
+
+  indicators.push({
+    name: "wake_failure_count",
+    value: failedWakes,
+    status: failedWakes > 5 ? "critical" : failedWakes > 2 ? "warning" : "ok",
+    threshold: { warning: 2, critical: 5 },
+  });
+
+  // 6. Cleanup backlog (expired but uncleaned relay messages)
+  const expiredRelay = await db
+    .collection(`users/${userId}/relay`)
+    .where("status", "==", "pending")
+    .where("expiresAt", "<=", now)
+    .get();
+
+  indicators.push({
+    name: "cleanup_backlog",
+    value: expiredRelay.size,
+    status: expiredRelay.size > 50 ? "critical" : expiredRelay.size > 10 ? "warning" : "ok",
+    threshold: { warning: 10, critical: 50 },
+  });
+
+  // Determine overall status
+  const hasCritical = indicators.some((i) => i.status === "critical");
+  const hasWarning = indicators.some((i) => i.status === "warning");
+  const overallStatus = hasCritical ? "critical" : hasWarning ? "warning" : "ok";
+
+  // Route alerts
+  if (hasCritical) {
+    // Critical: send mobile alert to Flynn
+    try {
+      const criticalIndicators = indicators.filter((i) => i.status === "critical");
+      const alertMessage = `HEALTH CRITICAL: ${criticalIndicators
+        .map((i) => `${i.name}=${i.value}`)
+        .join(", ")}`;
+
+      const alertDoc = {
+        message: alertMessage,
+        alertType: "error",
+        priority: "high",
+        source: "gridbot",
+        target: "flynn",
+        status: "pending",
+        type: "alert",
+        expiresAt: admin.firestore.Timestamp.fromDate(
+          new Date(now.toDate().getTime() + 3600 * 1000)
+        ),
+        createdAt: now,
+      };
+
+      // Write to relay for alert feed
+      await db.collection(`users/${userId}/relay`).add(alertDoc);
+
+      // Mirror to tasks for mobile visibility
+      await db.collection(`users/${userId}/tasks`).add({
+        ...alertDoc,
+        title: "[GRIDBOT] Health Critical Alert",
+        instructions: alertMessage,
+      });
+
+      alertsSent.push("HEALTH_CRITICAL alert to Flynn (mobile)");
+    } catch (err) {
+      console.error("[GRIDBOT] Failed to send critical alert:", err);
+    }
+
+    emitEvent(userId, {
+      event_type: "HEALTH_CRITICAL",
+      program_id: "gridbot",
+      indicators: indicators
+        .filter((i) => i.status === "critical")
+        .map((i) => ({ name: i.name, value: i.value })),
+    });
+  }
+
+  if (hasWarning) {
+    // Warning: relay message to ISO
+    try {
+      const warningIndicators = indicators.filter((i) => i.status === "warning");
+      const warningMessage = `HEALTH WARNING: ${warningIndicators
+        .map((i) => `${i.name}=${i.value}`)
+        .join(", ")}`;
+
+      await db.collection(`users/${userId}/relay`).add({
+        message: warningMessage,
+        source: "gridbot",
+        target: "iso",
+        message_type: "STATUS",
+        status: "pending",
+        priority: "normal",
+        createdAt: now,
+        expiresAt: admin.firestore.Timestamp.fromDate(
+          new Date(now.toDate().getTime() + 3600 * 1000)
+        ),
+      });
+
+      alertsSent.push("HEALTH_WARNING status to ISO");
+    } catch (err) {
+      console.error("[GRIDBOT] Failed to send warning:", err);
+    }
+
+    emitEvent(userId, {
+      event_type: "HEALTH_WARNING",
+      program_id: "gridbot",
+      indicators: indicators
+        .filter((i) => i.status === "warning")
+        .map((i) => ({ name: i.name, value: i.value })),
+    });
+  }
+
+  // Write health check result to Firestore for historical trending
+  const result: HealthCheckResult = {
+    timestamp: now.toDate().toISOString(),
+    overall_status: overallStatus,
+    indicators,
+    alerts_sent: alertsSent,
+  };
+
+  try {
+    await db.collection(`users/${userId}/health_checks`).add({
+      ...result,
+      timestamp: now,
+    });
+  } catch (err) {
+    console.error("[GRIDBOT] Failed to write health check:", err);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- New `gridbot-monitor.ts` with `runHealthCheck()` function
- 6 health indicators with warning/critical thresholds
- Critical alerts → Flynn mobile (via relay + tasks mirror)
- Warning alerts → ISO (via relay STATUS message)
- Health check history stored in `health_checks` collection
- New internal endpoint `/v1/internal/health-check` for Cloud Scheduler
- New event types: `HEALTH_WARNING`, `HEALTH_CRITICAL`

## Health Indicators
| Indicator | Warning | Critical |
|-----------|---------|----------|
| Task failure rate | >20% | >50% |
| Session death count | >3/hr | >10/hr |
| Stale task count | >5 | >15 |
| Relay queue depth | >20 | >50 |
| Wake failure count | >2/hr | >5/hr |
| Cleanup backlog | >10 | >50 |

## Test plan
- [x] Unit tests for health check logic (154 tests passing)
- [x] All existing tests pass
- [x] TypeScript compilation clean (only pre-existing dispatch.ts error)
- [ ] Cloud Scheduler job config (separate task, recommend every 5 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)