### PR TITLE
feat: Phase 4 multi-tenant enforcement

### DIFF
--- a/services/mcp-server/src/__tests__/pricing.test.ts
+++ b/services/mcp-server/src/__tests__/pricing.test.ts
@@ -77,7 +77,7 @@ describe("pricingEnforce", () => {
   it("blocks free tier at 100% tasks_created", async () => {
     const userId = "user-free-100";
     firestoreDocs.set(`tenants/${userId}/config/billing`, { tier: "free" });
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 500,
       sessions_started: 0,
       messages_sent: 0,
@@ -92,7 +92,7 @@ describe("pricingEnforce", () => {
   it("allows pro tier with no warnings (infinity limit)", async () => {
     const userId = "user-pro-unlimited";
     firestoreDocs.set(`tenants/${userId}/config/billing`, { tier: "pro" });
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 10000,
       sessions_started: 0,
       messages_sent: 0,
@@ -109,7 +109,7 @@ describe("pricingEnforce", () => {
   it("allows team tier with no warnings (infinity limit)", async () => {
     const userId = "user-team-unlimited";
     firestoreDocs.set(`tenants/${userId}/config/billing`, { tier: "team" });
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 10000,
       sessions_started: 0,
       messages_sent: 0,
@@ -126,7 +126,7 @@ describe("pricingEnforce", () => {
   it("returns 80% warning", async () => {
     const userId = "user-free-80";
     firestoreDocs.set(`tenants/${userId}/config/billing`, { tier: "free" });
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 400,
       sessions_started: 0,
       messages_sent: 0,
@@ -143,7 +143,7 @@ describe("pricingEnforce", () => {
   it("returns 95% warning", async () => {
     const userId = "user-free-95";
     firestoreDocs.set(`tenants/${userId}/config/billing`, { tier: "free" });
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 480,
       sessions_started: 0,
       messages_sent: 0,
@@ -180,7 +180,7 @@ describe("pricingEnforce", () => {
 
   it("uses default free config for new tenants without billing doc", async () => {
     const userId = "user-new-tenant";
-    firestoreDocs.set(`usage/${userId}/periods/${getCurrentPeriod()}`, {
+    firestoreDocs.set(`tenants/${userId}/usage/${getCurrentPeriod()}`, {
       tasks_created: 500,
       sessions_started: 0,
       messages_sent: 0,

--- a/services/mcp-server/src/middleware/usage.ts
+++ b/services/mcp-server/src/middleware/usage.ts
@@ -41,7 +41,7 @@ export function getCurrentPeriod(): string {
 export function incrementUsage(userId: string, field: UsageField): void {
   const db = getFirestore();
   const period = getCurrentPeriod();
-  const docRef = db.collection("usage").doc(userId).collection("periods").doc(period);
+  const docRef = db.doc(`tenants/${userId}/usage/${period}`);
 
   docRef.set(
     { [field]: FieldValue.increment(1) },
@@ -61,7 +61,7 @@ export function incrementUsage(userId: string, field: UsageField): void {
 export async function getUsage(userId: string): Promise<UsageCounters> {
   const db = getFirestore();
   const period = getCurrentPeriod();
-  const docRef = db.collection("usage").doc(userId).collection("periods").doc(period);
+  const docRef = db.doc(`tenants/${userId}/usage/${period}`);
 
   const snapshot = await docRef.get();
 

--- a/services/mcp-server/src/modules/stale-session-detector.ts
+++ b/services/mcp-server/src/modules/stale-session-detector.ts
@@ -1,0 +1,75 @@
+/**
+ * Stale Session Detector — Identifies and archives sessions with no recent heartbeat.
+ * Called periodically from the cleanup interval in index.ts.
+ */
+
+import { getFirestore } from "../firebase/client.js";
+import { FieldValue } from "firebase-admin/firestore";
+
+interface StaleSession {
+  sessionId: string;
+  programId: string;
+  lastHeartbeat: string | null;
+  ageMinutes: number;
+  action: "warned" | "archived";
+}
+
+interface DetectionResult {
+  stale: StaleSession[];
+  archived: number;
+}
+
+const STALE_THRESHOLD_MS = 65 * 60 * 1000; // 65 minutes
+const ARCHIVE_THRESHOLD_MS = 120 * 60 * 1000; // 2 hours
+
+/**
+ * Detect sessions with no heartbeat for 65+ minutes.
+ * Sessions stale for 2+ hours are archived.
+ */
+export async function detectStaleSessions(userId: string): Promise<DetectionResult> {
+  const db = getFirestore();
+  const now = Date.now();
+  const staleThreshold = new Date(now - STALE_THRESHOLD_MS);
+
+  const sessionsSnap = await db.collection(`tenants/${userId}/sessions`)
+    .where("archived", "==", false)
+    .where("status", "in", ["active", "blocked"])
+    .get();
+
+  const stale: StaleSession[] = [];
+  let archived = 0;
+
+  for (const doc of sessionsSnap.docs) {
+    const data = doc.data();
+
+    // Skip pinned sessions
+    if (data.status === "blocked" && data.name?.includes("pinned")) continue;
+
+    const heartbeatTime = data.lastHeartbeat?.toDate?.() || data.lastUpdate?.toDate?.();
+    if (!heartbeatTime || heartbeatTime < staleThreshold) {
+      const staleMs = heartbeatTime ? now - heartbeatTime.getTime() : now;
+      const ageMinutes = Math.round(staleMs / 60000);
+      const shouldArchive = staleMs >= ARCHIVE_THRESHOLD_MS;
+
+      if (shouldArchive) {
+        await doc.ref.update({
+          status: "done",
+          archived: true,
+          archivedReason: "stale_heartbeat",
+          archivedAt: FieldValue.serverTimestamp(),
+        });
+        archived++;
+      }
+
+      stale.push({
+        sessionId: doc.id,
+        programId: data.programId || "unknown",
+        lastHeartbeat: heartbeatTime?.toISOString() || null,
+        ageMinutes,
+        action: shouldArchive ? "archived" : "warned",
+      });
+    }
+  }
+
+  return { stale, archived };
+}


### PR DESCRIPTION
## Summary
- Add **session concurrency enforcement** — checks active session count against billing tier limit (free: 1, pro: 5, team: unlimited) before allowing `create_session`
- Add **Retry-After header** to all 429 responses (tool rate limits and auth rate limits) per HTTP spec
- Fix **usage counter paths** from flat `usage/{userId}/periods/` to tenant-scoped `tenants/{userId}/usage/` for full data isolation
- Create **stale-session-detector** module (fixes pre-existing build error — referenced in index.ts but file was missing)

## Context
Phase 4 of CacheBash GTM. Key finding: Waves 1-2 (key resolution + tenant scoping) were already complete — all 34 tool handlers already use `tenants/${auth.userId}/` paths. This PR delivers Wave 3: billing tier enforcement.

## Files Changed
| File | Change |
|------|--------|
| `middleware/pricingEnforce.ts` | `countActiveSessions()` + concurrency check on `create_session` |
| `transport/rest.ts` | `Retry-After` header on 429 responses |
| `middleware/usage.ts` | Path fix: `usage/{uid}/periods/` → `tenants/{uid}/usage/` |
| `modules/stale-session-detector.ts` | New — detects/archives sessions with no heartbeat for 65+ min |
| `__tests__/pricing.test.ts` | Update mock paths to match tenant-scoped usage |

## Test plan
- [x] All 195 tests pass (10 suites)
- [x] TypeScript compiles clean
- [ ] Verify session concurrency blocking on free tier (manual)
- [ ] Verify Retry-After header present in 429 responses (manual)