### PR TITLE
chore: upgrade Firebase Functions to Node.js 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13769,13 +13769,23 @@
       },
       "devDependencies": {
         "@types/jest": "^29.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^22.0.0",
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.3.0"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
+      }
+    },
+    "services/functions/node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "services/mcp-server": {

--- a/services/functions/package.json
+++ b/services/functions/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "dependencies": {
     "firebase-admin": "^12.0.0",
@@ -22,7 +22,7 @@
     "@octokit/rest": "^22.0.1"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "typescript": "^5.3.0",
     "jest": "^29.0.0",
     "@types/jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from 20 to 22 in `services/functions/package.json`
- Bump `@types/node` from ^20 to ^22
- Node.js 20 EOL: April 30 2026

## Test plan
- [x] `npm run build` passes
- [ ] `firebase deploy --only functions` (post-merge)