### PR TITLE
feat(phase4): Envelope v2.2 schemaVersion

### DIFF
--- a/mcp-server/src/__tests__/envelope-v2.2.test.ts
+++ b/mcp-server/src/__tests__/envelope-v2.2.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Envelope v2.2 Schema Version Tests
+ * Verify schemaVersion field structure and backward compatibility
+ */
+
+import { Envelope } from '../types/envelope';
+
+describe('Envelope v2.2 Schema Versioning', () => {
+  describe('Interface Structure', () => {
+    it('should allow documents with schemaVersion 2.2', () => {
+      const envelope: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal',
+        action: 'queue',
+        schemaVersion: '2.2',
+      };
+
+      expect(envelope.schemaVersion).toBe('2.2');
+    });
+
+    it('should allow documents with schemaVersion 2.1', () => {
+      const envelope: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal',
+        action: 'queue',
+        schemaVersion: '2.1',
+      };
+
+      expect(envelope.schemaVersion).toBe('2.1');
+    });
+
+    it('should allow documents without schemaVersion (backward compat)', () => {
+      const envelope: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal',
+        action: 'queue',
+      };
+
+      // schemaVersion is optional, so undefined is valid
+      expect(envelope.schemaVersion).toBeUndefined();
+    });
+
+    it('should allow all envelope fields with schemaVersion', () => {
+      const fullEnvelope: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'high',
+        action: 'interrupt',
+        schemaVersion: '2.2',
+        ttl: 3600,
+        replyTo: 'msg-123',
+        threadId: 'thread-456',
+        provenance: {
+          model: 'claude-opus-4',
+          cost_tokens: 1000,
+          confidence: 0.95,
+        },
+        fallback: ['quorra', 'alan'],
+      };
+
+      expect(fullEnvelope.schemaVersion).toBe('2.2');
+      expect(fullEnvelope.ttl).toBe(3600);
+      expect(fullEnvelope.provenance?.model).toBe('claude-opus-4');
+    });
+  });
+
+  describe('Version Semantics', () => {
+    it('v2.1 represents pre-Phase 4 documents', () => {
+      // Documents created before Phase 4 will have no schemaVersion,
+      // which is semantically equivalent to v2.1
+      const legacyDoc: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal',
+        action: 'queue',
+      };
+
+      // No schemaVersion = v2.1 semantics
+      expect(legacyDoc.schemaVersion).toBeUndefined();
+    });
+
+    it('v2.2 represents Phase 4+ documents with schema versioning', () => {
+      // All new documents created in Phase 4+ should have schemaVersion: '2.2'
+      const newDoc: Envelope = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal',
+        action: 'queue',
+        schemaVersion: '2.2',
+      };
+
+      expect(newDoc.schemaVersion).toBe('2.2');
+    });
+  });
+
+  describe('Read Path Compatibility', () => {
+    it('should read documents without requiring schemaVersion', () => {
+      // Reading code should not break when encountering documents
+      // without schemaVersion field
+      const documents: Envelope[] = [
+        // Legacy document (no version)
+        {
+          source: 'iso',
+          target: 'basher',
+          priority: 'normal',
+          action: 'queue',
+        },
+        // v2.1 explicit
+        {
+          source: 'quorra',
+          target: 'alan',
+          priority: 'high',
+          action: 'sprint',
+          schemaVersion: '2.1',
+        },
+        // v2.2 (current)
+        {
+          source: 'radia',
+          target: 'iso',
+          priority: 'low',
+          action: 'backlog',
+          schemaVersion: '2.2',
+        },
+      ];
+
+      // All documents should be readable
+      documents.forEach(doc => {
+        expect(doc.source).toBeDefined();
+        expect(doc.target).toBeDefined();
+        expect(doc.priority).toBeDefined();
+        expect(doc.action).toBeDefined();
+      });
+    });
+  });
+
+  describe('Future Extension', () => {
+    it('schemaVersion field enables future migrations', () => {
+      // The schemaVersion field is informational for now,
+      // but enables future schema migrations and deprecation cycles
+      
+      // Example: In future, we could add v2.3 with breaking changes
+      // and use schemaVersion to route through different handlers
+      const futureDoc = {
+        source: 'iso',
+        target: 'basher',
+        priority: 'normal' as const,
+        action: 'queue' as const,
+        schemaVersion: '2.2' as const,
+      };
+
+      // Handler logic could be: if (doc.schemaVersion === '2.1') { ... }
+      expect(futureDoc.schemaVersion).toBe('2.2');
+    });
+  });
+});

