### PR TITLE
fix: mobile bug sprint — bugs 1-7

### DIFF
--- a/mcp-server/src/modules/programState.ts
+++ b/mcp-server/src/modules/programState.ts
@@ -111,7 +111,7 @@ function defaultState(programId: string, sessionId: string): ProgramState {
  */
 function canRead(auth: AuthContext, targetProgramId: string): boolean {
   if (auth.programId === "legacy" || auth.programId === "mobile") return true;
-  if (auth.programId === "orchestrator" || auth.programId === "auditor") return true;
+  if (auth.programId === "orchestrator" || auth.programId === "iso" || auth.programId === "auditor") return true;
   return auth.programId === targetProgramId;
 }
 

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import { db } from '../config/firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { useSessions } from '../hooks/useSessions';
 import { useNotifications } from '../contexts/NotificationContext';
+import { useOnboarding } from '../contexts/OnboardingContext';
 import { theme } from '../theme';
 
 export default function SettingsScreen() {
@@ -13,6 +14,7 @@ export default function SettingsScreen() {
   const { signOut, user } = useAuth();
   const { error: sessionsError } = useSessions();
   const { permissionStatus, preferences, updatePreferences, requestPermissions } = useNotifications();
+  const { resetOnboarding } = useOnboarding();
 
   const [activeKeyCount, setActiveKeyCount] = useState<number | null>(null);
 
@@ -216,6 +218,31 @@ export default function SettingsScreen() {
             <Text style={styles.rowLabel}>Build</Text>
             <Text style={styles.rowValue}>Expo SDK 54</Text>
           </View>
+          <View style={styles.divider} />
+          <TouchableOpacity
+            style={styles.buttonRow}
+            onPress={() => {
+              Alert.alert(
+                'Replay Walkthrough',
+                'This will reset the onboarding walkthrough so you can view it again.',
+                [
+                  { text: 'Cancel', style: 'cancel' },
+                  {
+                    text: 'Replay',
+                    onPress: async () => {
+                      await resetOnboarding();
+                      navigation.navigate('Home');
+                    },
+                  },
+                ]
+              );
+            }}
+            activeOpacity={0.7}
+            accessibilityLabel="Replay onboarding walkthrough"
+            accessibilityRole="button"
+          >
+            <Text style={styles.replayText}>Replay Walkthrough</Text>
+          </TouchableOpacity>
         </View>
       </View>
 
@@ -298,6 +325,11 @@ const styles = StyleSheet.create({
   disconnectText: {
     fontSize: theme.fontSize.md,
     color: theme.colors.error,
+    fontWeight: '600',
+  },
+  replayText: {
+    fontSize: theme.fontSize.md,
+    color: theme.colors.primary,
     fontWeight: '600',
   },
   statusRow: {


### PR DESCRIPTION
## Summary
- **Bug 1**: Fix KeyGenerationModal named import (crash on key management screen)
- **Bug 2**: Make session items tappable with navigation to program detail
- **Bug 3**: Full-width single-column program cards (was 2-col grid)
- **Bug 4**: Add `target: 'admin'` query to useMessages for complete channel visibility
- **Bug 5**: Ascending sort in ChannelDetailScreen for chat-like display
- **Bug 6**: Add "Replay Walkthrough" button in Settings with onboarding reset
- **Bug 7**: Grant ISO program read access to program state (canRead)

## Test plan
- [ ] Key management screen opens without crash
- [ ] Session items navigate to program detail on tap
- [ ] Program cards render full-width on home screen
- [ ] Message channels show both admin-sent and admin-received messages
- [ ] Channel detail shows messages in chronological order (oldest first)
- [ ] Settings > Replay Walkthrough resets onboarding and navigates to Home
- [ ] ISO can read program state via get_program_state