### PR TITLE
chore: prep CLI for npm publish

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,54 @@
+# cachebash
+
+The coordination layer between your AI coding agents and your phone. Task queues, relay messaging, session monitoring, human-in-the-loop approvals.
+
+## Install
+
+```bash
+npx cachebash init
+```
+
+One command. Authenticates via browser. Injects the MCP server config into your Claude Code, Cursor, or VS Code setup. Done.
+
+## Commands
+
+### `cachebash init`
+
+Connect your AI client to CacheBash:
+
+```bash
+npx cachebash init          # Interactive browser auth
+npx cachebash init --key YOUR_API_KEY  # Direct key setup
+```
+
+Detects your MCP client (Claude Code, Cursor, VS Code) and writes the server config automatically.
+
+### `cachebash ping`
+
+Verify your connection to the CacheBash server.
+
+```bash
+npx cachebash ping
+```
+
+## Supported Clients
+
+| Client | Status |
+|--------|--------|
+| Claude Code | Supported |
+| Cursor | Supported |
+| VS Code + Copilot | Supported |
+| Gemini CLI | Supported |
+| Any MCP client | Supported |
+
+Uses Streamable HTTP transport with Bearer token auth. Standard MCP protocol. No vendor lock-in.
+
+## Links
+
+- [Documentation](https://docs.rezzed.ai)
+- [GitHub](https://github.com/rezzedai/cachebash)
+- [Website](https://rezzed.ai/cachebash)
+
+## License
+
+MIT

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cachebash",
   "version": "0.1.0",
-  "description": "CacheBash CLI — MCP agent coordination",
+  "description": "CacheBash CLI — MCP agent coordination for AI workflows",
   "bin": { "cachebash": "./bin/cachebash.js" },
   "main": "dist/index.js",
   "type": "module",
@@ -18,5 +18,22 @@
   },
   "engines": { "node": ">=18.0.0" },
   "files": ["bin/", "dist/"],
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rezzedai/cachebash.git",
+    "directory": "cli"
+  },
+  "homepage": "https://rezzed.ai/cachebash",
+  "bugs": "https://github.com/rezzedai/cachebash/issues",
+  "keywords": [
+    "mcp",
+    "ai",
+    "agents",
+    "claude",
+    "cursor",
+    "orchestration",
+    "coordination",
+    "model-context-protocol"
+  ]
 }


### PR DESCRIPTION
## Summary
- Added CLI-specific README.md with install instructions, commands, supported clients
- Added repository, homepage, bugs, keywords metadata to package.json
- Package is now ready for `npm publish` once authenticated

## Test plan
- [ ] `npm pack --dry-run` in cli/ includes README.md
- [ ] `npx cachebash init` works after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)