### PR TITLE
Phase 7 Chunk 1: Feedback backend pipeline

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -496,6 +496,13 @@
         { "fieldPath": "eventType", "order": "ASCENDING" },
         { "fieldPath": "timestamp", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "feedback",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -93,6 +93,12 @@ service cloud.firestore {
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['retrieved']);
     }
 
+    // Feedback: read own, write via Admin SDK only
+    match /tenants/{userId}/feedback/{feedbackId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
     // User root document: read-only
     match /tenants/{userId} {
       allow read: if isOwner(userId);

--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cachebash-functions",
       "version": "2.0.0",
       "dependencies": {
+        "@octokit/rest": "^22.0.1",
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^5.0.0"
       },
@@ -1179,6 +1180,161 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -1842,6 +1998,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -2667,6 +2829,22 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4273,6 +4451,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.3.tgz",
+      "integrity": "sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -6006,6 +6190,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^5.0.0",
+    "@octokit/rest": "^22.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/firebase/functions/src/feedback/githubIssueCreator.ts
+++ b/firebase/functions/src/feedback/githubIssueCreator.ts
@@ -1,0 +1,80 @@
+import { Octokit } from "@octokit/rest";
+import { defineSecret } from "firebase-functions/params";
+
+const githubPat = defineSecret("GITHUB_FEEDBACK_PAT");
+
+interface FeedbackIssueInput {
+  type: "bug" | "feature_request" | "general";
+  message: string;
+  platform: string;
+  appVersion: string;
+  osVersion: string;
+  deviceModel: string;
+  hashedUserId: string;
+  screenshotUrl?: string;
+}
+
+interface FeedbackIssueResult {
+  issueUrl: string;
+  issueNumber: number;
+}
+
+export async function createGithubIssue(
+  input: FeedbackIssueInput
+): Promise<FeedbackIssueResult> {
+  // Create Octokit instance with the secret
+  const octokit = new Octokit({ auth: githubPat.value() });
+
+  // Map type to labels
+  const labelMap: Record<string, string[]> = {
+    bug: ["bug", "user-feedback"],
+    feature_request: ["feature-request", "user-feedback"],
+    general: ["feedback", "user-feedback"],
+  };
+
+  // Build title: "type: first 80 chars of message"
+  const typeLabel =
+    input.type === "feature_request"
+      ? "Feature Request"
+      : input.type === "bug"
+        ? "Bug Report"
+        : "Feedback";
+  const title = `${typeLabel}: ${input.message.substring(0, 80)}${
+    input.message.length > 80 ? "..." : ""
+  }`;
+
+  // Build body using the template from the spec
+  const screenshotSection = input.screenshotUrl
+    ? `\n**Screenshot:** ${input.screenshotUrl}\n`
+    : "";
+  const body = `## ${typeLabel}
+
+**Submitted via:** CacheBash ${input.platform} v${input.appVersion}
+**Platform:** ${input.platform} ${input.osVersion}
+**Device:** ${input.deviceModel}
+**User:** ${input.hashedUserId}
+${screenshotSection}
+---
+
+${input.message}
+
+---
+
+*This issue was created automatically from in-app feedback.*`;
+
+  const response = await octokit.issues.create({
+    owner: "rezzedai",
+    repo: "cachebash",
+    title,
+    body,
+    labels: labelMap[input.type] || ["feedback", "user-feedback"],
+  });
+
+  return {
+    issueUrl: response.data.html_url,
+    issueNumber: response.data.number,
+  };
+}
+
+// Export the secret so it can be referenced by Cloud Functions that use this utility
+export { githubPat };

--- a/firebase/functions/src/feedback/submitFeedback.ts
+++ b/firebase/functions/src/feedback/submitFeedback.ts
@@ -1,0 +1,129 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import * as crypto from "crypto";
+import { createGithubIssue, githubPat } from "./githubIssueCreator";
+
+const db = admin.firestore();
+
+export const submitFeedback = functions
+  .runWith({ secrets: [githubPat] })
+  .https.onCall(async (data, context) => {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "Authentication required"
+      );
+    }
+
+    const userId = context.auth.uid;
+
+    // Validate input
+    const type = data.type;
+    if (!["bug", "feature_request", "general"].includes(type)) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        'type must be one of: bug, feature_request, general'
+      );
+    }
+
+    const message = data.message;
+    if (!message || typeof message !== "string") {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "message is required"
+      );
+    }
+    if (message.length < 1 || message.length > 2000) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        "message must be between 1 and 2000 characters"
+      );
+    }
+
+    const platform = data.platform || "ios";
+    if (!["ios", "android", "cli"].includes(platform)) {
+      throw new functions.https.HttpsError(
+        "invalid-argument",
+        'platform must be one of: ios, android, cli'
+      );
+    }
+
+    // Rate limit: max 5 submissions per user per hour
+    const oneHourAgo = admin.firestore.Timestamp.fromMillis(
+      Date.now() - 60 * 60 * 1000
+    );
+    const recentSubmissions = await db
+      .collection(`tenants/${userId}/feedback`)
+      .where("createdAt", ">", oneHourAgo)
+      .get();
+
+    if (recentSubmissions.size >= 5) {
+      throw new functions.https.HttpsError(
+        "resource-exhausted",
+        "Rate limit exceeded. Maximum 5 submissions per hour."
+      );
+    }
+
+    // Hash the userId for GitHub issues (first 8 chars of SHA-256)
+    const hashedUserId = crypto
+      .createHash("sha256")
+      .update(userId)
+      .digest("hex")
+      .substring(0, 8);
+
+    // Write to Firestore
+    const feedbackData = {
+      type,
+      message,
+      screenshotUrl: data.screenshotUrl || null,
+      appVersion: data.appVersion || "unknown",
+      platform,
+      osVersion: data.osVersion || "unknown",
+      deviceModel: data.deviceModel || "unknown",
+      githubIssueUrl: null,
+      githubIssueNumber: null,
+      status: "submitted",
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    };
+
+    const feedbackRef = await db
+      .collection(`tenants/${userId}/feedback`)
+      .add(feedbackData);
+
+    // Try to create GitHub issue (fail-open: feedback persists even if GitHub fails)
+    let issueUrl: string | null = null;
+    let issueNumber: number | null = null;
+
+    try {
+      const result = await createGithubIssue({
+        type,
+        message,
+        platform,
+        appVersion: data.appVersion || "unknown",
+        osVersion: data.osVersion || "unknown",
+        deviceModel: data.deviceModel || "unknown",
+        hashedUserId,
+        screenshotUrl: data.screenshotUrl,
+      });
+
+      issueUrl = result.issueUrl;
+      issueNumber = result.issueNumber;
+
+      // Update feedback doc with GitHub issue info
+      await feedbackRef.update({
+        githubIssueUrl: issueUrl,
+        githubIssueNumber: issueNumber,
+        status: "issue_created",
+      });
+    } catch (error) {
+      console.error("[Feedback] Failed to create GitHub issue:", error);
+      // Leave status as 'submitted' - don't lose the feedback
+    }
+
+    return {
+      success: true,
+      feedbackId: feedbackRef.id,
+      issueUrl,
+      issueNumber,
+    };
+  });

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -27,3 +27,6 @@ export { cleanupExpiredRelay } from "./cleanup/cleanupExpiredRelay";
 export { cleanupLedger } from "./cleanup/cleanupLedger";
 export { processDeadLetters } from "./cleanup/processDeadLetters";
 export { cleanupAudit } from "./cleanup/cleanupAudit";
