### PR TITLE
fix: add ascAppId for TestFlight submit

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -43,6 +43,7 @@
     "production": {
       "ios": {
         "appleId": "christianbourlier@gmail.com",
+        "ascAppId": "6758489389",
         "appleTeamId": "FKFQ6KS8ZA"
       }
     }


### PR DESCRIPTION
## Summary
- Adds `ascAppId: "6758489389"` to `eas.json` submit.production.ios
- Enables non-interactive `eas submit` for TestFlight deploys

Generated with [Claude Code](https://claude.com/claude-code)