### PR TITLE
chore: bump mobile app version to 1.1.0

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "CacheBash",
     "slug": "cachebash",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -16,12 +16,14 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.cachebash.app",
+      "buildNumber": "2",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {
       "package": "com.cachebash.app",
+      "versionCode": 2,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
## Summary
- Bump mobile app version from 1.0.0 to 1.1.0
- Add iOS buildNumber: 2
- Add Android versionCode: 2

## Test plan
- [ ] Verify app.json version reads 1.1.0
- [ ] Verify iOS build number incremented
- [ ] Verify Android version code incremented