### PR TITLE
feat: Phase 6 — Mobile Onboarding + Empty States

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,8 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
+import { OnboardingProvider, useOnboarding } from './src/contexts/OnboardingContext';
 import { NotificationProvider } from './src/contexts/NotificationContext';
 import { ConnectivityProvider } from './src/contexts/ConnectivityContext';
+import OnboardingNavigator from './src/navigation/OnboardingNavigator';
 import ConnectionBanner from './src/components/ConnectionBanner';
 import AppNavigation from './src/navigation';
 import SignInScreen from './src/screens/SignInScreen';
@@ -48,6 +50,24 @@ function AppContent() {
 
   if (showFirstKey) {
     return <FirstKeyScreen onComplete={() => setShowFirstKey(false)} />;
+  }
+
+  return (
+    <OnboardingProvider>
+      <AppContentWithOnboarding />
+    </OnboardingProvider>
+  );
+}
+
+function AppContentWithOnboarding() {
+  const { isFirstRun, isLoading } = useOnboarding();
+
+  if (isLoading) {
+    return <LoadingScreen />;
+  }
+
+  if (isFirstRun) {
+    return <OnboardingNavigator />;
   }
 
   return (

--- a/mobile/src/components/EmptyState.tsx
+++ b/mobile/src/components/EmptyState.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+interface EmptyStateProps {
+  icon: string;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  onCta?: () => void;
+}
+
+export default function EmptyState({ icon, title, description, ctaLabel, onCta }: EmptyStateProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconCircle}>
+        <Text style={styles.icon}>{icon}</Text>
+      </View>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+      {ctaLabel && onCta && (
+        <TouchableOpacity style={styles.cta} onPress={onCta}>
+          <Text style={styles.ctaText}>{ctaLabel}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1, alignItems: 'center', justifyContent: 'center',
+    paddingHorizontal: 40, paddingVertical: 60,
+  },
+  iconCircle: {
+    width: 64, height: 64, borderRadius: 32,
+    backgroundColor: 'rgba(107, 114, 128, 0.1)',
+    borderWidth: 1, borderColor: 'rgba(107, 114, 128, 0.2)',
+    alignItems: 'center', justifyContent: 'center', marginBottom: 20,
+  },
+  icon: { fontSize: 28 },
+  title: { fontSize: 18, fontWeight: '600', color: '#f0f0f5', textAlign: 'center', marginBottom: 8 },
+  description: { fontSize: 14, color: '#6b7280', textAlign: 'center', lineHeight: 20, marginBottom: 20 },
+  cta: {
+    backgroundColor: 'rgba(0, 212, 255, 0.1)', borderRadius: 8,
+    paddingVertical: 10, paddingHorizontal: 20,
+    borderWidth: 1, borderColor: 'rgba(0, 212, 255, 0.3)',
+  },
+  ctaText: { fontSize: 14, fontWeight: '600', color: '#00d4ff' },
+});

--- a/mobile/src/contexts/OnboardingContext.tsx
+++ b/mobile/src/contexts/OnboardingContext.tsx
@@ -1,0 +1,146 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '../config/firebase';
+import { useAuth } from './AuthContext';
+
+type OnboardingStep = 'welcome' | 'connect-agent' | 'first-task' | 'completion';
+
+interface OnboardingState {
+  isFirstRun: boolean;
+  isLoading: boolean;
+  currentStep: OnboardingStep;
+  completedSteps: OnboardingStep[];
+}
+
+interface OnboardingContextType extends OnboardingState {
+  completeStep: (step: OnboardingStep) => Promise<void>;
+  skipOnboarding: () => Promise<void>;
+  goToStep: (step: OnboardingStep) => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextType | undefined>(undefined);
+
+const STEPS: OnboardingStep[] = ['welcome', 'connect-agent', 'first-task', 'completion'];
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const { user, isAuthenticated } = useAuth();
+  const [isFirstRun, setIsFirstRun] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>('welcome');
+  const [completedSteps, setCompletedSteps] = useState<OnboardingStep[]>([]);
+
+  useEffect(() => {
+    async function checkOnboarding() {
+      if (!isAuthenticated || !user) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const onboardingDoc = await getDoc(doc(db, `tenants/${user.uid}/config/onboarding`));
+        if (onboardingDoc.exists()) {
+          const data = onboardingDoc.data();
+          if (data.completed) {
+            setIsFirstRun(false);
+          } else {
+            setIsFirstRun(true);
+            setCompletedSteps(data.completedSteps || []);
+            // Resume from last incomplete step
+            const lastCompleted = data.completedSteps || [];
+            const nextStep = STEPS.find(s => !lastCompleted.includes(s)) || 'welcome';
+            setCurrentStep(nextStep);
+          }
+        } else {
+          // No onboarding doc = first run
+          setIsFirstRun(true);
+        }
+      } catch (error) {
+        console.error('Failed to check onboarding status:', error);
+        setIsFirstRun(false); // Fail safe — don't block app
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    checkOnboarding();
+  }, [isAuthenticated, user]);
+
+  const completeStep = useCallback(async (step: OnboardingStep) => {
+    if (!user) return;
+
+    const newCompleted = [...completedSteps, step];
+    setCompletedSteps(newCompleted);
+
+    const stepIndex = STEPS.indexOf(step);
+    const nextStep = STEPS[stepIndex + 1];
+
+    if (nextStep) {
+      setCurrentStep(nextStep);
+    }
+
+    // Check if all steps done
+    const allDone = STEPS.every(s => newCompleted.includes(s));
+
+    try {
+      await setDoc(doc(db, `tenants/${user.uid}/config/onboarding`), {
+        completedSteps: newCompleted,
+        completed: allDone,
+        completedAt: allDone ? new Date().toISOString() : null,
+        updatedAt: new Date().toISOString(),
+      }, { merge: true });
+
+      if (allDone) {
+        setIsFirstRun(false);
+      }
+    } catch (error) {
+      console.error('Failed to save onboarding progress:', error);
+    }
+  }, [user, completedSteps]);
+
+  const skipOnboarding = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      await setDoc(doc(db, `tenants/${user.uid}/config/onboarding`), {
+        completed: true,
+        skipped: true,
+        completedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }, { merge: true });
+    } catch (error) {
+      console.error('Failed to skip onboarding:', error);
+    }
+
+    setIsFirstRun(false);
+  }, [user]);
+
+  const goToStep = useCallback((step: OnboardingStep) => {
+    setCurrentStep(step);
+  }, []);
+
+  return (
+    <OnboardingContext.Provider
+      value={{
+        isFirstRun,
+        isLoading,
+        currentStep,
+        completedSteps,
+        completeStep,
+        skipOnboarding,
+        goToStep,
+      }}
+    >
+      {children}
+    </OnboardingContext.Provider>
+  );
+}
+
+export function useOnboarding(): OnboardingContextType {
+  const context = useContext(OnboardingContext);
+  if (!context) {
+    throw new Error('useOnboarding must be used within an OnboardingProvider');
+  }
+  return context;
+}
+
+export type { OnboardingStep };

