### PR TITLE
Phase 7 Chunk 2: Mobile feedback UI

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -22,6 +22,7 @@ import 'screens/sprints/add_to_sprint_screen.dart';
 import 'screens/dreams/activate_dream_screen.dart';
 import 'screens/dreams/dream_detail_screen.dart';
 import 'screens/feedback/feedback_screen.dart';
+import 'screens/feedback/feedback_history_screen.dart';
 import 'theme/app_theme.dart';
 import 'widgets/main_shell.dart';
 
@@ -173,6 +174,10 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: '/feedback',
             builder: (context, state) => const FeedbackScreen(),
+          ),
+          GoRoute(
+            path: '/feedback/history',
+            builder: (context, state) => const FeedbackHistoryScreen(),
           ),
         ],
       ),

--- a/app/lib/models/feedback_model.dart
+++ b/app/lib/models/feedback_model.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FeedbackModel {
+  final String id;
+  final String type;         // 'bug', 'feature_request', 'general'
+  final String message;
+  final String? screenshotUrl;
+  final String? githubIssueUrl;
+  final int? githubIssueNumber;
+  final String status;       // 'submitted', 'issue_created', 'failed'
+  final String platform;
+  final String appVersion;
+  final DateTime createdAt;
+
+  FeedbackModel({
+    required this.id,
+    required this.type,
+    required this.message,
+    this.screenshotUrl,
+    this.githubIssueUrl,
+    this.githubIssueNumber,
+    required this.status,
+    required this.platform,
+    required this.appVersion,
+    required this.createdAt,
+  });
+
+  factory FeedbackModel.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return FeedbackModel(
+      id: doc.id,
+      type: data['type'] ?? 'general',
+      message: data['message'] ?? '',
+      screenshotUrl: data['screenshotUrl'],
+      githubIssueUrl: data['githubIssueUrl'],
+      githubIssueNumber: data['githubIssueNumber'],
+      status: data['status'] ?? 'submitted',
+      platform: data['platform'] ?? 'unknown',
+      appVersion: data['appVersion'] ?? 'unknown',
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+}

--- a/app/lib/providers/feedback_provider.dart
+++ b/app/lib/providers/feedback_provider.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/feedback_model.dart';
+import 'auth_provider.dart';
+
+void _log(String message) {
+  debugPrint('[FeedbackProvider] $message');
+}
+
+final firestore = FirebaseFirestore.instance;
+
+/// Stream provider for user's feedback submissions
+final feedbackHistoryProvider = StreamProvider<List<FeedbackModel>>((ref) {
+  final user = ref.watch(currentUserProvider);
+  if (user == null) return Stream.value([]);
+
+  _log('feedbackHistoryProvider: Setting up stream for user ${user.uid}');
+  return firestore
+      .collection('tenants/${user.uid}/feedback')
+      .orderBy('createdAt', descending: true)
+      .limit(50)
+      .snapshots()
+      .map((snapshot) {
+        _log('feedbackHistoryProvider: Got ${snapshot.docs.length} docs');
+        return snapshot.docs.map((doc) => FeedbackModel.fromFirestore(doc)).toList();
+      });
+});

--- a/app/lib/screens/feedback/feedback_history_screen.dart
+++ b/app/lib/screens/feedback/feedback_history_screen.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../models/feedback_model.dart';
+import '../../providers/feedback_provider.dart';
+import '../../services/haptic_service.dart';
+
+void _log(String message) {
+  debugPrint('[FeedbackHistoryScreen] $message');
+}
+
+class FeedbackHistoryScreen extends ConsumerWidget {
+  const FeedbackHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final feedbackAsync = ref.watch(feedbackHistoryProvider);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Feedback'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: feedbackAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) {
+          _log('Error loading feedback: $error');
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.error_outline,
+                    size: 48,
+                    color: theme.colorScheme.error,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Failed to load feedback',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    error.toString(),
+                    style: theme.textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+        data: (feedbackList) {
+          if (feedbackList.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.feedback_outlined,
+                      size: 64,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No feedback submitted yet',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Your feedback submissions will appear here.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          return ListView.builder(
+            itemCount: feedbackList.length,
+            padding: const EdgeInsets.all(16),
+            itemBuilder: (context, index) {
+              final feedback = feedbackList[index];
+              return _buildFeedbackCard(context, feedback);
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildFeedbackCard(BuildContext context, FeedbackModel feedback) {
+    final theme = Theme.of(context);
+    final typeConfig = _getTypeConfig(feedback.type);
+    final statusConfig = _getStatusConfig(feedback.status);
+
+    // Get first line of message
+    final firstLine = feedback.message.split('\n').first;
+    final displayMessage = firstLine.length > 80
+        ? '${firstLine.substring(0, 80)}...'
+        : firstLine;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: InkWell(
+        onTap: feedback.githubIssueUrl != null
+            ? () {
+                HapticService.light();
+                _openGitHubIssue(feedback.githubIssueUrl!);
+              }
+            : null,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Type and status row
+              Row(
+                children: [
+                  Icon(
+                    typeConfig.$1,
+                    size: 20,
+                    color: typeConfig.$2,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      typeConfig.$3,
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: typeConfig.$2,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: statusConfig.$2.withAlpha(30),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: statusConfig.$2.withAlpha(80),
+                      ),
+                    ),
+                    child: Text(
+                      statusConfig.$1,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold,
+                        color: statusConfig.$2,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+
+              // Message
+              Text(
+                displayMessage,
+                style: theme.textTheme.bodyMedium,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 8),
+
+              // Date and GitHub issue info
+              Row(
+                children: [
+                  Icon(
+                    Icons.access_time,
+                    size: 14,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    _formatDate(feedback.createdAt),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  if (feedback.githubIssueNumber != null) ...[
+                    const SizedBox(width: 12),
+                    Icon(
+                      Icons.tag,
+                      size: 14,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '#${feedback.githubIssueNumber}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                  if (feedback.githubIssueUrl != null) ...[
+                    const Spacer(),
+                    Icon(
+                      Icons.open_in_new,
+                      size: 14,
+                      color: theme.colorScheme.primary,
+                    ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  (IconData, Color, String) _getTypeConfig(String type) {
+    return switch (type) {
+      'bug' => (Icons.bug_report, Colors.red, 'Bug Report'),
+      'feature_request' => (Icons.lightbulb_outline, Colors.blue, 'Feature Request'),
+      _ => (Icons.feedback, Colors.orange, 'General Feedback'),
+    };
+  }
+
+  (String, Color) _getStatusConfig(String status) {
+    return switch (status) {
+      'issue_created' => ('Issue Created', Colors.green),
+      'failed' => ('Failed', Colors.red),
+      _ => ('Submitted', Colors.orange),
+    };
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inMinutes < 1) {
+      return 'just now';
+    } else if (diff.inMinutes < 60) {
+      return '${diff.inMinutes}m ago';
+    } else if (diff.inHours < 24) {
+      return '${diff.inHours}h ago';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays}d ago';
+    } else {
+      return '${date.month}/${date.day}/${date.year}';
+    }
+  }
+
+  Future<void> _openGitHubIssue(String url) async {
+    _log('Opening GitHub issue: $url');
+    try {
+      final uri = Uri.parse(url);
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        _log('Cannot launch URL: $url');
+      }
+    } catch (e) {
+      _log('Error launching URL: $e');
+    }
+  }
+}

--- a/app/lib/screens/settings/settings_screen.dart
+++ b/app/lib/screens/settings/settings_screen.dart
@@ -138,6 +138,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             },
           ),
           ListTile(
+            leading: const Icon(Icons.history),
+            title: const Text('My Feedback'),
+            subtitle: const Text('View past submissions'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              HapticService.light();
+              context.push('/feedback/history');
+            },
+          ),
+          ListTile(
             leading: const Icon(Icons.info_outline),
             title: const Text('About'),
             subtitle: Text('Version $_appVersion'),

--- a/app/lib/services/feedback_service.dart
+++ b/app/lib/services/feedback_service.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void _log(String message) {
+  debugPrint('[FeedbackService] $message');
+}
+
+class FeedbackService {
+  final FirebaseFunctions _functions = FirebaseFunctions.instance;
+
+  Future<Map<String, dynamic>> submitFeedback({
+    required String type,
+    required String message,
+    String? screenshotPath,
+  }) async {
+    _log('submitFeedback: type=$type, hasScreenshot=${screenshotPath != null}');
+
+    String? screenshotUrl;
+
+    // Upload screenshot if provided
+    if (screenshotPath != null) {
+      try {
+        screenshotUrl = await _uploadScreenshot(screenshotPath);
+        _log('Screenshot uploaded successfully: $screenshotUrl');
+      } catch (e) {
+        _log('Screenshot upload failed: $e');
+        // Continue without screenshot rather than failing entirely
+      }
+    }
+
+    // Get device info
+    final packageInfo = await PackageInfo.fromPlatform();
+    final platform = Platform.isIOS ? 'ios' : 'android';
+
+    _log('Calling submitFeedback Cloud Function...');
+    final callable = _functions.httpsCallable('submitFeedback');
+    final result = await callable.call({
+      'type': type,
+      'message': message,
+      'screenshotUrl': screenshotUrl,
+      'appVersion': '${packageInfo.version} (${packageInfo.buildNumber})',
+      'platform': platform,
+      'osVersion': Platform.operatingSystemVersion,
+      'deviceModel': Platform.localHostname,
+    });
+
+    _log('submitFeedback result: ${result.data}');
+    return Map<String, dynamic>.from(result.data);
+  }
+
+  Future<String> _uploadScreenshot(String filePath) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) throw Exception('Not authenticated');
+
+    final file = File(filePath);
+    final fileName = 'feedback/${user.uid}/${DateTime.now().millisecondsSinceEpoch}.jpg';
+    final ref = FirebaseStorage.instance.ref().child(fileName);
+
+    _log('Uploading screenshot to: $fileName');
+    await ref.putFile(file);
+    final downloadUrl = await ref.getDownloadURL();
+    return downloadUrl;
+  }
+}

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,13 @@ import Foundation
 
 import app_settings
 import cloud_firestore
+import cloud_functions
+import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_crashlytics
 import firebase_messaging
+import firebase_storage
 import flutter_app_badger
 import flutter_secure_storage_macos
 import package_info_plus
@@ -19,10 +22,13 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppSettingsPlugin.register(with: registry.registrar(forPlugin: "AppSettingsPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
+  FirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FirebaseFunctionsPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   FlutterAppBadgerPlugin.register(with: registry.registrar(forPlugin: "FlutterAppBadgerPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -89,6 +89,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.4.12"
+  cloud_functions:
+    dependency: "direct main"
+    description:
+      name: cloud_functions
+      sha256: b9ece944fc8c97ac0937cdf45e895f4670213c722ed819581e3d517b43413753
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.2"
+  cloud_functions_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_functions_platform_interface
+      sha256: "9720aa2ba715bfb1de6a131c70bbb0fa79329294ec1327fd24ce08004a080dcc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.2"
+  cloud_functions_web:
+    dependency: transitive
+    description:
+      name: cloud_functions_web
+      sha256: "7756b6a6cf16016dc4c8631c88b31b81156b129c40914a84021216a841c0b3d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.5"
   code_assets:
     dependency: transitive
     description:
@@ -113,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: "direct main"
     description:
@@ -161,6 +193,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -249,6 +313,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.10.10"
+  firebase_storage:
+    dependency: "direct main"
+    description:
+      name: firebase_storage
+      sha256: "958fc88a7ef0b103e694d30beed515c8f9472dde7e8459b029d0e32b8ff03463"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.4.10"
+  firebase_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_storage_platform_interface
+      sha256: d2661c05293c2a940c8ea4bc0444e1b5566c79dd3202c2271140c082c8cd8dd4
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.10"
+  firebase_storage_web:
+    dependency: transitive
+    description:
+      name: firebase_storage_web
+      sha256: "629a557c5e1ddb97a3666cbf225e97daa0a66335dbbfdfdce113ef9f881e833f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.17"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -270,6 +358,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -376,6 +472,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: eda9b91b7e266d9041084a42d605a74937d996b87083395c5e47835916a86156
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+14"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   js:
     dependency: transitive
     description:
@@ -448,6 +608,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   cloud_firestore: ^5.0.0
   firebase_messaging: ^15.0.0
   firebase_crashlytics: ^4.0.0
+  cloud_functions: ^5.0.0
+  firebase_storage: ^12.0.0
 
   # State Management
   flutter_riverpod: ^2.4.10
@@ -39,6 +41,7 @@ dependencies:
   app_settings: ^5.1.1
   url_launcher: ^6.2.5
   flutter_app_badger: ^1.5.0
+  image_picker: ^1.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- **Feedback screen** — complete rewrite of v1 placeholder. Type selector (Bug/Feature/General), 2000 char text field, screenshot attachment via image_picker, calls `submitFeedback` Cloud Function
- **Feedback history** — new screen listing past submissions from `tenants/{userId}/feedback/`. Status badges, GitHub Issue links, empty state
- **Settings integration** — "My Feedback" tile added to Support section
- **Service layer** — FeedbackService handles Cloud Function calls and Firebase Storage uploads
- **Model + Provider** — FeedbackModel with Firestore deserialization, Riverpod StreamProvider for history

## Dependencies added
- `cloud_functions` — for calling submitFeedback
- `firebase_storage` — for screenshot uploads
- `image_picker` — for camera/gallery access

## Depends on
- PR #128 (Phase 7 Chunk 1: Backend pipeline) — must be merged and deployed first

## Test plan
- [ ] Submit feedback with each type (bug, feature, general)
- [ ] Verify character counter works at 2000 limit
- [ ] Attach screenshot from gallery, verify upload and preview
- [ ] Verify success state shows GitHub Issue link
- [ ] Rate limit triggers after 5 submissions in 1 hour
- [ ] Feedback history shows all past submissions
- [ ] Tap history item opens GitHub Issue in browser
- [ ] No horizontal scroll on any device size

🤖 Generated with [Claude Code](https://claude.com/claude-code)