+
+// Feedback
+export { submitFeedback } from "./feedback/submitFeedback";

--- a/mcp-server/src/modules/feedback.ts
+++ b/mcp-server/src/modules/feedback.ts
@@ -1,0 +1,183 @@
+/**
+ * Feedback Module — Submit feedback that creates GitHub Issues.
+ * Collection: tenants/{uid}/feedback
+ */
+
+import { getFirestore, serverTimestamp } from "../firebase/client.js";
+import * as admin from "firebase-admin";
+import { AuthContext } from "../auth/apiKeyValidator.js";
+import { z } from "zod";
+import { Octokit } from "@octokit/rest";
+import * as crypto from "crypto";
+
+const SubmitFeedbackSchema = z.object({
+  type: z.enum(["bug", "feature_request", "general"]).default("general"),
+  message: z.string().min(1).max(2000),
+  platform: z.enum(["ios", "android", "cli"]).default("cli"),
+  appVersion: z.string().max(50).optional(),
+  osVersion: z.string().max(50).optional(),
+  deviceModel: z.string().max(100).optional(),
+});
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+function jsonResult(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+async function createGithubIssue(input: {
+  type: "bug" | "feature_request" | "general";
+  message: string;
+  platform: string;
+  appVersion: string;
+  osVersion: string;
+  deviceModel: string;
+  hashedUserId: string;
+  screenshotUrl?: string;
+}): Promise<{ issueUrl: string; issueNumber: number }> {
+  const githubToken = process.env.GITHUB_FEEDBACK_PAT;
+  if (!githubToken) {
+    throw new Error("GITHUB_FEEDBACK_PAT environment variable not set");
+  }
+
+  const octokit = new Octokit({ auth: githubToken });
+
+  // Map type to labels
+  const labelMap: Record<string, string[]> = {
+    bug: ["bug", "user-feedback"],
+    feature_request: ["feature-request", "user-feedback"],
+    general: ["feedback", "user-feedback"],
+  };
+
+  // Build title: "type: first 80 chars of message"
+  const typeLabel =
+    input.type === "feature_request"
+      ? "Feature Request"
+      : input.type === "bug"
+        ? "Bug Report"
+        : "Feedback";
+  const title = `${typeLabel}: ${input.message.substring(0, 80)}${
+    input.message.length > 80 ? "..." : ""
+  }`;
+
+  // Build body using the template from the spec
+  const screenshotSection = input.screenshotUrl
+    ? `\n**Screenshot:** ${input.screenshotUrl}\n`
+    : "";
+  const body = `## ${typeLabel}
+
+**Submitted via:** CacheBash ${input.platform} v${input.appVersion}
+**Platform:** ${input.platform} ${input.osVersion}
+**Device:** ${input.deviceModel}
+**User:** ${input.hashedUserId}
+${screenshotSection}
+---
+
+${input.message}
+
+---
+
+*This issue was created automatically from in-app feedback.*`;
+
+  const response = await octokit.issues.create({
+    owner: "rezzedai",
+    repo: "cachebash",
+    title,
+    body,
+    labels: labelMap[input.type] || ["feedback", "user-feedback"],
+  });
+
+  return {
+    issueUrl: response.data.html_url,
+    issueNumber: response.data.number,
+  };
+}
+
+export async function submitFeedbackHandler(
+  auth: AuthContext,
+  rawArgs: unknown
+): Promise<ToolResult> {
+  const args = SubmitFeedbackSchema.parse(rawArgs);
+  const db = getFirestore();
+
+  // Rate limit: max 5 submissions per user per hour
+  const oneHourAgo = admin.firestore.Timestamp.fromMillis(
+    Date.now() - 60 * 60 * 1000
+  );
+  const recentSubmissions = await db
+    .collection(`tenants/${auth.userId}/feedback`)
+    .where("createdAt", ">", oneHourAgo)
+    .get();
+
+  if (recentSubmissions.size >= 5) {
+    return jsonResult({
+      success: false,
+      error: "Rate limit exceeded. Maximum 5 submissions per hour.",
+    });
+  }
+
+  // Hash the userId for GitHub issues (first 8 chars of SHA-256)
+  const hashedUserId = crypto
+    .createHash("sha256")
+    .update(auth.userId)
+    .digest("hex")
+    .substring(0, 8);
+
+  // Write to Firestore
+  const feedbackData = {
+    type: args.type,
+    message: args.message,
+    screenshotUrl: null,
+    appVersion: args.appVersion || "unknown",
+    platform: args.platform,
+    osVersion: args.osVersion || "unknown",
+    deviceModel: args.deviceModel || "unknown",
+    githubIssueUrl: null,
+    githubIssueNumber: null,
+    status: "submitted",
+    createdAt: serverTimestamp(),
+  };
+
+  const feedbackRef = await db
+    .collection(`tenants/${auth.userId}/feedback`)
+    .add(feedbackData);
+
+  // Try to create GitHub issue (fail-open: feedback persists even if GitHub fails)
+  let issueUrl: string | null = null;
+  let issueNumber: number | null = null;
+
+  try {
+    const result = await createGithubIssue({
+      type: args.type,
+      message: args.message,
+      platform: args.platform,
+      appVersion: args.appVersion || "unknown",
+      osVersion: args.osVersion || "unknown",
+      deviceModel: args.deviceModel || "unknown",
+      hashedUserId,
+    });
+
+    issueUrl = result.issueUrl;
+    issueNumber = result.issueNumber;
+
+    // Update feedback doc with GitHub issue info
+    await feedbackRef.update({
+      githubIssueUrl: issueUrl,
+      githubIssueNumber: issueNumber,
+      status: "issue_created",
+    });
+  } catch (error) {
+    console.error("[Feedback] Failed to create GitHub issue:", error);
+    // Leave status as 'submitted' - don't lose the feedback
+  }
+
+  return jsonResult({
+    success: true,
+    feedbackId: feedbackRef.id,
+    issueUrl,
+    issueNumber,
+    message: issueUrl
+      ? `Feedback submitted and GitHub issue created: ${issueUrl}`
+      : "Feedback submitted (GitHub issue creation failed, but feedback was saved)",
+  });
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -15,6 +15,7 @@ import { getAuditHandler } from "./modules/audit.js";
 import { getProgramStateHandler, updateProgramStateHandler } from "./modules/programState.js";
 import { getCostSummaryHandler, getCommsMetricsHandler, getOperationalMetricsHandler } from "./modules/metrics.js";
 import { queryTracesHandler } from "./modules/trace.js";
+import { submitFeedbackHandler } from "./modules/feedback.js";
 
 type Handler = (auth: AuthContext, args: any) => Promise<any>;
 
@@ -70,6 +71,9 @@ export const TOOL_HANDLERS: Record<string, Handler> = {
 
   // Trace
   query_traces: queryTracesHandler,
+
+  // Feedback
+  submit_feedback: submitFeedbackHandler,
 };
 
 export const TOOL_DEFINITIONS = [
@@ -646,6 +650,23 @@ export const TOOL_DEFINITIONS = [
         until: { type: "string", description: "End date (ISO 8601)" },
         limit: { type: "number", minimum: 1, maximum: 100, default: 50 },
       },
+    },
+  },
+  // === Feedback ===
+  {
+    name: "submit_feedback",
+    description: "Submit feedback (bug report, feature request, or general) which creates a GitHub Issue",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        type: { type: "string", enum: ["bug", "feature_request", "general"], default: "general", description: "Feedback type" },
+        message: { type: "string", maxLength: 2000, description: "Feedback message (required, 1-2000 chars)" },
+        platform: { type: "string", enum: ["ios", "android", "cli"], default: "cli", description: "Submitting platform" },
+        appVersion: { type: "string", description: "App version string", maxLength: 50 },
+        osVersion: { type: "string", description: "OS version", maxLength: 50 },
+        deviceModel: { type: "string", description: "Device model", maxLength: 100 },
+      },
+      required: ["message"],
     },
   },
 ];

