### PR TITLE
feat: SaaS Phase 3 — Self-Service API Key Management

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -117,9 +117,10 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
-    // API keys: no client access at all (sensitive auth material)
+    // API keys: read own keys for key management screen, no client writes
     match /keyIndex/{hash} {
-      allow read, write: if false;
+      allow read: if isAuth() && resource.data.userId == request.auth.uid;
+      allow write: if false;
     }
 
     // Default deny

--- a/firebase/functions/src/auth/keyManagement.ts
+++ b/firebase/functions/src/auth/keyManagement.ts
@@ -1,0 +1,129 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import * as crypto from "crypto";
+
+const db = admin.firestore();
+
+export const createUserKey = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "Authentication required"
+    );
+  }
+
+  const label = data.label || "API Key";
+  const userId = context.auth.uid;
+
+  const activeKeysSnapshot = await db
+    .collection("keyIndex")
+    .where("userId", "==", userId)
+    .where("active", "==", true)
+    .get();
+
+  if (activeKeysSnapshot.size >= 10) {
+    throw new functions.https.HttpsError(
+      "resource-exhausted",
+      "Maximum of 10 active keys per user"
+    );
+  }
+
+  const rawKey = `cb_${crypto.randomBytes(32).toString("hex")}`;
+  const keyHash = crypto.createHash("sha256").update(rawKey).digest("hex");
+
+  await db.collection("keyIndex").doc(keyHash).set({
+    userId,
+    programId: "default",
+    label,
+    capabilities: ["*"],
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    active: true,
+  });
+
+  return {
+    success: true,
+    key: rawKey,
+    keyHash,
+    label,
+  };
+});
+
+export const revokeUserKey = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "Authentication required"
+    );
+  }
+
+  if (!data.keyHash) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "keyHash is required"
+    );
+  }
+
+  const keyDoc = await db.collection("keyIndex").doc(data.keyHash).get();
+
+  if (!keyDoc.exists) {
+    throw new functions.https.HttpsError("not-found", "Key not found");
+  }
+
+  const keyData = keyDoc.data();
+  if (keyData?.userId !== context.auth.uid) {
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Not authorized to revoke this key"
+    );
+  }
+
+  await db.collection("keyIndex").doc(data.keyHash).update({
+    active: false,
+    revokedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  return {
+    success: true,
+    keyHash: data.keyHash,
+  };
+});
+
+export const updateKeyLabel = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError(
+      "unauthenticated",
+      "Authentication required"
+    );
+  }
+
+  if (!data.keyHash || !data.label) {
+    throw new functions.https.HttpsError(
+      "invalid-argument",
+      "keyHash and label are required"
+    );
+  }
+
+  const keyDoc = await db.collection("keyIndex").doc(data.keyHash).get();
+
+  if (!keyDoc.exists) {
+    throw new functions.https.HttpsError("not-found", "Key not found");
+  }
+
+  const keyData = keyDoc.data();
+  if (keyData?.userId !== context.auth.uid) {
+    throw new functions.https.HttpsError(
+      "permission-denied",
+      "Not authorized to update this key"
+    );
+  }
+
+  await db.collection("keyIndex").doc(data.keyHash).update({
+    label: data.label,
+  });
+
+  return {
+    success: true,
+    keyHash: data.keyHash,
+    label: data.label,
+  };
+});

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -5,6 +5,9 @@ admin.initializeApp();
 // Auth triggers
 export { onUserCreate } from "./auth/onUserCreate";
 
+// Key management (callable)
+export { createUserKey, revokeUserKey, updateKeyLabel } from "./auth/keyManagement";
+
 // Notification triggers (new collection paths)
 export { onTaskCreate } from "./notifications/onTaskCreate";
 export { onTaskUpdate } from "./notifications/onTaskUpdate";

