### PR TITLE
Fix iOS encryption compliance for TestFlight

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -15,7 +15,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.cachebash.app"
+      "bundleIdentifier": "com.cachebash.app",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.cachebash.app",


### PR DESCRIPTION
## Summary
- Adds `ITSAppUsesNonExemptEncryption: false` to iOS Info.plist via Expo config
- Prevents TestFlight builds from being held for manual compliance answers
- App uses only standard HTTPS/TLS (Firebase SDK) — qualifies for exemption

## Test plan
- [ ] Next build auto-clears compliance in App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)