### PR TITLE
ci: add integration tests to GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+      
+      - name: Install dependencies
+        working-directory: ./mcp-server
+        run: npm ci
+      
+      - name: Run unit tests
+        working-directory: ./mcp-server
+        run: npm test
+      
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      
+      - name: Run integration tests with Firestore emulator
+        working-directory: ./firebase
+        run: |
+          firebase emulators:exec --only firestore --project cachebash-app 'cd ../mcp-server && npm run test:integration'
+        env:
+          FIRESTORE_EMULATOR_HOST: localhost:8080

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -5,5 +5,10 @@
   },
   "functions": {
     "source": "functions"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI workflow that runs both unit and integration tests on every PR and push to main.

## Changes

1. **Created `.github/workflows/ci.yml`** — GitHub Actions workflow with:
   - Unit test step (`npm test`)
   - Integration test step with Firestore emulator
   - Uses `firebase emulators:exec --only firestore` to automatically manage emulator lifecycle
   - Runs from `./firebase` directory where `firebase.json` lives

2. **Updated `firebase/firebase.json`** — added emulator configuration:
   ```json
   "emulators": {
     "firestore": {
       "port": 8080
     }
   }
   ```

## Why

Integration tests currently only run locally. This ensures Firestore interactions are tested in CI, catching bugs before merge. The emulator provides isolated, repeatable test environment without requiring production credentials.

## Test Plan

- [x] Workflow file syntax is valid YAML
- [x] Firebase emulator config added
- [ ] Verify workflow runs successfully on this PR
- [ ] Check that both unit and integration tests execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)