--- a/mobile/src/hooks/useOnboarding.ts
+++ b/mobile/src/hooks/useOnboarding.ts
@@ -1,0 +1,2 @@
+export { useOnboarding } from '../contexts/OnboardingContext';
+export type { OnboardingStep } from '../contexts/OnboardingContext';

--- a/mobile/src/navigation/OnboardingNavigator.tsx
+++ b/mobile/src/navigation/OnboardingNavigator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NavigationContainer } from '@react-navigation/native';
+import { navigationRef } from '../utils/navigationRef';
+import WelcomeScreen from '../screens/onboarding/WelcomeScreen';
+import ConnectAgentScreen from '../screens/onboarding/ConnectAgentScreen';
+import FirstTaskScreen from '../screens/onboarding/FirstTaskScreen';
+import CompletionScreen from '../screens/onboarding/CompletionScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function OnboardingNavigator() {
+  return (
+    <NavigationContainer ref={navigationRef}>
+      <Stack.Navigator
+        screenOptions={{
+          headerShown: false,
+          animation: 'slide_from_right',
+          contentStyle: { backgroundColor: '#0a0a0f' },
+        }}
+      >
+        <Stack.Screen name="Welcome" component={WelcomeScreen} />
+        <Stack.Screen name="ConnectAgent" component={ConnectAgentScreen} />
+        <Stack.Screen name="FirstTask" component={FirstTaskScreen} />
+        <Stack.Screen name="Completion" component={CompletionScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -21,6 +21,7 @@ import { theme } from '../theme';
 import type { Program } from '../types';
 import { timeAgo, getStateColor, getStatusColor, getMessageTypeColor } from '../utils';
 import { haptic } from '../utils/haptics';
+import EmptyState from '../components/EmptyState';
 
 // Enable LayoutAnimation on Android
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -154,6 +155,15 @@ export default function HomeScreen({ navigation }: Props) {
           </View>
         )}
 
+        {/* Empty State when no sessions and programs */}
+        {!isLoading && sessions.length === 0 && programs.length === 0 ? (
+          <EmptyState
+            icon="📡"
+            title="No Active Sessions"
+            description="Connect an agent from your IDE to see it appear here. Run npx cachebash init to get started."
+          />
+        ) : (
+          <>
         {/* Expandable Stat Cards */}
         <View style={styles.statsColumn}>
 
@@ -435,6 +445,10 @@ export default function HomeScreen({ navigation }: Props) {
         </View>
 
         {/* Pending Questions */}
+        </>
+        )}
+
+        {/* Questions Section (shown regardless of empty state) */}
         {pendingQuestions.length > 0 && (
           <View style={styles.section}>
             <View style={styles.sectionHeaderRow}>

--- a/mobile/src/screens/MessagesScreen.tsx
+++ b/mobile/src/screens/MessagesScreen.tsx
@@ -6,6 +6,7 @@ import { theme } from '../theme';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RelayMessage, RelayMessageType } from '../types';
 import { timeAgo, getMessageTypeColor, haptic } from '../utils';
+import EmptyState from '../components/EmptyState';
 
 type MessagesScreenProps = {
   navigation: NativeStackNavigationProp<any>;
@@ -137,10 +138,11 @@ export default function MessagesScreen({ navigation }: MessagesScreenProps) {
   if (messages.length === 0 && !isLoading) {
     return (
       <View style={styles.container}>
-        <View style={styles.emptyState}>
-          <Text style={styles.emptyText}>◈ No messages yet</Text>
-          <Text style={styles.emptyHintText}>Pull down to refresh</Text>
-        </View>
+        <EmptyState
+          icon="💬"
+          title="No Messages Yet"
+          description="Messages from your connected agents will appear here."
+        />
       </View>
     );
   }

--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -6,6 +6,7 @@ import { Task } from '../types';
 import { theme } from '../theme';
 import { timeAgo, getStatusColor } from '../utils';
 import { haptic } from '../utils/haptics';
+import EmptyState from '../components/EmptyState';
 
 type Props = NativeStackScreenProps<any, 'Tasks'>;
 
@@ -119,10 +120,13 @@ export default function TasksScreen({ navigation }: Props) {
       );
     }
     return (
-      <View style={styles.emptyState}>
-        <Text style={styles.emptyStateText}>☰ No tasks found</Text>
-        <Text style={styles.emptyHintText}>Pull down to refresh</Text>
-      </View>
+      <EmptyState
+        icon="📋"
+        title="No Tasks Yet"
+        description="Create your first task to coordinate your AI agents."
+        ctaLabel="Create Task"
+        onCta={() => navigation.navigate('CreateTask')}
+      />
     );
   };
 

--- a/mobile/src/screens/onboarding/CompletionScreen.tsx
+++ b/mobile/src/screens/onboarding/CompletionScreen.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useOnboarding } from '../../contexts/OnboardingContext';
+
+type Props = {
+  navigation: any;
+};
+
+export default function CompletionScreen({ navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { completeStep } = useOnboarding();
+
+  const handleFinish = async () => {
+    await completeStep('completion');
+  };
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 60 }]}>
+      <View style={styles.content}>
+        <View style={styles.iconCircle}>
+          <Text style={styles.icon}>🎉</Text>
+        </View>
+        <Text style={styles.title}>You're All Set!</Text>
+        <Text style={styles.subtitle}>
+          CacheBash is ready to coordinate your AI agents.
+        </Text>
+
+        <View style={styles.tips}>
+          <View style={styles.tip}>
+            <Text style={styles.tipBullet}>→</Text>
+            <Text style={styles.tipText}>View agent sessions on the Home tab</Text>
+          </View>
+          <View style={styles.tip}>
+            <Text style={styles.tipBullet}>→</Text>
+            <Text style={styles.tipText}>Send tasks from the Tasks tab</Text>
+          </View>
+          <View style={styles.tip}>
+            <Text style={styles.tipBullet}>→</Text>
+            <Text style={styles.tipText}>Monitor agent messages in real-time</Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + 20 }]}>
+        <TouchableOpacity style={styles.primaryButton} onPress={handleFinish}>
+          <Text style={styles.primaryButtonText}>Go to Dashboard</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0a0a0f' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 },
+  iconCircle: {
+    width: 80, height: 80, borderRadius: 40,
+    backgroundColor: 'rgba(34, 197, 94, 0.1)',
+    borderWidth: 1, borderColor: 'rgba(34, 197, 94, 0.3)',
+    alignItems: 'center', justifyContent: 'center', marginBottom: 32,
+  },
+  icon: { fontSize: 36 },
+  title: { fontSize: 28, fontWeight: '700', color: '#f0f0f5', textAlign: 'center', marginBottom: 12 },
+  subtitle: { fontSize: 16, color: '#9ca3af', textAlign: 'center', lineHeight: 24, marginBottom: 32 },
+  tips: { alignSelf: 'stretch' },
+  tip: { flexDirection: 'row', alignItems: 'center', marginBottom: 12, paddingHorizontal: 8 },
+  tipBullet: { fontSize: 16, color: '#00d4ff', marginRight: 12 },
+  tipText: { fontSize: 15, color: '#d1d5db' },
+  footer: { paddingHorizontal: 32 },
+  primaryButton: {
+    backgroundColor: '#00d4ff', borderRadius: 12, paddingVertical: 16,
+    alignItems: 'center',
+  },
+  primaryButtonText: { fontSize: 17, fontWeight: '600', color: '#0a0a0f' },
+});