--- a/mcp-server/src/types/feedback.ts
+++ b/mcp-server/src/types/feedback.ts
@@ -1,0 +1,20 @@
+import * as admin from "firebase-admin";
+
+export type FeedbackType = "bug" | "feature_request" | "general";
+export type FeedbackStatus = "submitted" | "issue_created" | "failed";
+export type FeedbackPlatform = "ios" | "android" | "cli";
+
+export interface FeedbackSubmission {
+  id: string;
+  type: FeedbackType;
+  message: string;
+  screenshotUrl: string | null;
+  appVersion: string;
+  platform: FeedbackPlatform;
+  osVersion: string;
+  deviceModel: string;
+  githubIssueUrl: string | null;
+  githubIssueNumber: number | null;
+  status: FeedbackStatus;
+  createdAt: admin.firestore.Timestamp;
+}


### PR DESCRIPTION
## Summary
- Cloud Function `submitFeedback` (callable) — validates input, rate limits (5/hr/user), persists to Firestore, creates GitHub Issue with auto-labels
- GitHub issue creator utility — maps feedback types to labels, hashes user IDs for privacy, formats issue body with device metadata
- MCP tool `submit_feedback` — CLI access to the same pipeline via the MCP server
- Firestore security rules and indexes for `tenants/{userId}/feedback/` collection
- Type definitions for feedback data model

## Pre-deploy setup required
1. `firebase functions:secrets:set GITHUB_FEEDBACK_PAT` — GitHub PAT scoped to `repo` on `rezzedai/cachebash`
2. Create issue labels: `user-feedback`, `bug`, `feature-request`, `feedback`
3. Set `GITHUB_FEEDBACK_PAT` env var on Cloud Run for MCP server

## Test plan
- [ ] Deploy Cloud Function and verify `submitFeedback` creates GitHub Issues
- [ ] Test rate limiting (6th submission within an hour should fail)
- [ ] Test fail-open: invalid PAT should still persist feedback to Firestore
- [ ] Test MCP tool `submit_feedback` via CLI
- [ ] Verify user IDs are hashed in GitHub Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)