### PR TITLE
fix: correct syncTaskCreated call arguments

### DIFF
--- a/mcp-server/src/modules/dispatch.ts
+++ b/mcp-server/src/modules/dispatch.ts
@@ -215,14 +215,10 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
     ref.id,
     args.title,
     args.instructions || "",
-    args.target,
+    args.action,
     args.priority,
     args.projectId,
-    args.action,
-    args.type,
-    verifiedSource,
-    null, // sessionId - not tracked at task creation
-    new Date().toISOString()
+    args.type
   );
 
   return jsonResult({


### PR DESCRIPTION
## Summary
- Fixes pre-existing TS error in dispatch.ts(222,5): Expected 4-8 arguments, but got 12
- Removed extra arguments (target, verifiedSource, sessionId, timestamp) that don't match syncTaskCreated signature
- This error became build-blocking when Cloud Build cache was invalidated during Sprint 3 deploy

## Test plan
- [x] TypeScript compilation: zero errors (was 1 error before)
- [x] All 154 unit tests pass
- [x] Function call now matches signature exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)