### PR TITLE
feat: expandable stat cards + filter chip fix

### DIFF
--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -240,10 +240,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: theme.spacing.md,
     paddingVertical: theme.spacing.sm,
     borderRadius: theme.borderRadius.lg,
-    backgroundColor: theme.colors.surface,
+    backgroundColor: theme.colors.surfaceElevated,
     borderWidth: 1,
     borderColor: theme.colors.border,
     marginRight: theme.spacing.sm,
+    minHeight: 34,
+    justifyContent: 'center',
   },
   filterChipActive: {
     backgroundColor: theme.colors.surface,
@@ -252,7 +254,8 @@ const styles = StyleSheet.create({
   filterChipText: {
     fontSize: theme.fontSize.sm,
     fontWeight: '600',
-    color: theme.colors.textSecondary,
+    color: theme.colors.text,
+    lineHeight: 18,
   },
   filterChipTextActive: {
     color: theme.colors.primary,


### PR DESCRIPTION
## Summary
- Home screen stat cards (Programs, Tasks, Messages) are now **tappable accordion sections** that expand inline to show relevant content
- Active sprints integrated into Programs expansion (no longer a separate section)
- Messages section shows **received** messages only (filters out orchestrator/admin sent messages)
- Tasks screen filter chip labels now use higher contrast text (#f0f0f5 vs #9ca3af) with explicit lineHeight

## Test plan
- [ ] Tap Programs card — expands to show fleet grid + active sprints
- [ ] Tap again — collapses
- [ ] Tap Pending Tasks — expands to show task list with status dots
- [ ] Tap Messages — expands to show received messages only
- [ ] Only one section expanded at a time
- [ ] Tasks tab filter chips show labels on initial load
- [ ] All expanded items are tappable and navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)