--- a/mobile/src/screens/onboarding/ConnectAgentScreen.tsx
+++ b/mobile/src/screens/onboarding/ConnectAgentScreen.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as Clipboard from 'expo-clipboard';
+import { useOnboarding } from '../../contexts/OnboardingContext';
+
+type Props = {
+  navigation: any;
+};
+
+export default function ConnectAgentScreen({ navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { completeStep, skipOnboarding } = useOnboarding();
+  const [copied, setCopied] = useState(false);
+
+  const command = 'npx cachebash init';
+
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleContinue = async () => {
+    await completeStep('connect-agent');
+    navigation.navigate('FirstTask');
+  };
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 40 }]}>
+      <View style={styles.content}>
+        <Text style={styles.stepLabel}>Step 1 of 2</Text>
+        <Text style={styles.title}>Connect Your IDE</Text>
+        <Text style={styles.subtitle}>
+          Run this command in your terminal to connect Claude Code, Cursor, or VS Code:
+        </Text>
+
+        <TouchableOpacity style={styles.codeBlock} onPress={handleCopy} activeOpacity={0.7}>
+          <Text style={styles.codeText}>{command}</Text>
+          <Text style={styles.copyHint}>{copied ? 'Copied!' : 'Tap to copy'}</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.hint}>
+          The CLI will open your browser to authenticate, then automatically configure your IDE.
+        </Text>
+      </View>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + 20 }]}>
+        <TouchableOpacity style={styles.primaryButton} onPress={handleContinue}>
+          <Text style={styles.primaryButtonText}>I've Connected</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.secondaryButton} onPress={handleContinue}>
+          <Text style={styles.secondaryText}>I'll do this later</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.skipButton} onPress={skipOnboarding}>
+          <Text style={styles.skipText}>Skip setup</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0a0a0f' },
+  content: { flex: 1, paddingHorizontal: 32 },
+  stepLabel: { fontSize: 13, fontWeight: '600', color: '#00d4ff', marginBottom: 8, textTransform: 'uppercase', letterSpacing: 1 },
+  title: { fontSize: 26, fontWeight: '700', color: '#f0f0f5', marginBottom: 12 },
+  subtitle: { fontSize: 16, color: '#9ca3af', lineHeight: 24, marginBottom: 24 },
+  codeBlock: {
+    backgroundColor: '#1a1a2e', borderRadius: 12, padding: 20,
+    borderWidth: 1, borderColor: '#2a2a3e', marginBottom: 16,
+  },
+  codeText: { fontSize: 18, fontWeight: '600', color: '#00d4ff', fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace' },
+  copyHint: { fontSize: 12, color: '#6b7280', marginTop: 8 },
+  hint: { fontSize: 14, color: '#6b7280', lineHeight: 20 },
+  footer: { paddingHorizontal: 32 },
+  primaryButton: {
+    backgroundColor: '#00d4ff', borderRadius: 12, paddingVertical: 16,
+    alignItems: 'center', marginBottom: 12,
+  },
+  primaryButtonText: { fontSize: 17, fontWeight: '600', color: '#0a0a0f' },
+  secondaryButton: { alignItems: 'center', paddingVertical: 10, marginBottom: 8 },
+  secondaryText: { fontSize: 15, color: '#9ca3af' },
+  skipButton: { alignItems: 'center', paddingVertical: 8 },
+  skipText: { fontSize: 14, color: '#4b5563' },
+});

