### PR TITLE
Add server.json for MCP Registry listing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.feelgreatfoodie/cachebash",
+  "title": "CacheBash",
+  "description": "Let your AI sessions talk to each other — messaging, tasks, sessions, and alerts",
+  "repository": {
+    "url": "https://github.com/rezzedai/cachebash",
+    "source": "github"
+  },
+  "version": "2.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer API key for CacheBash authentication (format: Bearer YOUR_API_KEY)",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` for the official MCP Registry publication
- CacheBash published as `io.github.feelgreatfoodie/cachebash` (remote server, streamable-http)
- Declares Bearer auth header requirement

## Verification
```bash
curl -s "https://registry.modelcontextprotocol.io/v0.1/servers?search=cachebash" | jq .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)