--- a/mcp-server/src/modules/keys.ts
+++ b/mcp-server/src/modules/keys.ts
@@ -137,7 +137,7 @@ export async function listKeysHandler(auth: AuthContext, args: any) {
   const { includeRevoked } = args || {};
 
   // Query all apiKeys docs for this user
-  let query = db.collection("apiKeys").where("userId", "==", auth.userId);
+  let query = db.collection("keyIndex").where("userId", "==", auth.userId);
 
   const snapshot = await query.get();
 

--- a/mobile/src/components/KeyGenerationModal.tsx
+++ b/mobile/src/components/KeyGenerationModal.tsx
@@ -1,0 +1,311 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Modal,
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { theme } from '../theme';
+
+interface KeyGenerationModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onKeyCreated: () => void;
+}
+
+export function KeyGenerationModal({ visible, onClose, onKeyCreated }: KeyGenerationModalProps) {
+  const [label, setLabel] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetState = () => {
+    setLabel('');
+    setGeneratedKey(null);
+    setCopied(false);
+    setError(null);
+    setGenerating(false);
+  };
+
+  const handleClose = () => {
+    resetState();
+    onClose();
+  };
+
+  const handleDone = () => {
+    onKeyCreated();
+    resetState();
+    onClose();
+  };
+
+  const handleGenerate = async () => {
+    if (generating) return;
+
+    setGenerating(true);
+    setError(null);
+
+    try {
+      const functions = getFunctions();
+      const createKey = httpsCallable(functions, 'createUserKey');
+      const result = await createKey({ label: label.trim() || 'API Key' });
+      const data = result.data as { success: boolean; key: string; keyHash: string; label: string };
+
+      if (data.success && data.key) {
+        setGeneratedKey(data.key);
+      } else {
+        setError('Failed to generate key');
+      }
+    } catch (err: any) {
+      setError(err.message || 'Failed to generate key');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!generatedKey) return;
+
+    try {
+      await Clipboard.setStringAsync(generatedKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 3000);
+    } catch (err) {
+      setError('Failed to copy to clipboard');
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="pageSheet"
+      visible={visible}
+      onRequestClose={handleClose}
+    >
+      <View style={styles.container}>
+        <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+          {!generatedKey ? (
+            // Phase 1: Input
+            <View style={styles.content}>
+              <Text style={styles.header}>Generate New Key</Text>
+
+              <TextInput
+                style={styles.input}
+                placeholder="API Key"
+                placeholderTextColor={theme.colors.textMuted}
+                value={label}
+                onChangeText={setLabel}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+
+              {error && (
+                <Text style={styles.errorText}>{error}</Text>
+              )}
+
+              <TouchableOpacity
+                style={[styles.button, styles.primaryButton, generating && styles.buttonDisabled]}
+                onPress={handleGenerate}
+                disabled={generating}
+              >
+                {generating ? (
+                  <ActivityIndicator color={theme.colors.background} />
+                ) : (
+                  <Text style={styles.buttonText}>Generate</Text>
+                )}
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.textButton}
+                onPress={handleClose}
+              >
+                <Text style={styles.textButtonLabel}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            // Phase 2: Key display
+            <View style={styles.content}>
+              <Text style={styles.header}>Your New API Key</Text>
+
+              <Text style={styles.warningText}>
+                Save this key now. You won't see it again.
+              </Text>
+
+              <View style={styles.keyContainer}>
+                <Text style={styles.keyText} selectable>
+                  {generatedKey}
+                </Text>
+              </View>
+
+              <TouchableOpacity
+                style={[styles.button, copied ? styles.successButton : styles.primaryButton]}
+                onPress={handleCopy}
+              >
+                <Text style={styles.buttonText}>
+                  {copied ? 'Copied!' : 'Copy to Clipboard'}
+                </Text>
+              </TouchableOpacity>
+
+              <View style={styles.configContainer}>
+                <Text style={styles.configLabel}>MCP Configuration:</Text>
+                <View style={styles.configBox}>
+                  <Text style={styles.configText} selectable>
+{`{
+  "mcpServers": {
+    "cachebash": {
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_KEY_HERE"
+      }
+    }
+  }
+}`}
+                  </Text>
+                </View>
+              </View>
+
+              <TouchableOpacity
+                style={[styles.button, styles.secondaryButton]}
+                onPress={handleDone}
+              >
+                <Text style={styles.secondaryButtonText}>Done</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  content: {
+    flex: 1,
+    padding: theme.spacing.lg,
+  },
+  header: {
+    fontSize: theme.fontSize.xxl,
+    fontWeight: '700',
+    color: theme.colors.text,
+    marginBottom: theme.spacing.lg,
+    textAlign: 'center',
+  },
+  input: {
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+    color: theme.colors.text,
+    fontSize: theme.fontSize.md,
+    marginBottom: theme.spacing.md,
+  },
+  errorText: {
+    color: theme.colors.error,
+    fontSize: theme.fontSize.sm,
+    marginBottom: theme.spacing.md,
+    textAlign: 'center',
+  },
+  warningText: {
+    color: theme.colors.warning,
+    fontSize: theme.fontSize.md,
+    marginBottom: theme.spacing.lg,
+    textAlign: 'center',
+    fontWeight: '600',
+  },
+  keyContainer: {
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+    marginBottom: theme.spacing.lg,
+  },
+  keyText: {
+    fontFamily: 'monospace',
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.text,
+    lineHeight: 20,
+  },
+  configContainer: {
+    marginTop: theme.spacing.lg,
+    marginBottom: theme.spacing.lg,
+  },
+  configLabel: {
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.textSecondary,
+    marginBottom: theme.spacing.sm,
+    fontWeight: '600',
+  },
+  configBox: {
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+  },
+  configText: {
+    fontFamily: 'monospace',
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.text,
+    lineHeight: 16,
+  },
+  button: {
+    paddingVertical: theme.spacing.md,
+    paddingHorizontal: theme.spacing.lg,
+    borderRadius: theme.borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: theme.spacing.md,
+    minHeight: 50,
+  },
+  primaryButton: {
+    backgroundColor: theme.colors.primary,
+  },
+  successButton: {
+    backgroundColor: theme.colors.success,
+  },
+  secondaryButton: {
+    backgroundColor: 'transparent',
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    fontSize: theme.fontSize.md,
+    fontWeight: '600',
+    color: theme.colors.background,
+  },
+  secondaryButtonText: {
+    fontSize: theme.fontSize.md,
+    fontWeight: '600',
+    color: theme.colors.text,
+  },
+  textButton: {
+    paddingVertical: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  textButtonLabel: {
+    fontSize: theme.fontSize.md,
+    color: theme.colors.textSecondary,
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/navigation/index.tsx
+++ b/mobile/src/navigation/index.tsx
@@ -17,6 +17,7 @@ import SprintsScreen from '../screens/SprintsScreen';
 import SprintDetailScreen from '../screens/SprintDetailScreen';
 import FleetHealthScreen from '../screens/FleetHealthScreen';
 import UsageScreen from '../screens/UsageScreen';
+import KeyManagementScreen from '../screens/KeyManagementScreen';
 import ComposeMessageScreen from '../screens/ComposeMessageScreen';
 import { navigationRef } from '../utils/navigationRef';
 import { useTasks } from '../hooks/useTasks';
@@ -206,6 +207,7 @@ function SettingsStackScreen() {
     >
       <SettingsStack.Screen name="SettingsMain" component={SettingsScreen} options={{ title: 'Settings' }} />
       <SettingsStack.Screen name="Usage" component={UsageScreen} options={{ title: 'Usage' }} />
+      <SettingsStack.Screen name="KeyManagement" component={KeyManagementScreen} options={{ title: 'API Keys' }} />
     </SettingsStack.Navigator>
   );
 }

--- a/mobile/src/screens/KeyManagementScreen.tsx
+++ b/mobile/src/screens/KeyManagementScreen.tsx
@@ -1,0 +1,429 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  Alert,
+  TextInput,
+  RefreshControl,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
+import { collection, query, where, onSnapshot, orderBy } from 'firebase/firestore';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { db } from '../config/firebase';
+import { useAuth } from '../contexts/AuthContext';
+import { theme } from '../theme';
+import KeyGenerationModal from '../components/KeyGenerationModal';
+
+interface ApiKey {
+  keyHash: string;
+  label: string;
+  createdAt: any;
+  lastUsed: any;
+  active: boolean;
+}
+
+interface KeyManagementScreenProps {
+  route?: {
+    params?: {
+      openGenerateModal?: boolean;
+    };
+  };
+  navigation?: any;
+}
+
+const KeyManagementScreen: React.FC<KeyManagementScreenProps> = ({ route, navigation }) => {
+  const { user } = useAuth();
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [editingKeyHash, setEditingKeyHash] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState('');
+  const [showGenerateModal, setShowGenerateModal] = useState(false);
+
+  // Check for deep link param to open generate modal
+  useEffect(() => {
+    if (route?.params?.openGenerateModal) {
+      setShowGenerateModal(true);
+    }
+  }, [route?.params?.openGenerateModal]);
+
+  // Real-time listener for keys
+  useEffect(() => {
+    if (!user?.uid) {
+      setLoading(false);
+      return;
+    }
+
+    const q = query(
+      collection(db, 'keyIndex'),
+      where('userId', '==', user.uid),
+      where('active', '==', true)
+    );
+
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const keyData = snapshot.docs.map((doc) => ({
+          keyHash: doc.id,
+          ...doc.data(),
+        })) as ApiKey[];
+
+        // Sort client-side by createdAt descending
+        keyData.sort((a, b) => {
+          const aTime = a.createdAt?.toMillis?.() || 0;
+          const bTime = b.createdAt?.toMillis?.() || 0;
+          return bTime - aTime;
+        });
+
+        setKeys(keyData);
+        setLoading(false);
+        setRefreshing(false);
+      },
+      (error) => {
+        console.error('Error fetching keys:', error);
+        Alert.alert('Error', 'Failed to load API keys');
+        setLoading(false);
+        setRefreshing(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [user?.uid]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    // Real-time listener will update automatically
+    setTimeout(() => setRefreshing(false), 1000);
+  }, []);
+
+  const handleLabelEdit = useCallback(
+    async (keyHash: string) => {
+      if (!editLabel.trim()) {
+        Alert.alert('Error', 'Label cannot be empty');
+        return;
+      }
+
+      try {
+        const updateKeyLabel = httpsCallable(getFunctions(), 'updateKeyLabel');
+        await updateKeyLabel({ keyHash, label: editLabel.trim() });
+        setEditingKeyHash(null);
+        setEditLabel('');
+      } catch (error: any) {
+        console.error('Error updating label:', error);
+        Alert.alert('Error', error.message || 'Failed to update label');
+      }
+    },
+    [editLabel]
+  );
+
+  const handleRevoke = useCallback((keyHash: string, label: string) => {
+    Alert.alert(
+      'Revoke Key',
+      `This key will stop working immediately. Continue?\n\nKey: ${label}`,
+      [
+        {
+          text: 'Cancel',
+          style: 'cancel',
+        },
+        {
+          text: 'Revoke',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              const revokeUserKey = httpsCallable(getFunctions(), 'revokeUserKey');
+              await revokeUserKey({ keyHash });
+            } catch (error: any) {
+              console.error('Error revoking key:', error);
+              Alert.alert('Error', error.message || 'Failed to revoke key');
+            }
+          },
+        },
+      ]
+    );
+  }, []);
+
+  const formatDate = (timestamp: any): string => {
+    if (!timestamp) return 'Never';
+    const date = timestamp.toDate?.() || new Date(timestamp);
+    return date.toLocaleString();
+  };
+
+  const renderKeyCard = useCallback(
+    ({ item }: { item: ApiKey }) => {
+      const isEditing = editingKeyHash === item.keyHash;
+
+      return (
+        <View style={styles.keyCard}>
+          <View style={styles.keyHeader}>
+            <View style={styles.keyHashContainer}>
+              <Text style={styles.keyHash}>
+                {item.keyHash.substring(0, 8)}...
+              </Text>
+              <View style={styles.statusBadge}>
+                <Text style={styles.statusText}>Active</Text>
+              </View>
+            </View>
+          </View>
+
+          <View style={styles.keyInfo}>
+            <Text style={styles.infoLabel}>Label</Text>
+            {isEditing ? (
+              <View style={styles.editContainer}>
+                <TextInput
+                  style={styles.editInput}
+                  value={editLabel}
+                  onChangeText={setEditLabel}
+                  onSubmitEditing={() => handleLabelEdit(item.keyHash)}
+                  onBlur={() => handleLabelEdit(item.keyHash)}
+                  autoFocus
+                  placeholder="Enter label"
+                  placeholderTextColor={theme.colors.textMuted}
+                />
+              </View>
+            ) : (
+              <TouchableOpacity
+                onPress={() => {
+                  setEditingKeyHash(item.keyHash);
+                  setEditLabel(item.label);
+                }}
+              >
+                <Text style={styles.infoValue}>{item.label}</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+
+          <View style={styles.keyInfo}>
+            <Text style={styles.infoLabel}>Created</Text>
+            <Text style={styles.infoValue}>{formatDate(item.createdAt)}</Text>
+          </View>
+
+          <View style={styles.keyInfo}>
+            <Text style={styles.infoLabel}>Last Used</Text>
+            <Text style={styles.infoValue}>
+              {item.lastUsed ? formatDate(item.lastUsed) : 'Never used'}
+            </Text>
+          </View>
+
+          <TouchableOpacity
+            style={styles.revokeButton}
+            onPress={() => handleRevoke(item.keyHash, item.label)}
+          >
+            <Text style={styles.revokeButtonText}>Revoke Key</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    },
+    [editingKeyHash, editLabel, handleLabelEdit, handleRevoke]
+  );
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyState}>
+      <Text style={styles.emptyTitle}>No API keys yet.</Text>
+      <Text style={styles.emptySubtitle}>
+        Generate one to connect your tools.
+      </Text>
+      <TouchableOpacity
+        style={styles.generateButton}
+        onPress={() => setShowGenerateModal(true)}
+      >
+        <Text style={styles.generateButtonText}>Generate Key</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>API Keys</Text>
+        <TouchableOpacity
+          style={styles.headerButton}
+          onPress={() => setShowGenerateModal(true)}
+        >
+          <Text style={styles.headerButtonText}>+ New Key</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={keys}
+        renderItem={renderKeyCard}
+        keyExtractor={(item) => item.keyHash}
+        contentContainerStyle={[
+          styles.listContent,
+          keys.length === 0 && styles.listContentEmpty,
+        ]}
+        ListEmptyComponent={renderEmptyState}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={theme.colors.primary}
+          />
+        }
+      />
+
+      <KeyGenerationModal
+        visible={showGenerateModal}
+        onClose={() => setShowGenerateModal(false)}
+        onKeyCreated={() => {
+          // Listener auto-updates
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+  },
+  title: {
+    fontSize: theme.fontSize.xl,
+    fontWeight: '700',
+    color: theme.colors.text,
+  },
+  headerButton: {
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.md,
+  },
+  headerButtonText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: '600',
+    color: theme.colors.background,
+  },
+  listContent: {
+    padding: theme.spacing.md,
+  },
+  listContentEmpty: {
+    flexGrow: 1,
+  },
+  keyCard: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.lg,
+    padding: theme.spacing.md,
+    marginBottom: theme.spacing.md,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  keyHeader: {
+    marginBottom: theme.spacing.md,
+  },
+  keyHashContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  keyHash: {
+    fontSize: theme.fontSize.md,
+    fontFamily: 'Menlo',
+    color: theme.colors.primary,
+    fontWeight: '600',
+  },
+  statusBadge: {
+    backgroundColor: theme.colors.success,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xxs,
+    borderRadius: theme.borderRadius.sm,
+  },
+  statusText: {
+    fontSize: theme.fontSize.xs,
+    fontWeight: '600',
+    color: theme.colors.background,
+  },
+  keyInfo: {
+    marginBottom: theme.spacing.sm,
+  },
+  infoLabel: {
+    fontSize: theme.fontSize.xs,
+    color: theme.colors.textMuted,
+    marginBottom: theme.spacing.xxs,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  infoValue: {
+    fontSize: theme.fontSize.md,
+    color: theme.colors.text,
+  },
+  editContainer: {
+    marginTop: theme.spacing.xxs,
+  },
+  editInput: {
+    backgroundColor: theme.colors.surfaceElevated,
+    borderRadius: theme.borderRadius.sm,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+    fontSize: theme.fontSize.md,
+    color: theme.colors.text,
+    borderWidth: 1,
+    borderColor: theme.colors.primary,
+  },
+  revokeButton: {
+    marginTop: theme.spacing.sm,
+    paddingVertical: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  revokeButtonText: {
+    fontSize: theme.fontSize.sm,
+    fontWeight: '600',
+    color: theme.colors.error,
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: theme.spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: theme.fontSize.xl,
+    fontWeight: '700',
+    color: theme.colors.text,
+    marginBottom: theme.spacing.sm,
+  },
+  emptySubtitle: {
+    fontSize: theme.fontSize.md,
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
+    marginBottom: theme.spacing.lg,
+  },
+  generateButton: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.md,
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.md,
+  },
+  generateButtonText: {
+    fontSize: theme.fontSize.md,
+    fontWeight: '600',
+    color: theme.colors.background,
+  },
+});
+
+export default KeyManagementScreen;


### PR DESCRIPTION
## Summary
- **Fix `list_keys` bug** — queried wrong collection (`apiKeys` instead of `keyIndex`)
- **KeyManagementScreen** — real-time Firestore listener, inline label editing, revoke with confirmation
- **KeyGenerationModal** — generate key via Cloud Function, one-time display, copy to clipboard + MCP config
- **3 Callable Cloud Functions** — `createUserKey` (max 10 active), `revokeUserKey`, `updateKeyLabel`
- **Settings integration** — "API Keys" section with active key count, navigates to management screen
- **Firestore rules** — allow authenticated read on `keyIndex` where `userId == auth.uid`

## Stories
| # | Story | Files |
|---|-------|-------|
| S1 | Fix listKeysHandler collection path bug | `mcp-server/src/modules/keys.ts` |
| S2 | KeyManagementScreen | `mobile/src/screens/KeyManagementScreen.tsx` |
| S3 | Key Generation Modal | `mobile/src/components/KeyGenerationModal.tsx` |
| S4 | Key Management Cloud Functions | `firebase/functions/src/auth/keyManagement.ts`, `firebase/functions/src/index.ts` |
| S5 | Navigation + Settings integration | `mobile/src/screens/SettingsScreen.tsx`, `mobile/src/navigation/index.tsx` |

## Build Verification
- `firebase/functions`: `tsc` — exit 0
- `mcp-server`: `tsc` — exit 0
- `mobile`: `npx expo export --platform ios` — 1075 modules bundled, exit 0

## Test Plan
- [ ] `list_keys` MCP tool returns actual keys (not empty)
- [ ] Settings → API Keys shows active key count
- [ ] Key list displays with real-time updates
- [ ] Tap label → inline edit → Cloud Function updates
- [ ] Revoke → confirmation → key disappears from list
- [ ] Generate new key → one-time display → copy works
- [ ] Max 10 key limit enforced
- [ ] Revoked keys immediately fail MCP auth
- [ ] Existing MCP `create_key`/`revoke_key` tools unaffected

Closes #111