--- a/mobile/src/screens/onboarding/FirstTaskScreen.tsx
+++ b/mobile/src/screens/onboarding/FirstTaskScreen.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useOnboarding } from '../../contexts/OnboardingContext';
+import { useAuth } from '../../contexts/AuthContext';
+
+type Props = {
+  navigation: any;
+};
+
+export default function FirstTaskScreen({ navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { completeStep, skipOnboarding } = useOnboarding();
+  const { api } = useAuth();
+  const [title, setTitle] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const handleSendTask = async () => {
+    if (!title.trim() || !api) return;
+
+    setSending(true);
+    try {
+      await api.createTask({
+        title: title.trim(),
+        target: 'all',
+        instructions: title.trim(),
+      });
+      await completeStep('first-task');
+      navigation.navigate('Completion');
+    } catch (error) {
+      console.error('Failed to create task:', error);
+      // Still advance — don't block onboarding
+      await completeStep('first-task');
+      navigation.navigate('Completion');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleSkipStep = async () => {
+    await completeStep('first-task');
+    navigation.navigate('Completion');
+  };
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 40 }]}>
+      <View style={styles.content}>
+        <Text style={styles.stepLabel}>Step 2 of 2</Text>
+        <Text style={styles.title}>Send Your First Task</Text>
+        <Text style={styles.subtitle}>
+          Create a task that your connected agents can pick up. Try something simple:
+        </Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder='e.g., "Run the test suite and report results"'
+          placeholderTextColor="#4b5563"
+          value={title}
+          onChangeText={setTitle}
+          multiline
+          maxLength={200}
+          autoFocus
+        />
+
+        <Text style={styles.hint}>
+          Tasks are delivered to all connected agents via MCP.
+        </Text>
+      </View>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + 20 }]}>
+        <TouchableOpacity
+          style={[styles.primaryButton, (!title.trim() || sending) && styles.primaryButtonDisabled]}
+          onPress={handleSendTask}
+          disabled={!title.trim() || sending}
+        >
+          {sending ? (
+            <ActivityIndicator color="#0a0a0f" />
+          ) : (
+            <Text style={styles.primaryButtonText}>Send Task</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.secondaryButton} onPress={handleSkipStep}>
+          <Text style={styles.secondaryText}>Skip for now</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.skipButton} onPress={skipOnboarding}>
+          <Text style={styles.skipText}>Skip setup</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0a0a0f' },
+  content: { flex: 1, paddingHorizontal: 32 },
+  stepLabel: { fontSize: 13, fontWeight: '600', color: '#00d4ff', marginBottom: 8, textTransform: 'uppercase', letterSpacing: 1 },
+  title: { fontSize: 26, fontWeight: '700', color: '#f0f0f5', marginBottom: 12 },
+  subtitle: { fontSize: 16, color: '#9ca3af', lineHeight: 24, marginBottom: 24 },
+  input: {
+    backgroundColor: '#1a1a2e', borderRadius: 12, padding: 16,
+    borderWidth: 1, borderColor: '#2a2a3e',
+    color: '#f0f0f5', fontSize: 16, minHeight: 80,
+    textAlignVertical: 'top', marginBottom: 12,
+  },
+  hint: { fontSize: 14, color: '#6b7280', lineHeight: 20 },
+  footer: { paddingHorizontal: 32 },
+  primaryButton: {
+    backgroundColor: '#00d4ff', borderRadius: 12, paddingVertical: 16,
+    alignItems: 'center', marginBottom: 12,
+  },
+  primaryButtonDisabled: { opacity: 0.5 },
+  primaryButtonText: { fontSize: 17, fontWeight: '600', color: '#0a0a0f' },
+  secondaryButton: { alignItems: 'center', paddingVertical: 10, marginBottom: 8 },
+  secondaryText: { fontSize: 15, color: '#9ca3af' },
+  skipButton: { alignItems: 'center', paddingVertical: 8 },
+  skipText: { fontSize: 14, color: '#4b5563' },
+});

