### PR TITLE
fix: iOS v1.0.0 build 32 for TestFlight

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "CacheBash",
     "slug": "cachebash",
-    "version": "1.1.0",
+    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.cachebash.app",
-      "buildNumber": "2",
+      "buildNumber": "32",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "UIBackgroundModes": ["remote-notification"]


### PR DESCRIPTION
## Summary
- Set version to 1.0.0 (matching existing ASC version)
- Set buildNumber to 32 (next after ASC's existing 31)
- Fixes silent rejection: no v1.1.0 in ASC + build number 9 < 31

## Next
Merge → rebuild → resubmit to TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)