### PR TITLE
fix: remove invalid ascAppId from eas.json

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -32,7 +32,6 @@
     "production": {
       "ios": {
         "appleId": "christianbourlier@gmail.com",
-        "ascAppId": "com.cachebash.app",
         "appleTeamId": "FKFQ6KS8ZA"
       }
     }


### PR DESCRIPTION
## Summary
- Removed `ascAppId: "com.cachebash.app"` — EAS expects numeric App Store Connect ID, not bundle ID
- EAS submit will look up the correct ID during interactive authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)