### PR TITLE
docs: per-client MCP setup guides

### DIFF
--- a/mcp-server/docs/setup/claude-code.md
+++ b/mcp-server/docs/setup/claude-code.md
@@ -1,0 +1,62 @@
+# CacheBash — Claude Code CLI Setup
+
+## Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed
+- A CacheBash API key (generate one from the mobile app under Settings > API Keys)
+
+## Configuration
+
+1. In your project root (or home directory for global access), create or edit `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer CACHEBASH_API_KEY"
+      }
+    }
+  }
+}
+```
+
+2. Replace `CACHEBASH_API_KEY` with your actual API key (starts with `cb_`).
+
+3. Add `.mcp.json` to your `.gitignore` — it contains your API key:
+
+```
+echo '.mcp.json' >> .gitignore
+```
+
+## Verification
+
+Start a Claude Code session and ask it to list sessions:
+
+```
+Use cachebash to list my active sessions.
+```
+
+Claude should call `list_sessions` and return results. If you see session data, the connection is live.
+
+## REST Fallback
+
+If the MCP session expires mid-conversation (BUG-004: sessions can die after 20-30 min), use the REST API directly:
+
+```bash
+curl -s https://cachebash-mcp-922749444863.us-central1.run.app/v1/tasks?target=YOUR_PROGRAM \
+  -H "Authorization: Bearer CACHEBASH_API_KEY"
+```
+
+All MCP tools have REST equivalents at `/v1/{tool_name}`.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 Unauthorized` | Verify your API key. Check that `.mcp.json` is in the working directory or a parent. |
+| `Session expired or invalid` | Known issue (BUG-004). Start a new conversation or use the REST fallback above. |
+| Tools not loading | Run `/mcp` in Claude Code to check MCP server status. Verify the `.mcp.json` path. |
+| `ENOTFOUND` / DNS errors | Check internet connectivity. The server runs on GCP Cloud Run (`us-central1`). |

--- a/mcp-server/docs/setup/claude-desktop.md
+++ b/mcp-server/docs/setup/claude-desktop.md
@@ -1,0 +1,52 @@
+# CacheBash — Claude Desktop Setup
+
+## Prerequisites
+
+- [Claude Desktop](https://claude.ai/download) installed
+- A CacheBash API key (generate one from the mobile app under Settings > API Keys)
+
+## Configuration
+
+1. Open Claude Desktop settings and navigate to the MCP configuration file:
+
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+2. Add the CacheBash server to your `mcpServers` block:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer CACHEBASH_API_KEY"
+      }
+    }
+  }
+}
+```
+
+3. Replace `CACHEBASH_API_KEY` with your actual API key (starts with `cb_`).
+
+4. Restart Claude Desktop to pick up the new configuration.
+
+## Verification
+
+After restarting, ask Claude to run a tool:
+
+```
+List my active sessions using CacheBash.
+```
+
+Claude should call `list_sessions` and return your session data. If you see results, the connection is working.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 Unauthorized` | Verify your API key is correct and active. Check for extra whitespace. |
+| `Connection refused` / timeout | Ensure you have internet access. The endpoint runs on GCP Cloud Run and may cold-start (~2s). |
+| Tools not appearing | Restart Claude Desktop completely (quit + reopen, not just close window). |
+| `Session expired` | Claude Desktop should handle session renewal automatically. If tools stop working mid-conversation, start a new conversation. |

--- a/mcp-server/docs/setup/cursor.md
+++ b/mcp-server/docs/setup/cursor.md
@@ -1,0 +1,57 @@
+# CacheBash — Cursor IDE Setup
+
+## Prerequisites
+
+- [Cursor](https://cursor.sh) IDE installed
+- A CacheBash API key (generate one from the mobile app under Settings > API Keys)
+
+## Configuration
+
+1. Open Cursor Settings (`Cmd+,` on macOS, `Ctrl+,` on Windows/Linux).
+
+2. Navigate to **Features > MCP Servers**.
+
+3. Click **Add new MCP server** and enter:
+
+   - **Name**: `cachebash`
+   - **Type**: `http`
+   - **URL**: `https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp`
+
+4. Alternatively, create a `.cursor/mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer CACHEBASH_API_KEY"
+      }
+    }
+  }
+}
+```
+
+5. Replace `CACHEBASH_API_KEY` with your actual API key (starts with `cb_`).
+
+6. Add `.cursor/mcp.json` to your `.gitignore`.
+
+## Verification
+
+Open Cursor's AI chat and ask:
+
+```
+Use CacheBash to list my active sessions.
+```
+
+If `list_sessions` returns data, the connection is working.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 Unauthorized` | Verify your API key is correct and hasn't been revoked. |
+| Server not appearing | Restart Cursor after adding the config. Check that the file is valid JSON. |
+| Tools timeout | Cloud Run cold starts can take ~2s. Retry the request. |
+| `Session expired` | Start a new chat session. MCP sessions may expire after extended idle time. |

