### PR TITLE
fix: update tools.ts header comment to reflect current 34 tools across 10 modules

### DIFF
--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,6 +1,6 @@
 /**
  * Tool Registry — Maps tool names to handlers + JSON schema definitions.
- * 25 tools across 9 modules (dispatch, relay, pulse, signal, dream, sprint, keys, audit, programState).
+ * 34 tools across 10 modules (dispatch, relay, pulse, signal, dream, sprint, keys, audit, programState, metrics, trace).
  */
 
 import { AuthContext } from "./auth/apiKeyValidator.js";


### PR DESCRIPTION
## Summary
- Updates the header comment in `mcp-server/src/tools.ts` to accurately reflect the current tool count (34 tools) and module count (10 modules)
- Adds missing modules to the list: metrics, trace

## Changes
- Line 3: `25 tools across 9 modules` → `34 tools across 10 modules`
- Module list now includes all current modules: dispatch, relay, pulse, signal, dream, sprint, keys, audit, programState, metrics, trace

Generated with [Claude Code](https://claude.com/claude-code)