--- a/mobile/src/screens/onboarding/WelcomeScreen.tsx
+++ b/mobile/src/screens/onboarding/WelcomeScreen.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useOnboarding } from '../../contexts/OnboardingContext';
+
+type Props = {
+  navigation: any;
+};
+
+export default function WelcomeScreen({ navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { completeStep, skipOnboarding } = useOnboarding();
+
+  const handleContinue = async () => {
+    await completeStep('welcome');
+    navigation.navigate('ConnectAgent');
+  };
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 60 }]}>
+      <View style={styles.content}>
+        <View style={styles.iconCircle}>
+          <Text style={styles.icon}>⚡</Text>
+        </View>
+        <Text style={styles.title}>Welcome to CacheBash</Text>
+        <Text style={styles.subtitle}>
+          Coordinate AI agents across any MCP-compatible IDE.{'\n'}
+          Let's get you set up in under a minute.
+        </Text>
+      </View>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + 20 }]}>
+        <TouchableOpacity style={styles.primaryButton} onPress={handleContinue}>
+          <Text style={styles.primaryButtonText}>Get Started</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.skipButton} onPress={skipOnboarding}>
+          <Text style={styles.skipText}>Skip setup</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#0a0a0f' },
+  content: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32 },
+  iconCircle: {
+    width: 80, height: 80, borderRadius: 40,
+    backgroundColor: 'rgba(0, 212, 255, 0.1)',
+    borderWidth: 1, borderColor: 'rgba(0, 212, 255, 0.3)',
+    alignItems: 'center', justifyContent: 'center', marginBottom: 32,
+  },
+  icon: { fontSize: 36 },
+  title: { fontSize: 28, fontWeight: '700', color: '#f0f0f5', textAlign: 'center', marginBottom: 12 },
+  subtitle: { fontSize: 16, color: '#9ca3af', textAlign: 'center', lineHeight: 24 },
+  footer: { paddingHorizontal: 32 },
+  primaryButton: {
+    backgroundColor: '#00d4ff', borderRadius: 12, paddingVertical: 16,
+    alignItems: 'center', marginBottom: 12,
+  },
+  primaryButtonText: { fontSize: 17, fontWeight: '600', color: '#0a0a0f' },
+  skipButton: { alignItems: 'center', paddingVertical: 12 },
+  skipText: { fontSize: 15, color: '#6b7280' },
+});


### PR DESCRIPTION
## Summary
- **OnboardingContext**: Firestore-persisted onboarding state (`tenants/{uid}/config/onboarding`), step tracking, skip/resume support
- **Guided tour**: 4-screen flow — Welcome → Connect Agent (`npx cachebash init` with copy) → First Task (creates via API) → Completion
- **OnboardingNavigator**: Stack navigator with slide animations, integrated into App.tsx after auth
- **EmptyState component**: Reusable with icon, title, description, optional CTA button
- **Empty states**: HomeScreen (no sessions), TasksScreen (no tasks + Create CTA), MessagesScreen (no messages)

## Chunks
1. OnboardingContext + useOnboarding hook (2 files)
2. Guided tour screens + navigator (5 files)
3. EmptyState component + screen modifications (4 files)

## Test plan
- [x] TypeScript compiles (no new errors beyond pre-existing)
- [x] All 12 files staged correctly
- [ ] Manual: new user sees guided tour on first login
- [ ] Manual: skip button works at every step
- [ ] Manual: tour completion persists across app restarts
- [ ] Manual: empty states show on Home/Tasks/Messages when data is empty
- [ ] Manual: empty states disappear when data arrives