### PR TITLE
Phase 7 Chunk 3: CLI feedback command

### DIFF
--- a/cli/src/commands/feedback.ts
+++ b/cli/src/commands/feedback.ts
@@ -1,0 +1,142 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import { detectConfigs } from "../config/writer.js";
+import { Spinner, printSuccess, printError, printStep } from "../ui/output.js";
+
+const MCP_URL = "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp";
+
+export async function runFeedback(type: string, message: string): Promise<void> {
+  // 1. Validate message
+  if (!message || message.trim().length === 0) {
+    printError("Message is required. Usage: cachebash feedback \"your message here\"");
+    process.exit(1);
+  }
+  if (message.length > 2000) {
+    printError("Message must be 2000 characters or less.");
+    process.exit(1);
+  }
+
+  // 2. Read API key from config (same pattern as ping.ts)
+  const configs = await detectConfigs();
+  if (configs.length === 0) {
+    printError("No MCP config found. Run `cachebash init` first.");
+    process.exit(1);
+  }
+
+  const target = configs[0];
+  let apiKey: string | undefined;
+  try {
+    const content = await readFile(target.path, "utf-8");
+    const config = JSON.parse(content);
+    const servers = target.key === "mcp.servers" ? config?.mcp?.servers : config?.[target.key];
+    const auth = servers?.cachebash?.headers?.Authorization;
+    if (auth && typeof auth === "string") {
+      apiKey = auth.replace("Bearer ", "");
+    }
+  } catch {
+    printError(`Failed to read config at ${target.path}`);
+    process.exit(1);
+  }
+
+  if (!apiKey) {
+    printError("No CacheBash API key found in config. Run `cachebash init` first.");
+    process.exit(1);
+  }
+
+  // 3. Submit feedback via MCP server
+  const spinner = new Spinner();
+  const typeLabel = type === 'bug' ? 'bug report' : type === 'feature_request' ? 'feature request' : 'feedback';
+  spinner.start(`Submitting ${typeLabel}...`);
+
+  try {
+    // Step 1: Initialize MCP session
+    const initRes = await fetch(MCP_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "cachebash-cli", version: "0.1.0" },
+        },
+        id: 1,
+      }),
+    });
+
+    if (!initRes.ok) {
+      spinner.stop();
+      if (initRes.status === 401) {
+        printError("Authentication failed — API key may be invalid or revoked.");
+      } else {
+        printError(`Server returned ${initRes.status}`);
+      }
+      process.exit(1);
+    }
+
+    // Step 2: Call submit_feedback tool
+    const toolRes = await fetch(MCP_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          name: "submit_feedback",
+          arguments: {
+            type,
+            message: message.trim(),
+            platform: "cli",
+            appVersion: "cli-0.1.0",
+            osVersion: `${process.platform} ${os.release()}`,
+            deviceModel: os.hostname(),
+          },
+        },
+        id: 2,
+      }),
+    });
+
+    if (!toolRes.ok) {
+      spinner.stop();
+      printError(`Failed to submit feedback (${toolRes.status})`);
+      process.exit(1);
+    }
+
+    const toolData = await toolRes.json() as any;
+
+    // Parse the MCP tool response
+    // MCP tools return { result: { content: [{ type: "text", text: "..." }] } }
+    const resultText = toolData?.result?.content?.[0]?.text;
+    if (!resultText) {
+      spinner.stop();
+      printError("Unexpected response from server");
+      process.exit(1);
+    }
+
+    const result = JSON.parse(resultText);
+
+    spinner.stop();
+
+    if (result.success) {
+      printSuccess("Feedback submitted");
+      if (result.issueUrl) {
+        printStep(`Track it: ${result.issueUrl}`);
+      }
+    } else {
+      printError(result.message || "Failed to submit feedback");
+      process.exit(1);
+    }
+  } catch (err) {
+    spinner.stop();
+    printError(`Connection failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+    printStep("Check your network connection and try again.");
+    process.exit(1);
+  }
+}

--- a/cli/src/ui/output.ts
+++ b/cli/src/ui/output.ts
@@ -21,6 +21,12 @@ ${bold("Commands:")}
   init          Set up CacheBash MCP connection
   init --key    Use an existing API key
   ping          Test MCP connectivity
+  feedback      Submit feedback (bug report, feature request, or general)
+
+${bold("Feedback:")}
+  cachebash feedback "your message"
+  cachebash feedback --type bug "description of the issue"
+  cachebash feedback -t feature "I'd like to see..."
 
 ${bold("Options:")}
   --help        Show this help message


### PR DESCRIPTION
## Summary
- `cachebash feedback "message"` — submit feedback from the terminal
- `cachebash feedback --type bug "description"` — specify feedback type
- `cachebash feedback -t feature "I'd like..."` — short flag variant
- Returns GitHub Issue URL on success
- Uses existing MCP config and API key (same auth flow as `cachebash ping`)

## Usage
```
cachebash feedback "This tool is amazing!"
cachebash feedback --type bug "CLI crashes when..."
cachebash feedback -t feature "Add webhook support"
```

## Depends on
- PR #128 (Phase 7 Chunk 1: Backend pipeline) — MCP tool `submit_feedback` must be deployed

## Test plan
- [ ] `cachebash feedback "test"` submits and returns issue URL
- [ ] `--type bug` creates issue with bug label
- [ ] `--type feature` creates issue with feature-request label  
- [ ] Empty message shows usage help
- [ ] No API key configured shows "Run cachebash init first"
- [ ] Network failure shows clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)