### PR TITLE
Story 2.3: Per-client MCP setup guides

### DIFF
--- a/launch-kit/guides/claude-code.md
+++ b/launch-kit/guides/claude-code.md
@@ -1,0 +1,62 @@
+# CacheBash MCP — Claude Code Setup Guide
+
+Connect CacheBash to Claude Code in under 2 minutes.
+
+## Prerequisites
+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- A CacheBash API key (get one from your admin or generate via the `create_key` tool)
+
+## Config File Location
+
+| Scope | Path |
+|-------|------|
+| Global (all projects) | `~/.mcp.json` |
+| Project-scoped | `<project-root>/.mcp.json` |
+
+## Configuration
+
+Add the following to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR_API_KEY` with your actual CacheBash API key.
+
+## Verify Connection
+
+1. Start a new Claude Code session (or restart your current one)
+2. Ask Claude to run any CacheBash tool:
+   ```
+   Use the list_sessions tool to check active sessions
+   ```
+3. If tools load correctly, you'll see CacheBash tools in Claude's available tool list
+
+All 30+ CacheBash tools should be available immediately — no additional setup required.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Tools not appearing | Stale session | Restart Claude Code (`/exit` then relaunch) |
+| `401 Unauthorized` | Invalid or expired API key | Verify your key with `curl -H "Authorization: Bearer YOUR_KEY" https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp` |
+| Connection timeout | Network issue or endpoint down | Check endpoint status; ensure no firewall/VPN blocking HTTPS |
+| Project config not loading | Wrong file location | Ensure `.mcp.json` is in the project root, not a subdirectory |
+
+## Notes
+
+- Claude Code is CacheBash's reference client — this is the most battle-tested integration.
+- Session management (MCP session IDs, reconnection) is handled automatically.
+- Global config (`~/.mcp.json`) applies to all projects. Project-scoped config overrides global for that project.
+- Never commit `.mcp.json` to version control — it contains your API key. Add it to `.gitignore`.

--- a/launch-kit/guides/cursor.md
+++ b/launch-kit/guides/cursor.md
@@ -1,0 +1,99 @@
+# CacheBash MCP — Cursor Setup Guide
+
+Connect CacheBash to Cursor using Streamable HTTP transport.
+
+## Prerequisites
+
+- [Cursor](https://cursor.com) installed (v0.40+)
+- A CacheBash API key
+- (Fallback only) Node.js 18+ and `npx` available
+
+## Config File Location
+
+| Scope | Path |
+|-------|------|
+| Global | `~/.cursor/mcp.json` |
+| Project-scoped | `<project-root>/.cursor/mcp.json` |
+
+## Configuration
+
+### Option A: Direct HTTP (recommended)
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "streamable-http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Option B: Environment variable for the key
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "streamable-http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:CACHEBASH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Set `CACHEBASH_API_KEY` in your shell profile before launching Cursor.
+
+### Option C: mcp-remote bridge (fallback)
+
+Some Cursor versions have a bug where `cursor-agent` silently drops auth headers. If you get persistent `401` errors with Option A, use the `mcp-remote` npm bridge:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+        "--header",
+        "Authorization: Bearer ${CACHEBASH_API_KEY}"
+      ],
+      "env": {
+        "CACHEBASH_API_KEY": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## Verify Connection
+
+1. Save your config file
+2. **Fully restart Cursor** (Cmd/Ctrl+Shift+P > "Reload Window" is not enough)
+3. Open **Cursor Settings > MCP** — `cachebash` should show as connected
+4. In chat, ask: "Use the list_sessions CacheBash tool"
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `401 Unauthorized` | Auth headers dropped by `cursor-agent` | Switch to Option C (`mcp-remote` bridge) |
+| Server not showing in settings | Config not loaded | Full restart (not just reload window) |
+| JSON parse error | Trailing comma or syntax error | Validate JSON — Cursor's parser is strict, no trailing commas |
+| Tools not appearing in chat | MCP Resources requested | CacheBash exposes Tools only, not Resources |
+| `env:` variable not expanding | Used `env` with URL-based server | `${env:VAR}` works in `headers`; `env` object only works with `command`-based servers |
+
+## Notes
+
+- CacheBash exposes ~30 tools, well within Cursor's performance limits (issues start at 70+).
+- After any config change, always do a full Cursor restart.
+- Never commit `mcp.json` with hardcoded keys to version control.

--- a/launch-kit/guides/gemini-cli.md
+++ b/launch-kit/guides/gemini-cli.md
@@ -1,0 +1,94 @@
+# CacheBash MCP — Gemini CLI Setup Guide
+
+Connect CacheBash to Google's Gemini CLI.
+
+## Prerequisites
+
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed (`npm install -g @anthropic-ai/gemini-cli` or via source)
+- A CacheBash API key
+
+## Config File Location
+
+| Scope | Path |
+|-------|------|
+| Global | `~/.gemini/settings.json` |
+| Project-scoped | `<project-root>/.gemini/settings.json` |
+
+## Configuration
+
+### Option A: Hardcoded key
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_KEY"
+      },
+      "timeout": 30000,
+      "trust": true
+    }
+  }
+}
+```
+
+### Option B: Environment variable (recommended)
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer $CACHEBASH_API_KEY"
+      },
+      "timeout": 30000,
+      "trust": true
+    }
+  }
+}
+```
+
+Set `CACHEBASH_API_KEY` in your shell profile before launching Gemini CLI.
+
+> Gemini CLI uses `$VAR_NAME` syntax for env var expansion — not `${env:VAR_NAME}`.
+
+## Verify Connection
+
+1. Save your config to `~/.gemini/settings.json`
+2. Start a Gemini CLI session:
+   ```bash
+   gemini
+   ```
+3. Ask: "List the available CacheBash tools"
+4. CacheBash tools should appear in the tool list
+
+## Configuration Options
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | CacheBash MCP endpoint |
+| `type` | No | `"http"` for Streamable HTTP (auto-detected if omitted) |
+| `headers` | Yes | Auth headers |
+| `timeout` | No | Request timeout in ms (default: 600,000ms / 10 min). 30s recommended for CacheBash. |
+| `trust` | No | `true` auto-approves tool calls; `false` prompts for confirmation each time |
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `401 Unauthorized` | Env var not set or wrong syntax | Use `$VAR_NAME` (not `${env:VAR_NAME}`); verify with `echo $CACHEBASH_API_KEY` |
+| Tools not loading | Config in wrong location | Check `~/.gemini/settings.json` exists and is valid JSON |
+| Tool name conflicts | Multiple MCP servers with same tool names | Gemini CLI prefixes with `serverName__toolName` — no action needed |
+| Schema validation warnings | Gemini strips `$schema`/`additionalProperties` | Normal behavior — CacheBash tools are compatible |
+| Slow responses | Default 10-minute timeout | Set `"timeout": 30000` to fail fast on connection issues |
+
+## Notes
+
+- Setting `"trust": true` auto-approves all CacheBash tool calls without prompting. Set to `false` if you want per-call confirmation.
+- Gemini CLI tries Streamable HTTP first, then falls back to SSE if `type` is omitted.
+- The 30-second timeout is recommended — CacheBash operations typically complete in under 2 seconds.
+- Never commit `settings.json` with hardcoded keys to version control.

--- a/launch-kit/guides/vscode-copilot.md
+++ b/launch-kit/guides/vscode-copilot.md
@@ -1,0 +1,110 @@
+# CacheBash MCP — VS Code + GitHub Copilot Setup Guide
+
+Connect CacheBash to VS Code using GitHub Copilot's MCP support.
+
+## Prerequisites
+
+- [VS Code](https://code.visualstudio.com) 1.100+ (MCP GA since 1.102)
+- [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) installed and active
+- A CacheBash API key
+
+## Config File Location
+
+| Scope | Path | Key format |
+|-------|------|------------|
+| Workspace (recommended) | `.vscode/mcp.json` | `servers` (top-level) |
+| User-level | VS Code `settings.json` | `mcp.servers` (nested) |
+
+> VS Code uses `servers` — not `mcpServers`.
+
+## Configuration
+
+### Option A: Secure input prompt (recommended)
+
+This prompts for your API key on first use — nothing stored in plaintext:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "cachebash-api-key",
+      "description": "CacheBash MCP API Key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:cachebash-api-key}"
+      }
+    }
+  }
+}
+```
+
+Save as `.vscode/mcp.json` in your workspace root.
+
+### Option B: Environment variable
+
+```json
+{
+  "servers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:CACHEBASH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Set `CACHEBASH_API_KEY` in your shell profile before launching VS Code.
+
+### User-level config (settings.json)
+
+To make CacheBash available across all workspaces, add to your VS Code `settings.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "cachebash": {
+        "type": "http",
+        "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+        "headers": {
+          "Authorization": "Bearer ${env:CACHEBASH_API_KEY}"
+        }
+      }
+    }
+  }
+}
+```
+
+## Verify Connection
+
+1. Save `.vscode/mcp.json` in your workspace
+2. Open Command Palette (Cmd/Ctrl+Shift+P) > **"MCP: List Servers"**
+3. `cachebash` should appear in the server list
+4. Open Copilot Chat and ask: "Use the list_sessions CacheBash tool"
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Server not listed | VS Code too old | Upgrade to VS Code 1.100+ (SSE header bug fixed in that release) |
+| `401 Unauthorized` | Key not entered or env var missing | Re-enter when prompted (Option A) or check `CACHEBASH_API_KEY` is exported |
+| Config ignored | Wrong key format | Use `servers` (not `mcpServers`) in `.vscode/mcp.json` |
+| Tools not available in chat | Copilot extension disabled | Ensure GitHub Copilot is active and signed in |
+| "Too many tools" warning | Exceeds 128 tool limit | Only applies if you have many MCP servers; CacheBash's ~30 tools are fine |
+
+## Notes
+
+- The `inputs` array with `"password": true` is VS Code's built-in secrets mechanism — your key is never stored in plaintext config files.
+- VS Code tries Streamable HTTP first and falls back to SSE automatically.
+- Session lifecycle is managed automatically — no manual session ID handling needed.
+- Add `.vscode/mcp.json` to `.gitignore` if it contains hardcoded keys.


### PR DESCRIPTION
## Summary
- Adds setup guides for all 4 compatible MCP clients: Claude Code, Cursor, VS Code + GitHub Copilot, and Gemini CLI
- Each guide includes prerequisites, exact config JSON, connection verification steps, and troubleshooting tables
- References cross-platform testing results from `launch-kit/testing/cross-platform-results.md`

## Deliverables
- `launch-kit/guides/claude-code.md`
- `launch-kit/guides/cursor.md`
- `launch-kit/guides/vscode-copilot.md`
- `launch-kit/guides/gemini-cli.md`

## Test plan
- [ ] Config JSON in each guide is valid and matches the cross-platform results
- [ ] All 4 guides cover: prerequisites, config location, exact JSON, verification, troubleshooting
- [ ] No hardcoded API keys — all examples use `YOUR_API_KEY` placeholder
- [ ] Cursor guide includes `mcp-remote` bridge fallback for known header-dropping bug
- [ ] VS Code guide includes secure input prompt option (`password: true`)
- [ ] Gemini CLI guide documents `$VAR_NAME` env var syntax (not `${env:VAR_NAME}`)