### PR TITLE
fix: add Sprint 3 Cloud Scheduler jobs

### DIFF
--- a/mcp-server/scripts/setup-schedulers.sh
+++ b/mcp-server/scripts/setup-schedulers.sh
@@ -71,5 +71,51 @@ gcloud scheduler jobs update http cachebash-ttl-reaper \
   --attempt-deadline="60s"
 
 echo ""
+echo "=== Creating GitHub reconciliation scheduler (every 15min) ==="
+gcloud scheduler jobs create http cachebash-github-reconcile \
+  --schedule="*/15 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/reconcile-github" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="GitHub Reconciliation: retries failed GitHub sync operations" \
+  --attempt-deadline="120s" 2>/dev/null || \
+gcloud scheduler jobs update http cachebash-github-reconcile \
+  --schedule="*/15 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/reconcile-github" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="GitHub Reconciliation: retries failed GitHub sync operations" \
+  --attempt-deadline="120s"
+
+echo ""
+echo "=== Creating health check scheduler (every 5min) ==="
+gcloud scheduler jobs create http cachebash-health-check \
+  --schedule="*/5 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/health-check" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="GRIDBOT Health Check: monitors 6 health indicators, routes alerts" \
+  --attempt-deadline="60s" 2>/dev/null || \
+gcloud scheduler jobs update http cachebash-health-check \
+  --schedule="*/5 * * * *" \
+  --uri="${SERVICE_URL}/v1/internal/health-check" \
+  --http-method=POST \
+  --oidc-service-account-email="$SA_EMAIL" \
+  --oidc-token-audience="$SERVICE_URL" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="GRIDBOT Health Check: monitors 6 health indicators, routes alerts" \
+  --attempt-deadline="60s"
+
+echo ""
 echo "=== Done. Verify with: ==="
 echo "gcloud scheduler jobs list --location=$REGION --project=$PROJECT"


### PR DESCRIPTION
## Summary
- Adds `cachebash-github-reconcile` job (every 15min) for `/v1/internal/reconcile-github`
- Adds `cachebash-health-check` job (every 5min) for `/v1/internal/health-check`
- Script is idempotent (create || update pattern)

## Context
Sprint 3 added two new internal endpoints. This updates the scheduler setup script to configure Cloud Scheduler jobs for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)