### PR TITLE
docs: client setup guides for top 5 MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ gcloud run deploy cachebash-mcp \
 
 See [docs/deployment.md](docs/deployment.md) for the full guide including Firestore setup, Firebase Auth, and API key configuration.
 
+## Client Setup Guides
+
+Step-by-step configuration for each supported MCP client:
+
+| Client | Guide | Auth |
+|--------|-------|------|
+| Claude Code | [docs/guides/claude-code.md](docs/guides/claude-code.md) | Bearer token |
+| Cursor | [docs/guides/cursor.md](docs/guides/cursor.md) | Bearer token |
+| VS Code | [docs/guides/vscode.md](docs/guides/vscode.md) | Bearer token |
+| Gemini CLI | [docs/guides/gemini-cli.md](docs/guides/gemini-cli.md) | Bearer token |
+| ChatGPT | [docs/guides/chatgpt.md](docs/guides/chatgpt.md) | OAuth 2.1 (not yet supported) |
+
 ## Documentation
 
 - [Architecture](docs/architecture.md) — System design, data model, security

--- a/docs/guides/chatgpt.md
+++ b/docs/guides/chatgpt.md
@@ -1,0 +1,38 @@
+# CacheBash + ChatGPT Desktop
+
+> **Status: Not yet supported.** ChatGPT requires OAuth 2.1 for MCP server auth. CacheBash currently uses Bearer token (API key) auth. OAuth 2.1 support is on the roadmap.
+
+## Why it doesn't work yet
+
+ChatGPT's MCP implementation exclusively requires OAuth 2.1 with:
+
+- **Protected Resource Metadata** at `/.well-known/oauth-protected-resource`
+- **Authorization Server Metadata** at `/.well-known/oauth-authorization-server`
+- **Dynamic Client Registration** — each ChatGPT session gets a unique `client_id`
+- **PKCE** (S256) is mandatory
+
+Static Bearer tokens, API keys, and custom auth headers are not supported.
+
+## What's needed
+
+CacheBash would need to implement a full OAuth 2.1 authorization server to support ChatGPT. This includes:
+
+1. Token issuance and verification endpoints
+2. Dynamic client registration
+3. PKCE challenge/response flow
+4. Proper `aud` claim validation
+
+## Additional requirements
+
+- ChatGPT MCP is only available on **Business, Enterprise, and Edu plans** (not free or Plus)
+- A workspace admin must enable developer mode
+- MCP servers are registered through the ChatGPT web interface under **Settings > Apps & Connectors**, not via local config files
+
+## Alternatives
+
+While waiting for OAuth 2.1 support, you can use CacheBash with any of the supported clients:
+
+- [Claude Code](claude-code.md) — primary client, production-tested
+- [Cursor](cursor.md) — works out of the box
+- [VS Code](vscode.md) — works with GitHub Copilot
+- [Gemini CLI](gemini-cli.md) — works with env var expansion

