### PR TITLE
fix: route message responses to correct channel

### DIFF
--- a/mobile/src/screens/MessagesScreen.tsx
+++ b/mobile/src/screens/MessagesScreen.tsx
@@ -26,10 +26,16 @@ export default function MessagesScreen({ navigation }: MessagesScreenProps) {
     const channelMap = new Map<string, Channel>();
 
     messages.forEach((message) => {
-      // Group by conversation partner — the program that isn't orchestrator/admin
-      const programId = (message.source === 'orchestrator' || message.source === 'admin')
-        ? message.target
-        : message.source;
+      // Group by conversation partner — the party that isn't the user (admin)
+      let programId: string;
+      if (message.source === 'admin') {
+        programId = message.target;
+      } else if (message.target === 'admin') {
+        programId = message.source;
+      } else {
+        // Messages between programs — group by the non-orchestrator party
+        programId = message.source === 'orchestrator' ? message.target : message.source;
+      }
 
       // Skip empty programId
       if (!programId) return;


### PR DESCRIPTION
## Summary
- Responses to admin (user) were creating a separate "ADMIN" channel instead of showing in the program's channel
- Root cause: channel grouping used `target` for all orchestrator/admin-sourced messages, but when orchestrator responds TO admin, `target` is 'admin' — wrong channel
- Fix: identify conversation partner as whoever is NOT 'admin' (the user), so both directions of a conversation stay in the same channel

## Test plan
- [ ] Send a message to ORCHESTRATOR — shows in ORCHESTRATOR channel
- [ ] Receive a response — shows in same ORCHESTRATOR channel, not a separate ADMIN channel
- [ ] Messages between programs (builder → orchestrator) still group correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)