### PR TITLE
feat: G-33 T1-B — Cloud Function triggers for analytics aggregation

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -45,6 +45,12 @@ service cloud.firestore {
       allow read: if isOwner(userId);
       allow write: if false;
     }
+
+    // Analytics Aggregates (G-33 T1-B): read-only for clients. Server writes via Cloud Functions.
+    match /users/{userId}/analytics_aggregates/{docId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
     
     // Ledger: read-only for clients. Server-authoritative.
     match /users/{userId}/ledger/{entryId} {

--- a/firebase/functions/jest.config.js
+++ b/firebase/functions/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: ".",
+  testMatch: ["<rootDir>/src/**/*.test.ts"],
+};

--- a/firebase/functions/lib/analytics/helpers.js
+++ b/firebase/functions/lib/analytics/helpers.js
@@ -1,0 +1,44 @@
+"use strict";
+/**
+ * Pure helper functions for analytics aggregation.
+ * No Firebase dependencies — safe to import in tests.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getISOWeek = getISOWeek;
+exports.getISOWeekYear = getISOWeekYear;
+exports.buildAggregateKeys = buildAggregateKeys;
+/**
+ * Get ISO 8601 week number for a date.
+ * Week 1 is the week containing the first Thursday of the year.
+ */
+function getISOWeek(date) {
+    const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+/**
+ * Get the ISO week year (may differ from calendar year at year boundaries).
+ */
+function getISOWeekYear(date) {
+    const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+    return d.getUTCFullYear();
+}
+/**
+ * Build aggregate document keys from a timestamp.
+ * Returns keys for daily, weekly, and monthly aggregate documents.
+ */
+function buildAggregateKeys(timestamp) {
+    const yyyy = timestamp.getUTCFullYear();
+    const mm = String(timestamp.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(timestamp.getUTCDate()).padStart(2, "0");
+    const weekNum = getISOWeek(timestamp);
+    const weekYear = getISOWeekYear(timestamp);
+    return {
+        daily: `daily_${yyyy}-${mm}-${dd}`,
+        weekly: `weekly_${weekYear}-W${String(weekNum).padStart(2, "0")}`,
+        monthly: `monthly_${yyyy}-${mm}`,
+    };
+}
+//# sourceMappingURL=helpers.js.map

--- a/firebase/functions/lib/analytics/onAnalyticsEventCreate.js
+++ b/firebase/functions/lib/analytics/onAnalyticsEventCreate.js
@@ -1,0 +1,97 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.onAnalyticsEventCreate = void 0;
+const functions = __importStar(require("firebase-functions"));
+const admin = __importStar(require("firebase-admin"));
+const helpers_1 = require("./helpers");
+const db = admin.firestore();
+/**
+ * Triggered when a new analytics event is created.
+ * Aggregates counters into daily, weekly, and monthly rollups
+ * using atomic increment — no read-before-write.
+ */
+exports.onAnalyticsEventCreate = functions.firestore
+    .document("users/{userId}/analytics_events/{eventId}")
+    .onCreate(async (snapshot, context) => {
+    const { userId } = context.params;
+    const data = snapshot.data();
+    const eventType = data.eventType;
+    const programId = data.programId;
+    const timestamp = data.timestamp;
+    // Skip if missing required eventType
+    if (!eventType) {
+        functions.logger.warn("Analytics event missing eventType, skipping aggregation");
+        return;
+    }
+    // Parse timestamp — handle Firestore Timestamp, ISO string, or fallback to now
+    let date;
+    if (timestamp && typeof timestamp.toDate === "function") {
+        date = timestamp.toDate();
+    }
+    else if (typeof timestamp === "string") {
+        date = new Date(timestamp);
+    }
+    else {
+        date = new Date();
+    }
+    if (isNaN(date.getTime())) {
+        functions.logger.warn("Analytics event has invalid timestamp, using current time");
+        date = new Date();
+    }
+    const keys = (0, helpers_1.buildAggregateKeys)(date);
+    const increment = admin.firestore.FieldValue.increment(1);
+    const aggregatesRef = db.collection(`users/${userId}/analytics_aggregates`);
+    // Build the update payload — same shape for all three periods
+    const update = {
+        totalEvents: increment,
+        [`byType.${eventType}`]: increment,
+    };
+    if (programId) {
+        update[`byProgram.${programId}`] = increment;
+    }
+    const options = { merge: true };
+    try {
+        await Promise.all([
+            aggregatesRef.doc(keys.daily).set(update, options),
+            aggregatesRef.doc(keys.weekly).set(update, options),
+            aggregatesRef.doc(keys.monthly).set(update, options),
+        ]);
+    }
+    catch (error) {
+        functions.logger.error("Failed to write analytics aggregates", error);
+    }
+});
+//# sourceMappingURL=onAnalyticsEventCreate.js.map

--- a/firebase/functions/lib/analytics/onAnalyticsEventCreate.test.js
+++ b/firebase/functions/lib/analytics/onAnalyticsEventCreate.test.js
@@ -1,0 +1,57 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const helpers_1 = require("./helpers");
+describe("getISOWeek", () => {
+    it("returns week 1 for Jan 1 2026 (Thursday)", () => {
+        expect((0, helpers_1.getISOWeek)(new Date("2026-01-01T00:00:00Z"))).toBe(1);
+    });
+    it("returns week 53 for Dec 31 2020 (Thursday)", () => {
+        expect((0, helpers_1.getISOWeek)(new Date("2020-12-31T00:00:00Z"))).toBe(53);
+    });
+    it("returns week 1 for Jan 4 2021 (Monday, first week)", () => {
+        expect((0, helpers_1.getISOWeek)(new Date("2021-01-04T00:00:00Z"))).toBe(1);
+    });
+    it("returns correct week for mid-year date", () => {
+        // June 15 2026 is a Monday
+        expect((0, helpers_1.getISOWeek)(new Date("2026-06-15T00:00:00Z"))).toBe(25);
+    });
+});
+describe("getISOWeekYear", () => {
+    it("returns 2020 for Dec 31 2020 (still in week 53 of 2020)", () => {
+        expect((0, helpers_1.getISOWeekYear)(new Date("2020-12-31T00:00:00Z"))).toBe(2020);
+    });
+    it("returns 2026 for Jan 1 2026", () => {
+        expect((0, helpers_1.getISOWeekYear)(new Date("2026-01-01T00:00:00Z"))).toBe(2026);
+    });
+});
+describe("buildAggregateKeys", () => {
+    it("builds correct keys for a known date", () => {
+        const date = new Date("2026-02-23T15:30:00Z");
+        const keys = (0, helpers_1.buildAggregateKeys)(date);
+        expect(keys.daily).toBe("daily_2026-02-23");
+        expect(keys.monthly).toBe("monthly_2026-02");
+        // Feb 23 2026 is a Monday, week 9
+        expect(keys.weekly).toBe("weekly_2026-W09");
+    });
+    it("zero-pads single-digit months and days", () => {
+        const date = new Date("2026-01-05T00:00:00Z");
+        const keys = (0, helpers_1.buildAggregateKeys)(date);
+        expect(keys.daily).toBe("daily_2026-01-05");
+        expect(keys.monthly).toBe("monthly_2026-01");
+    });
+    it("zero-pads single-digit week numbers", () => {
+        const date = new Date("2026-01-01T00:00:00Z");
+        const keys = (0, helpers_1.buildAggregateKeys)(date);
+        expect(keys.weekly).toBe("weekly_2026-W01");
+    });
+    it("handles year-boundary weeks correctly", () => {
+        // Dec 31 2025 is a Wednesday — week 1 of 2026
+        const date = new Date("2025-12-31T00:00:00Z");
+        const keys = (0, helpers_1.buildAggregateKeys)(date);
+        expect(keys.daily).toBe("daily_2025-12-31");
+        expect(keys.monthly).toBe("monthly_2025-12");
+        // Week year may differ from calendar year at boundaries
+        expect(keys.weekly).toMatch(/^weekly_\d{4}-W\d{2}$/);
+    });
+});
+//# sourceMappingURL=onAnalyticsEventCreate.test.js.map

--- a/firebase/functions/lib/index.js
+++ b/firebase/functions/lib/index.js
@@ -33,7 +33,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanupAudit = exports.processDeadLetters = exports.cleanupLedger = exports.cleanupExpiredRelay = exports.cleanupOrphanedTasks = exports.cleanupExpiredSessions = exports.onRelayCreate = exports.onSessionUpdate = exports.onTaskUpdate = exports.onTaskCreate = exports.onUserCreate = void 0;
+exports.cleanupAudit = exports.processDeadLetters = exports.cleanupLedger = exports.cleanupExpiredRelay = exports.cleanupOrphanedTasks = exports.cleanupExpiredSessions = exports.onAnalyticsEventCreate = exports.onRelayCreate = exports.onSessionUpdate = exports.onTaskUpdate = exports.onTaskCreate = exports.onUserCreate = void 0;
 const admin = __importStar(require("firebase-admin"));
 admin.initializeApp();
 // Auth triggers
@@ -48,6 +48,9 @@ var onSessionUpdate_1 = require("./notifications/onSessionUpdate");
 Object.defineProperty(exports, "onSessionUpdate", { enumerable: true, get: function () { return onSessionUpdate_1.onSessionUpdate; } });
 var onRelayCreate_1 = require("./notifications/onRelayCreate");
 Object.defineProperty(exports, "onRelayCreate", { enumerable: true, get: function () { return onRelayCreate_1.onRelayCreate; } });
+// Analytics aggregation
+var onAnalyticsEventCreate_1 = require("./analytics/onAnalyticsEventCreate");
+Object.defineProperty(exports, "onAnalyticsEventCreate", { enumerable: true, get: function () { return onAnalyticsEventCreate_1.onAnalyticsEventCreate; } });
 // Scheduled cleanup
 var cleanupExpiredSessions_1 = require("./cleanup/cleanupExpiredSessions");
 Object.defineProperty(exports, "cleanupExpiredSessions", { enumerable: true, get: function () { return cleanupExpiredSessions_1.cleanupExpiredSessions; } });

--- a/firebase/functions/src/analytics/helpers.ts
+++ b/firebase/functions/src/analytics/helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helper functions for analytics aggregation.
+ * No Firebase dependencies — safe to import in tests.
+ */
+
+/**
+ * Get ISO 8601 week number for a date.
+ * Week 1 is the week containing the first Thursday of the year.
+ */
+export function getISOWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+/**
+ * Get the ISO week year (may differ from calendar year at year boundaries).
+ */
+export function getISOWeekYear(date: Date): number {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  return d.getUTCFullYear();
+}
+
+/**
+ * Build aggregate document keys from a timestamp.
+ * Returns keys for daily, weekly, and monthly aggregate documents.
+ */
+export function buildAggregateKeys(timestamp: Date): {
+  daily: string;
+  weekly: string;
+  monthly: string;
+} {
+  const yyyy = timestamp.getUTCFullYear();
+  const mm = String(timestamp.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(timestamp.getUTCDate()).padStart(2, "0");
+  const weekNum = getISOWeek(timestamp);
+  const weekYear = getISOWeekYear(timestamp);
+
+  return {
+    daily: `daily_${yyyy}-${mm}-${dd}`,
+    weekly: `weekly_${weekYear}-W${String(weekNum).padStart(2, "0")}`,
+    monthly: `monthly_${yyyy}-${mm}`,
+  };
+}

--- a/firebase/functions/src/analytics/onAnalyticsEventCreate.test.ts
+++ b/firebase/functions/src/analytics/onAnalyticsEventCreate.test.ts
@@ -1,0 +1,68 @@
+import { getISOWeek, getISOWeekYear, buildAggregateKeys } from "./helpers";
+
+describe("getISOWeek", () => {
+  it("returns week 1 for Jan 1 2026 (Thursday)", () => {
+    expect(getISOWeek(new Date("2026-01-01T00:00:00Z"))).toBe(1);
+  });
+
+  it("returns week 53 for Dec 31 2020 (Thursday)", () => {
+    expect(getISOWeek(new Date("2020-12-31T00:00:00Z"))).toBe(53);
+  });
+
+  it("returns week 1 for Jan 4 2021 (Monday, first week)", () => {
+    expect(getISOWeek(new Date("2021-01-04T00:00:00Z"))).toBe(1);
+  });
+
+  it("returns correct week for mid-year date", () => {
+    // June 15 2026 is a Monday
+    expect(getISOWeek(new Date("2026-06-15T00:00:00Z"))).toBe(25);
+  });
+});
+
+describe("getISOWeekYear", () => {
+  it("returns 2020 for Dec 31 2020 (still in week 53 of 2020)", () => {
+    expect(getISOWeekYear(new Date("2020-12-31T00:00:00Z"))).toBe(2020);
+  });
+
+  it("returns 2026 for Jan 1 2026", () => {
+    expect(getISOWeekYear(new Date("2026-01-01T00:00:00Z"))).toBe(2026);
+  });
+});
+
+describe("buildAggregateKeys", () => {
+  it("builds correct keys for a known date", () => {
+    const date = new Date("2026-02-23T15:30:00Z");
+    const keys = buildAggregateKeys(date);
+
+    expect(keys.daily).toBe("daily_2026-02-23");
+    expect(keys.monthly).toBe("monthly_2026-02");
+    // Feb 23 2026 is a Monday, week 9
+    expect(keys.weekly).toBe("weekly_2026-W09");
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    const date = new Date("2026-01-05T00:00:00Z");
+    const keys = buildAggregateKeys(date);
+
+    expect(keys.daily).toBe("daily_2026-01-05");
+    expect(keys.monthly).toBe("monthly_2026-01");
+  });
+
+  it("zero-pads single-digit week numbers", () => {
+    const date = new Date("2026-01-01T00:00:00Z");
+    const keys = buildAggregateKeys(date);
+
+    expect(keys.weekly).toBe("weekly_2026-W01");
+  });
+
+  it("handles year-boundary weeks correctly", () => {
+    // Dec 31 2025 is a Wednesday — week 1 of 2026
+    const date = new Date("2025-12-31T00:00:00Z");
+    const keys = buildAggregateKeys(date);
+
+    expect(keys.daily).toBe("daily_2025-12-31");
+    expect(keys.monthly).toBe("monthly_2025-12");
+    // Week year may differ from calendar year at boundaries
+    expect(keys.weekly).toMatch(/^weekly_\d{4}-W\d{2}$/);
+  });
+});

--- a/firebase/functions/src/analytics/onAnalyticsEventCreate.ts
+++ b/firebase/functions/src/analytics/onAnalyticsEventCreate.ts
@@ -1,0 +1,68 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { buildAggregateKeys } from "./helpers";
+
+const db = admin.firestore();
+
+/**
+ * Triggered when a new analytics event is created.
+ * Aggregates counters into daily, weekly, and monthly rollups
+ * using atomic increment — no read-before-write.
+ */
+export const onAnalyticsEventCreate = functions.firestore
+  .document("users/{userId}/analytics_events/{eventId}")
+  .onCreate(async (snapshot, context) => {
+    const { userId } = context.params;
+    const data = snapshot.data();
+
+    const eventType: string | undefined = data.eventType;
+    const programId: string | undefined = data.programId;
+    const timestamp = data.timestamp;
+
+    // Skip if missing required eventType
+    if (!eventType) {
+      functions.logger.warn("Analytics event missing eventType, skipping aggregation");
+      return;
+    }
+
+    // Parse timestamp — handle Firestore Timestamp, ISO string, or fallback to now
+    let date: Date;
+    if (timestamp && typeof timestamp.toDate === "function") {
+      date = timestamp.toDate();
+    } else if (typeof timestamp === "string") {
+      date = new Date(timestamp);
+    } else {
+      date = new Date();
+    }
+
+    if (isNaN(date.getTime())) {
+      functions.logger.warn("Analytics event has invalid timestamp, using current time");
+      date = new Date();
+    }
+
+    const keys = buildAggregateKeys(date);
+    const increment = admin.firestore.FieldValue.increment(1);
+    const aggregatesRef = db.collection(`users/${userId}/analytics_aggregates`);
+
+    // Build the update payload — same shape for all three periods
+    const update: Record<string, admin.firestore.FieldValue> = {
+      totalEvents: increment,
+      [`byType.${eventType}`]: increment,
+    };
+
+    if (programId) {
+      update[`byProgram.${programId}`] = increment;
+    }
+
+    const options: admin.firestore.SetOptions = { merge: true };
+
+    try {
+      await Promise.all([
+        aggregatesRef.doc(keys.daily).set(update, options),
+        aggregatesRef.doc(keys.weekly).set(update, options),
+        aggregatesRef.doc(keys.monthly).set(update, options),
+      ]);
+    } catch (error) {
+      functions.logger.error("Failed to write analytics aggregates", error);
+    }
+  });

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -11,6 +11,9 @@ export { onTaskUpdate } from "./notifications/onTaskUpdate";
 export { onSessionUpdate } from "./notifications/onSessionUpdate";
 export { onRelayCreate } from "./notifications/onRelayCreate";
 
+// Analytics aggregation
+export { onAnalyticsEventCreate } from "./analytics/onAnalyticsEventCreate";
+
 // Scheduled cleanup
 export { cleanupExpiredSessions } from "./cleanup/cleanupExpiredSessions";
 export { cleanupOrphanedTasks } from "./cleanup/cleanupOrphanedTasks";


### PR DESCRIPTION
## Summary
- Adds Firestore `onCreate` trigger on `users/{userId}/analytics_events/{eventId}` that atomically increments daily, weekly, and monthly aggregate counters
- Uses `FieldValue.increment(1)` with `set(..., { merge: true })` — zero read-before-write
- Aggregates stored in `users/{userId}/analytics_aggregates/` with keys: `daily_YYYY-MM-DD`, `weekly_YYYY-WNN`, `monthly_YYYY-MM`
- Each aggregate doc has: `totalEvents`, `byType.{eventType}`, `byProgram.{programId}`

## Changes
| File | Change |
|------|--------|
| `firebase/functions/src/analytics/helpers.ts` | Pure helper functions (ISO week calculation, key generation) |
| `firebase/functions/src/analytics/onAnalyticsEventCreate.ts` | Cloud Function trigger |
| `firebase/functions/src/analytics/onAnalyticsEventCreate.test.ts` | 10 unit tests |
| `firebase/functions/src/index.ts` | Export new trigger |
| `firebase/functions/jest.config.js` | Jest config for functions |
| `firebase/firestore.rules` | Read-only rule for `analytics_aggregates` |

## Test plan
- [x] 10/10 Cloud Functions unit tests passing (ISO week, week year, key generation)
- [x] 180/180 MCP server tests passing (zero regressions)
- [x] TypeScript build clean (strict mode)
- [ ] Deploy to staging and verify trigger fires on analytics event creation
- [ ] Confirm aggregate docs created with correct structure in Firestore console