### PR TITLE
fix: track firebase.ts for EAS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ dist/
 *.log
 .DS_Store
 
-# Firebase config with real credentials
-mobile/src/config/firebase.ts
+# Firebase native config (generated, platform-specific)
 **/google-services.json
 **/GoogleService-Info.plist
 

--- a/mobile/src/config/firebase.ts
+++ b/mobile/src/config/firebase.ts
@@ -1,0 +1,31 @@
+/**
+ * Firebase Configuration
+ * Expo Go compatible using Firebase JS SDK v11
+ */
+
+import { initializeApp } from 'firebase/app';
+import { initializeAuth, getReactNativePersistence } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyChgdJSsv0__YpYBdIOzPvSFMwPgwMZFak",
+  authDomain: "cachebash-app.firebaseapp.com",
+  projectId: "cachebash-app",
+  storageBucket: "cachebash-app.firebasestorage.app",
+  messagingSenderId: "922749444863",
+  appId: "1:922749444863:web:db02ac6cfc0769aa3c62ca",
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+
+// Initialize Auth with React Native persistence
+const auth = initializeAuth(app, {
+  persistence: getReactNativePersistence(AsyncStorage),
+});
+
+// Initialize Firestore
+const db = getFirestore(app);
+
+export { app, auth, db };


### PR DESCRIPTION
## Summary
- Removed `mobile/src/config/firebase.ts` from `.gitignore` — Firebase web SDK config contains public client identifiers, not secrets
- EAS cloud builds were failing because they build from git and the file was missing
- Four consecutive builds failed with `Error: Unable to resolve module ./src/config/firebase`

## Context
Firebase web API keys are designed to be public (embedded in every compiled client). Security is enforced via Firebase Security Rules and App Check, not by hiding the key. Google's documentation confirms these are safe to expose.

## Test plan
- [ ] `git check-ignore mobile/src/config/firebase.ts` returns exit 1 (not ignored)
- [ ] EAS build completes successfully
- [ ] TestFlight build submitted to App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)