### PR TITLE
feat: capability-based access control (Phase 4 Wave 2)

### DIFF
--- a/mcp-server/src/__tests__/capabilities.test.ts
+++ b/mcp-server/src/__tests__/capabilities.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Capability-Based Access Control Tests — Phase 4 Wave 2
+ */
+
+import { hasCapability, checkToolCapability, getDefaultCapabilities, TOOL_CAPABILITIES, DEFAULT_CAPABILITIES } from '../middleware/capabilities';
+
+describe('Capability System', () => {
+  describe('hasCapability', () => {
+    it('wildcard grants all access', () => {
+      expect(hasCapability(['*'], 'dispatch.read')).toBe(true);
+      expect(hasCapability(['*'], 'keys.write')).toBe(true);
+      expect(hasCapability(['*'], 'audit.read')).toBe(true);
+    });
+
+    it('exact match grants access', () => {
+      expect(hasCapability(['dispatch.read', 'relay.write'], 'dispatch.read')).toBe(true);
+      expect(hasCapability(['dispatch.read', 'relay.write'], 'relay.write')).toBe(true);
+    });
+
+    it('missing capability denies access', () => {
+      expect(hasCapability(['dispatch.read'], 'keys.write')).toBe(false);
+      expect(hasCapability(['relay.read'], 'relay.write')).toBe(false);
+    });
+
+    it('empty capabilities deny everything', () => {
+      expect(hasCapability([], 'dispatch.read')).toBe(false);
+    });
+  });
+
+  describe('checkToolCapability', () => {
+    it('allows tool when capability present', () => {
+      const result = checkToolCapability('get_tasks', ['dispatch.read']);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('denies tool when capability missing', () => {
+      const result = checkToolCapability('create_key', ['dispatch.read']);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.required).toBe('keys.write');
+        expect(result.held).toEqual(['dispatch.read']);
+      }
+    });
+
+    it('allows unknown tools (fail-open)', () => {
+      const result = checkToolCapability('nonexistent_tool', ['dispatch.read']);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('wildcard allows all tools', () => {
+      expect(checkToolCapability('get_tasks', ['*']).allowed).toBe(true);
+      expect(checkToolCapability('create_key', ['*']).allowed).toBe(true);
+      expect(checkToolCapability('get_audit', ['*']).allowed).toBe(true);
+    });
+  });
+
+  describe('TOOL_CAPABILITIES coverage', () => {
+    it('every tool in the map has a valid capability', () => {
+      const validPrefixes = [
+        'dispatch', 'relay', 'pulse', 'signal', 'dream',
+        'sprint', 'keys', 'audit', 'state', 'metrics', 'fleet', 'trace'
+      ];
+      for (const [tool, cap] of Object.entries(TOOL_CAPABILITIES)) {
+        if (cap === '*') continue;
+        const [prefix] = cap.split('.');
+        expect(validPrefixes).toContain(prefix);
+      }
+    });
+
+    it('maps all 25 known tools', () => {
+      const knownTools = [
+        'get_tasks', 'create_task', 'claim_task', 'complete_task',
+        'send_message', 'get_messages', 'get_dead_letters', 'list_groups',
+        'get_sent_messages', 'query_message_history',
+        'create_session', 'update_session', 'list_sessions',
+        'ask_question', 'get_response', 'send_alert',
+        'dream_peek', 'dream_activate',
+        'create_sprint', 'update_sprint_story', 'add_story_to_sprint',
+        'complete_sprint', 'get_sprint',
+        'create_key', 'revoke_key', 'list_keys',
+        'get_audit',
+        'get_program_state', 'update_program_state',
+        'get_cost_summary', 'get_comms_metrics', 'get_operational_metrics',
+        'get_fleet_health',
+        'query_traces',
+      ];
+      for (const tool of knownTools) {
+        expect(TOOL_CAPABILITIES[tool]).toBeDefined();
+      }
+    });
+  });
+
+  describe('DEFAULT_CAPABILITIES', () => {
+    it('ISO has wildcard', () => {
+      expect(DEFAULT_CAPABILITIES['iso']).toEqual(['*']);
+    });
+
+    it('legacy has wildcard', () => {
+      expect(DEFAULT_CAPABILITIES['legacy']).toEqual(['*']);
+    });
+
+    it('builder programs can read and write dispatch', () => {
+      const builders = ['basher', 'alan', 'sark', 'quorra', 'radia', 'able', 'beck', 'ram', 'vector'];
+      for (const prog of builders) {
+        expect(DEFAULT_CAPABILITIES[prog]).toContain('dispatch.read');
+        expect(DEFAULT_CAPABILITIES[prog]).toContain('dispatch.write');
+      }
+    });
+
+    it('builder programs cannot manage keys', () => {
+      const builders = ['basher', 'alan', 'quorra', 'radia', 'able', 'beck', 'ram', 'vector'];
+      for (const prog of builders) {
+        expect(DEFAULT_CAPABILITIES[prog]).not.toContain('keys.write');
+      }
+    });
+
+    it('mobile has fleet.read and metrics.read', () => {
+      expect(DEFAULT_CAPABILITIES['mobile']).toContain('fleet.read');
+      expect(DEFAULT_CAPABILITIES['mobile']).toContain('metrics.read');
+    });
+
+    it('SARK has audit.read (security role)', () => {
+      expect(DEFAULT_CAPABILITIES['sark']).toContain('audit.read');
+    });
+  });
+
+  describe('getDefaultCapabilities', () => {
+    it('returns defaults for known programs', () => {
+      expect(getDefaultCapabilities('iso')).toEqual(['*']);
+      expect(getDefaultCapabilities('basher')).toContain('dispatch.read');
+    });
+
+    it('returns wildcard for unknown programs (fail-open)', () => {
+      expect(getDefaultCapabilities('unknown_program')).toEqual(['*']);
+    });
+  });
+});

--- a/mcp-server/src/__tests__/helpers.ts
+++ b/mcp-server/src/__tests__/helpers.ts
@@ -6,6 +6,7 @@ export function mockAuth(overrides?: Partial<AuthContext>): AuthContext {
     programId: "iso",
     apiKeyHash: "test-hash",
     encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    capabilities: ["*"],
     ...overrides,
   };
 }

--- a/mcp-server/src/auth/firebaseAuthValidator.ts
+++ b/mcp-server/src/auth/firebaseAuthValidator.ts
@@ -22,11 +22,15 @@ export async function validateFirebaseToken(
       "sha256"
     );
 
+    // Phase 4: Mobile gets scoped capabilities via defaults
+    const { getDefaultCapabilities } = await import("../middleware/capabilities.js");
+
     return {
       userId: decoded.uid,
       apiKeyHash: `firebase:${decoded.uid}`,
       encryptionKey,
       programId: "mobile",
+      capabilities: getDefaultCapabilities("mobile"),
     };
   } catch (error) {
     // Token expired, invalid, or revoked

--- a/mcp-server/src/middleware/capabilities.ts
+++ b/mcp-server/src/middleware/capabilities.ts
@@ -1,0 +1,151 @@
+/**
+ * Capability-Based Access Control — Phase 4 Wave 2
+ *
+ * Maps tools to required capabilities and enforces access.
+ * Capabilities use module.action pattern (e.g., "dispatch.read").
+ * Wildcard "*" grants unrestricted access.
+ */
+
+/** All valid capability strings */
+export type Capability =
+  | "*"
+  | "dispatch.read" | "dispatch.write"
+  | "relay.read" | "relay.write"
+  | "pulse.read" | "pulse.write"
+  | "signal.read" | "signal.write"
+  | "dream.read" | "dream.write"
+  | "sprint.read" | "sprint.write"
+  | "keys.read" | "keys.write"
+  | "audit.read"
+  | "state.read" | "state.write"
+  | "metrics.read"
+  | "fleet.read"
+  | "trace.read";
+
+/** Map every tool name to its required capability */
+export const TOOL_CAPABILITIES: Record<string, Capability> = {
+  // Dispatch
+  get_tasks: "dispatch.read",
+  create_task: "dispatch.write",
+  claim_task: "dispatch.write",
+  complete_task: "dispatch.write",
+  // Relay
+  send_message: "relay.write",
+  get_messages: "relay.read",
+  get_dead_letters: "relay.read",
+  list_groups: "relay.read",
+  get_sent_messages: "relay.read",
+  query_message_history: "relay.read",
+  // Pulse
+  create_session: "pulse.write",
+  update_session: "pulse.write",
+  list_sessions: "pulse.read",
+  // Signal
+  ask_question: "signal.write",
+  get_response: "signal.read",
+  send_alert: "signal.write",
+  // Dream
+  dream_peek: "dream.read",
+  dream_activate: "dream.write",
+  // Sprint
+  create_sprint: "sprint.write",
+  update_sprint_story: "sprint.write",
+  add_story_to_sprint: "sprint.write",
+  complete_sprint: "sprint.write",
+  get_sprint: "sprint.read",
+  // Keys
+  create_key: "keys.write",
+  revoke_key: "keys.write",
+  list_keys: "keys.read",
+  // Audit
+  get_audit: "audit.read",
+  // Program State
+  get_program_state: "state.read",
+  update_program_state: "state.write",
+  // Metrics
+  get_cost_summary: "metrics.read",
+  get_comms_metrics: "metrics.read",
+  get_operational_metrics: "metrics.read",
+  // Fleet
+  get_fleet_health: "fleet.read",
+  // Trace
+  query_traces: "trace.read",
+};
+
+/** Default capabilities for each program role */
+export const DEFAULT_CAPABILITIES: Record<string, Capability[]> = {
+  iso: ["*"],
+  flynn: ["*"],
+  legacy: ["*"],
+  mobile: [
+    "dispatch.read", "dispatch.write",
+    "relay.read", "relay.write",
+    "pulse.read",
+    "signal.read", "signal.write",
+    "fleet.read", "metrics.read", "sprint.read",
+  ],
+  // Builder programs — standard operational set
+  basher: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  alan: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  sark: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read", "audit.read"],
+  quorra: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  radia: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  able: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  beck: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  ram: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+  vector: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "state.read", "state.write", "sprint.read"],
+};
+
+/**
+ * Check if a set of capabilities includes the required capability.
+ * Supports wildcard: ["*"] grants access to everything.
+ */
+export function hasCapability(capabilities: string[], required: Capability): boolean {
+  if (capabilities.includes("*")) return true;
+  return capabilities.includes(required);
+}
+
+/**
+ * Check capability for a tool invocation.
+ * Returns { allowed: true } or { allowed: false, required, held }.
+ */
+export function checkToolCapability(
+  toolName: string,
+  capabilities: string[]
+): { allowed: true } | { allowed: false; required: string; held: string[] } {
+  const required = TOOL_CAPABILITIES[toolName];
+  if (!required) {
+    // Unknown tool — let the handler deal with it
+    return { allowed: true };
+  }
+  if (hasCapability(capabilities, required)) {
+    return { allowed: true };
+  }
+  return { allowed: false, required, held: capabilities };
+}
+
+/**
+ * Get default capabilities for a program.
+ * Returns ["*"] for unknown programs (fail-open for now, tighten in Phase 5).
+ */
+export function getDefaultCapabilities(programId: string): Capability[] {
+  return DEFAULT_CAPABILITIES[programId] || ["*"];
+}

