### PR TITLE
feat: P0 UX improvements — icons, badges, priority, compose

### DIFF
--- a/mobile/src/screens/ComposeMessageScreen.tsx
+++ b/mobile/src/screens/ComposeMessageScreen.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, FlatList } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { theme } from '../theme';
+import { haptic } from '../utils/haptics';
+
+type Props = NativeStackScreenProps<any, 'ComposeMessage'>;
+
+interface Program {
+  id: string;
+  name: string;
+  color: string;
+}
+
+const PROGRAMS: Program[] = [
+  { id: 'orchestrator', name: 'ISO', color: '#6FC3DF' },
+  { id: 'builder', name: 'BASHER', color: '#E87040' },
+  { id: 'architect', name: 'ALAN', color: '#4A8ED4' },
+  { id: 'reviewer', name: 'QUORRA', color: '#9B6FC0' },
+  { id: 'auditor', name: 'SARK', color: '#C44040' },
+  { id: 'able', name: 'ABLE', color: '#4DB870' },
+  { id: 'beck', name: 'BECK', color: '#40A8A0' },
+  { id: 'designer', name: 'RADIA', color: '#E8E0D0' },
+];
+
+export default function ComposeMessageScreen({ navigation }: Props) {
+  const handleSelect = (program: Program) => {
+    haptic.light();
+    navigation.replace('ChannelDetail', {
+      programId: program.id,
+      channelName: program.name,
+    });
+  };
+
+  const renderProgram = ({ item }: { item: Program }) => (
+    <TouchableOpacity
+      style={styles.programRow}
+      onPress={() => handleSelect(item)}
+      activeOpacity={0.7}
+      accessibilityLabel={`Message ${item.name}`}
+      accessibilityRole="button"
+    >
+      <View style={[styles.avatar, { backgroundColor: item.color + '20' }]}>
+        <Text style={[styles.avatarText, { color: item.color }]}>
+          {item.name.charAt(0)}
+        </Text>
+      </View>
+      <View style={styles.programInfo}>
+        <Text style={styles.programName}>{item.name}</Text>
+        <Text style={styles.programId}>{item.id}</Text>
+      </View>
+      <Text style={styles.chevron}>{'\u203A'}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionHeader}>Select a program to message</Text>
+      <FlatList
+        data={PROGRAMS}
+        renderItem={renderProgram}
+        keyExtractor={(item) => item.id}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        contentContainerStyle={styles.list}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  sectionHeader: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: '600',
+    color: theme.colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.lg,
+    paddingBottom: theme.spacing.sm,
+  },
+  list: {
+    paddingBottom: theme.spacing.xl,
+  },
+  programRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
+    backgroundColor: theme.colors.surface,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: theme.spacing.md,
+  },
+  avatarText: {
+    fontSize: theme.fontSize.lg,
+    fontWeight: '700',
+  },
+  programInfo: {
+    flex: 1,
+  },
+  programName: {
+    fontSize: theme.fontSize.md,
+    fontWeight: '600',
+    color: theme.colors.text,
+    marginBottom: 2,
+  },
+  programId: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.textMuted,
+  },
+  chevron: {
+    fontSize: theme.fontSize.xl,
+    color: theme.colors.textMuted,
+    marginLeft: theme.spacing.sm,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: theme.colors.border,
+    marginLeft: theme.spacing.lg + 40 + theme.spacing.md,
+  },
+});

--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -55,7 +55,11 @@ export default function TasksScreen({ navigation }: Props) {
 
   const renderTaskCard = ({ item: task }: { item: Task }) => (
     <TouchableOpacity
-      style={styles.taskCard}
+      style={[
+        styles.taskCard,
+        task.priority === 'high' && styles.taskCardHighPriority,
+        task.type === 'question' && task.status === 'created' && styles.taskCardQuestion,
+      ]}
       onPress={() => navigation.navigate('TaskDetail', { task })}
       activeOpacity={0.7}
       accessibilityLabel={`${task.title}, ${task.status}, ${task.priority} priority`}
@@ -271,6 +275,15 @@ const styles = StyleSheet.create({
     marginBottom: theme.spacing.md,
     borderWidth: 1,
     borderColor: theme.colors.border,
+    borderLeftWidth: 3,
+    borderLeftColor: theme.colors.border,
+  },
+  taskCardHighPriority: {
+    borderLeftColor: theme.colors.error,
+    backgroundColor: theme.colors.surface,
+  },
+  taskCardQuestion: {
+    borderLeftColor: theme.colors.primary,
   },
   taskCardHeader: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
From [council UX assessment](https://github.com/rezzedai/grid/blob/main/grid/decisions/council-assessment-cachebash-app-ux.md), implementing the 5 P0 items:

1. **Tab icons** — replaced Unicode (`⬡ ◈ ☰ ⚙`) with View-based geometric icons that render consistently
2. **Tab badges** — red badge counts on Messages (unread) and Tasks (pending) tabs
3. **Priority distinction** — high-priority tasks get red left border, pending questions get cyan border
4. **Compose button** — `+` button on Messages header opens program picker for new conversations
5. **ComposeMessageScreen** — new screen with program list (avatar, name, ID) that navigates to ChannelDetail

## Test plan
- [ ] Tab icons render consistently (no Unicode rendering issues)
- [ ] Badge counts update as messages/tasks change
- [ ] High-priority task cards have red left border
- [ ] Question task cards have cyan left border
- [ ] Compose button opens program picker
- [ ] Selecting a program opens ChannelDetail for that program

🤖 Generated with [Claude Code](https://claude.com/claude-code)