--- a/mcp-server/src/modules/dispatch.ts
+++ b/mcp-server/src/modules/dispatch.ts
@@ -165,6 +165,7 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
   const now = serverTimestamp();
 
   const taskData: Record<string, unknown> = {
+    schemaVersion: '2.2' as const,
     type: args.type,
     title: args.title,
     instructions: args.instructions || "",
@@ -404,6 +405,7 @@ Cap: $${budgetCheck.cap.toFixed(4)}
 Overage: $${(budgetCheck.consumed - budgetCheck.cap).toFixed(4)}`;
             
             db.collection(`users/${auth.userId}/relay`).add({
+              schemaVersion: '2.2' as const,
               source: "system",
               target: "user",
               message_type: "STATUS",

--- a/mcp-server/src/modules/relay.ts
+++ b/mcp-server/src/modules/relay.ts
@@ -112,6 +112,7 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
   const multicastId = isMulticast ? db.collection("_").doc().id : undefined;
 
   const baseData: Record<string, unknown> = {
+    schemaVersion: '2.2' as const,
     source: verifiedSource,
     message_type: args.message_type,
     payload: args.message,
@@ -152,6 +153,7 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
     const preview = args.message.length > 50 ? args.message.substring(0, 47) + "..." : args.message;
     const taskRef = db.collection(`users/${auth.userId}/tasks`).doc();
     batch.set(taskRef, {
+      schemaVersion: '2.2' as const,
       type: "task",
       title: `[${verifiedSource}→${args.target}] ${args.message_type}`,
       instructions: args.message,
@@ -220,6 +222,7 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
   // Also write to tasks collection for mobile app visibility
   const preview = args.message.length > 50 ? args.message.substring(0, 47) + "..." : args.message;
   await db.collection(`users/${auth.userId}/tasks`).doc(relayRef.id).set({
+    schemaVersion: '2.2' as const,
     type: "task",
     title: `[${verifiedSource}→${args.target}] ${args.message_type}`,
     instructions: args.message,

--- a/mcp-server/src/modules/signal.ts
+++ b/mcp-server/src/modules/signal.ts
@@ -69,6 +69,7 @@ export async function askQuestionHandler(auth: AuthContext, rawArgs: unknown): P
 
   // Questions are tasks with type: "question"
   const taskData: Record<string, unknown> = {
+    schemaVersion: '2.2' as const,
     type: "question",
     title: preview,
     instructions: "",
@@ -168,6 +169,7 @@ export async function sendAlertHandler(auth: AuthContext, rawArgs: unknown): Pro
 
   // Alerts go to relay with short TTL
   const alertData: Record<string, unknown> = {
+    schemaVersion: '2.2' as const,
     source: "program",
     target: "user",
     message_type: "STATUS",
@@ -187,6 +189,7 @@ export async function sendAlertHandler(auth: AuthContext, rawArgs: unknown): Pro
 
   // Also write to tasks for mobile visibility
   await db.collection(`users/${auth.userId}/tasks`).doc(ref.id).set({
+    schemaVersion: '2.2' as const,
     type: "task",
     title: `[Alert: ${args.alertType}] ${preview}`,
     instructions: args.message,

--- a/mcp-server/src/modules/sprint.ts
+++ b/mcp-server/src/modules/sprint.ts
@@ -107,6 +107,7 @@ export async function createSprintHandler(auth: AuthContext, rawArgs: unknown): 
 
   // Create parent sprint task
   const sprintData: Record<string, unknown> = {
+    schemaVersion: '2.2' as const,
     type: "sprint",
     title: `Sprint: ${args.projectName}`,
     instructions: "",
@@ -144,6 +145,7 @@ export async function createSprintHandler(auth: AuthContext, rawArgs: unknown): 
   for (const story of args.stories) {
     const storyRef = db.collection(`users/${auth.userId}/tasks`).doc();
     batch.set(storyRef, {
+      schemaVersion: '2.2' as const,
       type: "sprint-story",
       title: story.title,
       instructions: "",
@@ -290,6 +292,7 @@ export async function addStoryHandler(auth: AuthContext, rawArgs: unknown): Prom
   if (args.insertionMode === "backlog") wave = 999;
 
   await storyRef.set({
+    schemaVersion: '2.2' as const,
     type: "sprint-story",
     title: args.story.title,
     instructions: "",

--- a/mcp-server/src/types/envelope.ts
+++ b/mcp-server/src/types/envelope.ts
@@ -1,5 +1,5 @@
 /**
- * Envelope v2.1 — Shared fields for all Grid entities.
+ * Envelope v2.2 — Shared fields for all Grid entities.
  *
  * Every task, relay message, and inter-program communication
  * carries an envelope. This is the Grid's addressing system.
@@ -29,6 +29,9 @@ export interface Envelope {
   target: ProgramId;
   priority: Priority;
   action: Action;
+
+  /** Schema version — v2.1 = pre-Phase 4, v2.2 = Phase 4+ with schema versioning */
+  schemaVersion?: '2.1' | '2.2';
 
   /** Seconds until expiry (null = no expiry) */
   ttl?: number | null;


### PR DESCRIPTION
## Summary
- Adds `schemaVersion` field to the `Envelope` interface (`'2.1' | '2.2'`, optional for backward compat)
- Stamps `schemaVersion: '2.2'` on every Firestore document write: tasks, relay messages, questions, alerts, sprints, stories
- Includes test suite covering interface structure, version semantics, read path compatibility, and future extensibility

## Phase 4 Context
Wave 1 story (`I6DVW0YhehUHMRQSFM83`) from sprint `cJeYhL53xAU3qzpMUzx2`. This enables future schema migrations by making document version explicit.

## Test plan
- [ ] TypeScript compilation passes
- [ ] Envelope v2.2 test suite passes
- [ ] Existing integration tests unaffected (backward compatible change)
- [ ] New documents in Firestore carry `schemaVersion: '2.2'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)