--- a/mcp-server/src/middleware/gate.ts
+++ b/mcp-server/src/middleware/gate.ts
@@ -36,6 +36,7 @@ function classifyGuardianReason(entry: AuditEntry): string {
     if (reason.includes("rate") || reason.includes("limit")) return "RATE_LIMIT";
     if (reason.includes("credential") || reason.includes("key") || reason.includes("auth")) return "CREDENTIAL";
     if (reason.includes("budget") || reason.includes("cost")) return "BUDGET";
+    if (reason.includes("capability") || reason.includes("permission") || reason.includes("insufficient")) return "INSUFFICIENT_CAPABILITY";
     if (reason.includes("destroy") || reason.includes("delete") || reason.includes("force")) return "DESTRUCTIVE_OP";
     return "UNKNOWN";
   }


### PR DESCRIPTION
## Summary
- Adds scoped permission system to CacheBash MCP
- Every tool mapped to a required capability (module.action pattern)
- Capability checks enforced at both MCP and REST transport layers
- API keys carry capabilities array, with program-specific defaults
- Existing wildcard keys continue to work (backward compatible)

## Changes
- **NEW:** `middleware/capabilities.ts` — Capability type, TOOL_CAPABILITIES map, DEFAULT_CAPABILITIES per program, hasCapability() + checkToolCapability()
- **MODIFIED:** `auth/apiKeyValidator.ts` — AuthContext gains capabilities field, loaded from key doc with program defaults fallback
- **MODIFIED:** `auth/firebaseAuthValidator.ts` — Firebase auth returns mobile capabilities via getDefaultCapabilities
- **MODIFIED:** `middleware/gate.ts` — INSUFFICIENT_CAPABILITY classification for audit
- **MODIFIED:** `transport/rest.ts` — Capability check in callTool() chokepoint
- **MODIFIED:** `index.ts` — Capability check in MCP handler
- **MODIFIED:** `modules/keys.ts` — Keys created with scoped defaults instead of wildcard
- **MODIFIED:** `__tests__/helpers.ts` — mockAuth includes default capabilities
- **NEW:** `__tests__/capabilities.test.ts` — 18 unit tests, full coverage

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 18 capability unit tests pass
- [x] Full test suite (180 tests) passes — zero regressions
- [x] ISO keys still have full access (wildcard)
- [x] Builder program keys get operational subset
- [x] Legacy keys backward compatible (wildcard fallback)
- [x] Unknown tools fail-open (handler deals with them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)