### PR TITLE
feat: Agent Trace L1 — Envelope, Schema, Indexes

### DIFF
--- a/infra/firestore.indexes.json
+++ b/infra/firestore.indexes.json
@@ -503,6 +503,30 @@
       "fields": [
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "traceId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "traceId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "ledger",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "context.traceId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/services/mcp-server/src/modules/dispatch.ts
+++ b/services/mcp-server/src/modules/dispatch.ts
@@ -41,6 +41,10 @@ const CreateTaskSchema = z.object({
     confidence: z.number().optional(),
   }).optional(),
   fallback: z.array(z.string()).optional(),
+  // Agent Trace L1
+  traceId: z.string().optional(),
+  spanId: z.string().optional(),
+  parentSpanId: z.string().optional(),
 });
 
 const ClaimTaskSchema = z.object({

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -32,6 +32,10 @@ const SendMessageSchema = z.object({
   }).optional(),
   payload: z.record(z.string(), z.unknown()).optional(),
   idempotency_key: z.string().max(100).optional(),
+  // Agent Trace L1
+  traceId: z.string().optional(),
+  spanId: z.string().optional(),
+  parentSpanId: z.string().optional(),
 });
 
 const GetMessagesSchema = z.object({

--- a/services/mcp-server/src/modules/trace.ts
+++ b/services/mcp-server/src/modules/trace.ts
@@ -23,6 +23,10 @@ export function extractContext(tool: string, args: unknown): Record<string, stri
     if (typeof a.sprintId === "string") ctx.sprintId = a.sprintId;
     if (typeof a.taskId === "string") ctx.taskId = a.taskId;
     if (typeof a.storyId === "string") ctx.storyId = a.storyId;
+    // Agent Trace L1
+    if (typeof a.traceId === "string") ctx.traceId = a.traceId;
+    if (typeof a.spanId === "string") ctx.spanId = a.spanId;
+    if (typeof a.parentSpanId === "string") ctx.parentSpanId = a.parentSpanId;
   }
   return ctx;
 }

--- a/services/mcp-server/src/types/envelope.ts
+++ b/services/mcp-server/src/types/envelope.ts
@@ -47,6 +47,11 @@ export interface Envelope {
 
   /** Ordered fallback targets if primary is unreachable */
   fallback?: string[];
+
+  /** Agent Trace L1 — correlation across task/relay/ledger boundaries */
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
 }
 
 /** Firestore timestamp type alias for cleaner signatures */

--- a/services/mcp-server/src/utils/trace.ts
+++ b/services/mcp-server/src/utils/trace.ts
@@ -1,0 +1,48 @@
+/**
+ * Trace utilities — UUID v7 generation for agent trace correlation.
+ * Zero external dependencies — uses Node.js crypto module.
+ */
+
+import { randomBytes } from "node:crypto";
+
+/**
+ * Generate a UUID v7 (timestamp-ordered, RFC 9562).
+ *
+ * Layout (128 bits):
+ *   48 bits  — unix_ts_ms (milliseconds since epoch)
+ *    4 bits  — version (0b0111 = 7)
+ *   12 bits  — rand_a
+ *    2 bits  — variant (0b10)
+ *   62 bits  — rand_b
+ */
+export function generateSpanId(): string {
+  const now = Date.now();
+  const rand = randomBytes(10); // 80 bits of randomness
+
+  // Bytes 0-5: 48-bit timestamp (big-endian)
+  const buf = Buffer.alloc(16);
+  buf[0] = (now / 2 ** 40) & 0xff;
+  buf[1] = (now / 2 ** 32) & 0xff;
+  buf[2] = (now / 2 ** 24) & 0xff;
+  buf[3] = (now / 2 ** 16) & 0xff;
+  buf[4] = (now / 2 ** 8) & 0xff;
+  buf[5] = now & 0xff;
+
+  // Bytes 6-7: version (4 bits) + rand_a (12 bits)
+  buf[6] = 0x70 | (rand[0] & 0x0f); // version 7
+  buf[7] = rand[1];
+
+  // Bytes 8-15: variant (2 bits) + rand_b (62 bits)
+  buf[8] = 0x80 | (rand[2] & 0x3f); // variant 10
+  buf[9] = rand[3];
+  buf[10] = rand[4];
+  buf[11] = rand[5];
+  buf[12] = rand[6];
+  buf[13] = rand[7];
+  buf[14] = rand[8];
+  buf[15] = rand[9];
+
+  // Format as 8-4-4-4-12 hex string
+  const hex = buf.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
## Summary
- Extends Envelope interface with optional `traceId`, `spanId`, `parentSpanId` fields (zero breaking changes)
- Creates `generateSpanId()` utility — UUID v7 (timestamp-ordered) with zero external dependencies
- Adds trace fields to `CreateTaskSchema`, `SendMessageSchema`, and `extractContext()` Zod schemas
- Adds Firestore composite indexes for trace queries on tasks, relay, and ledger collections

## Sprint Context
Agent Trace Layer 1, Story 1 (Wave 1 — no dependencies). Sprint: j9UUZ2ONmf1IJu9NbzlQ.
Stories 2-5 will add to this branch before merge.

## Test plan
- [ ] TypeScript compiles with no new errors
- [ ] Existing task/relay/trace tests pass (all new fields optional)
- [ ] Zod schemas accept requests with and without trace fields
- [ ] `generateSpanId()` produces valid UUID v7 format

🤖 Generated with [Claude Code](https://claude.com/claude-code)