### PR TITLE
config: add VECTOR to spawnable programs

### DIFF
--- a/mcp-server/src/config/launch.ts
+++ b/mcp-server/src/config/launch.ts
@@ -76,6 +76,13 @@ export const SPAWNABLE_PROGRAMS: Map<string, ProgramLaunchConfig> = new Map([
     repo: "rezzedai/grid",
     description: "Knowledge — pattern store, memory management",
   }],
+  ["vector", {
+    programId: "vector",
+    spawnable: true,
+    model: "opus",
+    repo: "rezzedai/grid",
+    description: "Strategic counsel — architecture, roadmap, council contributions",
+  }],
 ]);
 
 /** Check if a program is spawnable by the wake daemon */


### PR DESCRIPTION
## Summary
- Adds VECTOR to the `SPAWNABLE_PROGRAMS` map in `launch.ts`
- Enables wake daemon auto-spawn for VECTOR terminal sessions
- VECTOR now supports dual-mode: terminal (primary) + Desktop (artifacts)

## Test plan
- [ ] TypeScript compiles
- [ ] Wake daemon recognizes `vector` as spawnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)