--- a/docs/guides/claude-code.md
+++ b/docs/guides/claude-code.md
@@ -1,0 +1,92 @@
+# CacheBash + Claude Code
+
+Connect CacheBash to [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Anthropic's CLI for Claude).
+
+## Prerequisites
+
+- Claude Code installed and working
+- A CacheBash API key
+
+## Configure
+
+Create or edit `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CACHEBASH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Set your API key as an environment variable:
+
+```bash
+export CACHEBASH_API_KEY="cb_your_key_here"
+```
+
+Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist across sessions.
+
+### Config scopes
+
+| Scope | Location | Use case |
+|-------|----------|----------|
+| Project (shared) | `.mcp.json` at project root | Checked into git, shared with team |
+| Local (personal) | Stored in `~/.claude.json` | Per-project, not committed |
+| User (global) | Stored in `~/.claude.json` | All projects on this machine |
+
+Use `claude mcp add` to configure via CLI:
+
+```bash
+claude mcp add cachebash --type http \
+  --url "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp" \
+  --header "Authorization: Bearer \${CACHEBASH_API_KEY}"
+```
+
+## Verify
+
+Start Claude Code and ask it to list sessions:
+
+```
+> list my cachebash sessions
+```
+
+If connected, you'll see a response from the `list_sessions` tool. You can also try:
+
+```
+> call dream_peek
+```
+
+A successful response (even if empty) confirms the connection is working.
+
+## Troubleshooting
+
+### "401 Unauthorized"
+
+- Verify your API key is set: `echo $CACHEBASH_API_KEY`
+- Check the key hasn't been revoked
+- Ensure the `Authorization` header format is exactly `Bearer <key>` (with a space)
+
+### "MCP server not found"
+
+- Confirm `.mcp.json` is in the current project root
+- Restart Claude Code after changing config
+- Check for JSON syntax errors in `.mcp.json`
+
+### Tools not appearing
+
+- Run `claude mcp list` to verify CacheBash is registered
+- If the server times out on startup, set `MCP_TIMEOUT` to a higher value
+- Check that the URL is correct and the server is reachable: `curl -s -o /dev/null -w "%{http_code}" https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp`
+
+### Env var not expanding
+
+- Claude Code supports `${VAR}` and `${VAR:-default}` syntax
+- If the variable is unset and has no default, the config will fail to parse
+- Double-check the variable is exported, not just set

--- a/docs/guides/cursor.md
+++ b/docs/guides/cursor.md
@@ -1,0 +1,72 @@
+# CacheBash + Cursor
+
+Connect CacheBash to [Cursor](https://cursor.com) IDE.
+
+## Prerequisites
+
+- Cursor v0.5 or later
+- A CacheBash API key
+
+## Configure
+
+Create or edit `.cursor/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:CACHEBASH_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Set your API key as an environment variable:
+
+```bash
+export CACHEBASH_API_KEY="cb_your_key_here"
+```
+
+Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist across sessions.
+
+### Config scopes
+
+| Scope | Location |
+|-------|----------|
+| Project | `.cursor/mcp.json` in the project root |
+| User (global) | `~/.cursor/mcp.json` |
+
+You can also configure MCP servers through **Cursor Settings > MCP**.
+
+## Verify
+
+Open Cursor's AI chat and ask:
+
+```
+> list my cachebash sessions
+```
+
+Or check MCP server status in **Cursor Settings > MCP** — CacheBash should show as connected with a green indicator.
+
+## Troubleshooting
+
+### "401 Unauthorized"
+
+- Verify your API key is set: `echo $CACHEBASH_API_KEY`
+- Cursor uses `${env:VAR}` syntax (not `${VAR}`) — make sure you include the `env:` prefix
+- Restart Cursor after changing environment variables
+
+### Server not connecting
+
+- Check for JSON syntax errors in `.cursor/mcp.json`
+- Verify the URL is reachable from your network
+- Go to **Cursor Settings > MCP** to see connection status and error messages
+
+### Env var not expanding
+
+- Cursor requires `${env:VARIABLE_NAME}` syntax — this is different from Claude Code's `${VARIABLE}` syntax
+- The variable must be exported in the shell that launched Cursor
+- If launched from Dock/Finder, shell env vars may not be available — try launching from terminal: `open -a Cursor`

--- a/docs/guides/gemini-cli.md
+++ b/docs/guides/gemini-cli.md
@@ -1,0 +1,78 @@
+# CacheBash + Gemini CLI
+
+Connect CacheBash to [Gemini CLI](https://github.com/google-gemini/gemini-cli) (Google's command-line AI tool).
+
+## Prerequisites
+
+- Gemini CLI installed (`npm install -g @anthropic-ai/gemini-cli` or via the official install method)
+- A CacheBash API key
+
+## Configure
+
+Create or edit `.gemini/settings.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "httpUrl": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer $CACHEBASH_API_KEY"
+      },
+      "timeout": 10000
+    }
+  }
+}
+```
+
+> **Important:** Use `"httpUrl"` (not `"url"`). The `httpUrl` field uses Streamable HTTP transport. Using `url` instead would connect via SSE, which is a legacy transport.
+
+Set your API key as an environment variable:
+
+```bash
+export CACHEBASH_API_KEY="cb_your_key_here"
+```
+
+Add it to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist across sessions.
+
+### Config scopes
+
+| Scope | Location |
+|-------|----------|
+| Project | `.gemini/settings.json` in the project root |
+| User (global) | `~/.gemini/settings.json` |
+
+## Verify
+
+Start Gemini CLI and ask:
+
+```
+> list my cachebash sessions
+```
+
+A successful response confirms the connection. You can also try:
+
+```
+> call dream_peek to check for pending work
+```
+
+## Troubleshooting
+
+### "401 Unauthorized"
+
+- Verify your API key is set: `echo $CACHEBASH_API_KEY`
+- Gemini CLI uses `$VAR` or `${VAR}` syntax (POSIX-style) — no special prefix needed
+- Undefined variables resolve to empty strings silently — double-check the variable name matches exactly
+
+### Server not connecting
+
+- Verify you're using `"httpUrl"` (not `"url"`) — this is the most common mistake
+- `"url"` connects via SSE (legacy), `"httpUrl"` connects via Streamable HTTP
+- Check that the JSON is valid — `settings.json` must be well-formed
+- Increase the `"timeout"` value if you're on a slow connection
+
+### Env var not expanding
+
+- Gemini CLI supports `$VAR` and `${VAR}` syntax
+- On Windows, use `%VAR%` syntax instead
+- Variables must be exported in the shell that launched Gemini CLI

--- a/docs/guides/vscode.md
+++ b/docs/guides/vscode.md
@@ -1,0 +1,89 @@
+# CacheBash + VS Code
+
+Connect CacheBash to [VS Code](https://code.visualstudio.com) with GitHub Copilot Chat MCP support.
+
+## Prerequisites
+
+- VS Code 1.99 or later
+- GitHub Copilot extension installed
+- A CacheBash API key
+
+## Configure
+
+Create `.vscode/mcp.json` in your project root:
+
+```json
+{
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "cachebash-api-key",
+      "description": "CacheBash API Key",
+      "password": true
+    }
+  ],
+  "servers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:cachebash-api-key}"
+      }
+    }
+  }
+}
+```
+
+VS Code will prompt you for the API key on first connection and store it securely.
+
+### Alternative: hardcoded key
+
+If you prefer not to use the interactive prompt (e.g., for automation):
+
+```json
+{
+  "servers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer cb_your_key_here"
+      }
+    }
+  }
+}
+```
+
+> **Note:** The top-level key is `"servers"`, not `"mcpServers"`. This is different from Claude Code and Cursor.
+
+### User-level config
+
+To add CacheBash globally, open the command palette (`Cmd+Shift+P`) and run **MCP: Open User Configuration**, then add the same server block.
+
+## Verify
+
+Open Copilot Chat and ask:
+
+```
+> list my cachebash sessions
+```
+
+You can also check MCP status via the command palette: **MCP: List Servers**.
+
+## Troubleshooting
+
+### "401 Unauthorized"
+
+- Re-enter your API key — open command palette, run **MCP: List Servers**, find CacheBash, and reset the credential
+- If using a hardcoded key, verify it hasn't been revoked
+
+### Config not loading
+
+- The top-level key must be `"servers"`, NOT `"mcpServers"` — this is the most common mistake when porting from other clients
+- Ensure GitHub Copilot extension is installed and `chat.mcp.enabled` is `true` in settings
+- Requires VS Code 1.99+ — check your version with **Help > About**
+
+### Input prompt not appearing
+
+- VS Code prompts once per session — if you dismissed it, restart VS Code
+- Check that the `"inputs"` array `id` matches the `${input:id}` reference exactly


### PR DESCRIPTION
## Summary
- Per-client setup guides for Claude Code, Cursor, VS Code, ChatGPT, and Gemini CLI
- Each guide: Prerequisites → Configure → Verify → Troubleshooting
- Zero-to-working target: under 60 seconds for supported clients
- ChatGPT documented as not yet supported (OAuth 2.1 required)
- README updated with Client Setup Guides table

## Key differences between clients

| Client | Config file | Top-level key | Env var syntax | URL field |
|--------|-------------|---------------|----------------|-----------|
| Claude Code | `.mcp.json` | `mcpServers` | `${VAR}` | `url` |
| Cursor | `.cursor/mcp.json` | `mcpServers` | `${env:VAR}` | `url` |
| VS Code | `.vscode/mcp.json` | `servers` | `${input:id}` | `url` |
| Gemini CLI | `.gemini/settings.json` | `mcpServers` | `$VAR` | `httpUrl` |

## Test plan
- [ ] Verify Claude Code config works with `.mcp.json`
- [ ] Verify Cursor config loads in `.cursor/mcp.json`
- [ ] Verify VS Code config with `servers` key (not `mcpServers`)
- [ ] Verify Gemini CLI uses `httpUrl` for Streamable HTTP
- [ ] Confirm ChatGPT guide clearly states OAuth 2.1 requirement
- [ ] Verify all README links resolve correctly