### PR TITLE
feat: authorized email auto-linking in Firestore rules

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -86,10 +86,22 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // User links: readable by the linked user, writable only by server
+    // Authorized emails: readable by authenticated users (for auto-linking check)
+    match /authorizedEmails/{email} {
+      allow read: if isAuth();
+      allow write: if false;
+    }
+
+    // User links: readable by the linked user, auto-created for authorized emails
     match /userLinks/{linkId} {
       allow read: if isAuth() && request.auth.uid == linkId;
-      allow write: if false;
+      // Allow auto-linking: user can create their own link if their email is in authorizedEmails
+      allow create: if isAuth() && request.auth.uid == linkId &&
+        exists(/databases/$(database)/documents/authorizedEmails/$(request.auth.token.email)) &&
+        request.resource.data.dataUid == get(/databases/$(database)/documents/authorizedEmails/$(request.auth.token.email)).data.dataUid &&
+        request.resource.data.keys().hasOnly(['dataUid']);
+      // No updates or deletes from client
+      allow update, delete: if false;
     }
 
     // API keys: no client access at all (sensitive auth material)


### PR DESCRIPTION
## Summary
- Adds `authorizedEmails` collection rule (read-only for authenticated users)
- Allows users to auto-create their own `userLinks` document if their email matches an `authorizedEmails` entry
- Link must exactly match the `dataUid` from the authorized entry — no arbitrary linking

## Context
Enables `christian@bourlier.ai` and `christian@rezzed.ai` to access the Grid Command Center with auto-linking on first sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)