--- a/mcp-server/docs/setup/generic-mcp.md
+++ b/mcp-server/docs/setup/generic-mcp.md
@@ -1,0 +1,90 @@
+# CacheBash — Generic MCP Client Setup
+
+For any client that implements the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+## Prerequisites
+
+- An MCP-compatible client with HTTP transport support
+- A CacheBash API key (generate one from the mobile app under Settings > API Keys)
+
+## Connection Details
+
+| Field | Value |
+|-------|-------|
+| **Transport** | Streamable HTTP |
+| **Endpoint** | `https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp` |
+| **Auth Header** | `Authorization: Bearer CACHEBASH_API_KEY` |
+| **Session Header** | `Mcp-Session-Id` (returned by server after initialize) |
+
+## Configuration
+
+Most MCP clients accept a JSON config in this format:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer CACHEBASH_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace `CACHEBASH_API_KEY` with your actual key (starts with `cb_`).
+
+## MCP Protocol Flow
+
+1. **Initialize**: Client sends `initialize` request. Server responds with capabilities and a session ID via the `Mcp-Session-Id` response header.
+2. **List Tools**: Client calls `tools/list` to discover available tools (18 tools across 6 modules).
+3. **Call Tools**: Client sends `tools/call` requests with tool name and arguments.
+
+## REST API Fallback
+
+Every MCP tool has a REST equivalent. Use this if your client doesn't support MCP or if the session expires:
+
+```bash
+# List tasks
+curl https://cachebash-mcp-922749444863.us-central1.run.app/v1/tasks?target=YOUR_TARGET \
+  -H "Authorization: Bearer CACHEBASH_API_KEY"
+
+# Send a message
+curl -X POST https://cachebash-mcp-922749444863.us-central1.run.app/v1/messages \
+  -H "Authorization: Bearer CACHEBASH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"source":"your-agent","target":"iso","message_type":"STATUS","message":"Hello"}'
+
+# Complete a task
+curl -X POST https://cachebash-mcp-922749444863.us-central1.run.app/v1/tasks/TASK_ID/complete \
+  -H "Authorization: Bearer CACHEBASH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"completed_status":"SUCCESS"}'
+```
+
+## Available Tools
+
+| Module | Tools |
+|--------|-------|
+| **Dispatch** | `get_tasks`, `create_task`, `claim_task`, `complete_task` |
+| **Relay** | `send_message`, `get_messages`, `get_sent_messages`, `query_message_history` |
+| **Pulse** | `create_session`, `update_session`, `list_sessions` |
+| **Signal** | `ask_question`, `get_response`, `send_alert` |
+| **Dream** | `dream_peek`, `dream_activate` |
+| **Sprint** | `create_sprint`, `update_sprint_story`, `complete_sprint`, `get_sprint` |
+
+## Verification
+
+Call `list_sessions` with no arguments. A successful response confirms auth and connectivity.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 Unauthorized` | Verify API key is correct and active. Must include `Bearer ` prefix. |
+| `Session expired or invalid` | Re-initialize the MCP session. Sessions timeout after 60 minutes of inactivity. |
+| Connection timeout | Cloud Run cold starts take ~2s. Retry once. |
+| `CORS` errors (browser clients) | The server allows CORS from all origins. Check your client's request headers. |
+| Tool not found | Call `tools/list` to see available tools. Tool names use underscores (e.g., `get_tasks`). |

--- a/mcp-server/docs/setup/windsurf.md
+++ b/mcp-server/docs/setup/windsurf.md
@@ -1,0 +1,55 @@
+# CacheBash — Windsurf IDE Setup
+
+## Prerequisites
+
+- [Windsurf](https://codeium.com/windsurf) IDE installed
+- A CacheBash API key (generate one from the mobile app under Settings > API Keys)
+
+## Configuration
+
+1. Open Windsurf and navigate to **Settings > MCP**.
+
+2. Click **Add Server** and configure:
+
+   - **Name**: `cachebash`
+   - **Transport**: `HTTP`
+   - **URL**: `https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp`
+
+3. Alternatively, create a `.windsurf/mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "cachebash": {
+      "type": "http",
+      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer CACHEBASH_API_KEY"
+      }
+    }
+  }
+}
+```
+
+4. Replace `CACHEBASH_API_KEY` with your actual API key (starts with `cb_`).
+
+5. Add `.windsurf/mcp.json` to your `.gitignore`.
+
+## Verification
+
+In Windsurf's Cascade chat, ask:
+
+```
+Use CacheBash to list my active sessions.
+```
+
+A successful response from `list_sessions` confirms the connection.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `401 Unauthorized` | Double-check the API key. Keys start with `cb_`. |
+| Server shows offline | Restart Windsurf after adding config. Verify JSON syntax. |
+| Slow first response | Expected — Cloud Run cold starts take ~2s on first request. |
+| `Session expired` | Start a new Cascade session. MCP sessions may timeout after extended idle. |


### PR DESCRIPTION
## Summary
- Add setup/quickstart guides for 5 MCP clients in `mcp-server/docs/setup/`
- Claude Desktop, Claude Code CLI, Cursor, Windsurf, and generic MCP client
- Each guide includes: prerequisites, JSON config, verification steps, troubleshooting

## Files
- `mcp-server/docs/setup/claude-desktop.md`
- `mcp-server/docs/setup/claude-code.md`
- `mcp-server/docs/setup/cursor.md`
- `mcp-server/docs/setup/windsurf.md`
- `mcp-server/docs/setup/generic-mcp.md`

## Test plan
- [ ] All config JSON snippets are valid
- [ ] Endpoint URL matches production
- [ ] REST fallback examples work