### PR TITLE
fix: walkthrough replay race condition + add task dismiss UX

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
 import { OnboardingProvider, useOnboarding } from './src/contexts/OnboardingContext';
 import { NotificationProvider } from './src/contexts/NotificationContext';
@@ -80,15 +81,17 @@ function AppContentWithOnboarding() {
 
 export default function App() {
   return (
-    <SafeAreaProvider>
-      <ConnectivityProvider>
-        <AuthProvider>
-          <ErrorBoundary>
-            <StatusBar style="light" />
-            <AppContent />
-          </ErrorBoundary>
-        </AuthProvider>
-      </ConnectivityProvider>
-    </SafeAreaProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <ConnectivityProvider>
+          <AuthProvider>
+            <ErrorBoundary>
+              <StatusBar style="light" />
+              <AppContent />
+            </ErrorBoundary>
+          </AuthProvider>
+        </ConnectivityProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -28,6 +28,7 @@
     "firebase": "^11.2.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-gesture-handler": "~2.28.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0"
   },

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -231,7 +231,6 @@ export default function SettingsScreen() {
                     text: 'Replay',
                     onPress: async () => {
                       await resetOnboarding();
-                      navigation.navigate('Home');
                     },
                   },
                 ]

--- a/apps/mobile/src/services/api.ts
+++ b/apps/mobile/src/services/api.ts
@@ -183,14 +183,18 @@ class CacheBashAPI {
 
   async completeTask(
     taskId: string,
-    tokens_in?: number,
-    tokens_out?: number,
-    cost_usd?: number
+    params?: {
+      completed_status?: 'SUCCESS' | 'FAILED' | 'SKIPPED' | 'CANCELLED';
+      tokens_in?: number;
+      tokens_out?: number;
+      cost_usd?: number;
+    }
   ): Promise<any> {
     return this.post(`/tasks/${encodeURIComponent(taskId)}/complete`, {
-      ...(tokens_in !== undefined ? { tokens_in } : {}),
-      ...(tokens_out !== undefined ? { tokens_out } : {}),
-      ...(cost_usd !== undefined ? { cost_usd } : {}),
+      ...(params?.completed_status ? { completed_status: params.completed_status } : {}),
+      ...(params?.tokens_in !== undefined ? { tokens_in: params.tokens_in } : {}),
+      ...(params?.tokens_out !== undefined ? { tokens_out: params.tokens_out } : {}),
+      ...(params?.cost_usd !== undefined ? { cost_usd: params.cost_usd } : {}),
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "firebase": "^11.2.0",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-gesture-handler": "~2.28.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0"
       },
@@ -1639,6 +1640,18 @@
     "node_modules/@cachebash/types": {
       "resolved": "packages/types",
       "link": true
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@expo/cli": {
       "version": "54.0.23",
@@ -4136,6 +4149,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -7788,6 +7807,21 @@
         "hermes-estree": "0.29.1"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hono": {
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
@@ -11437,6 +11471,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {


### PR DESCRIPTION
## Summary

- **Story 1 (walkthrough-replay-fix):** Remove `navigation.navigate('Home')` after `resetOnboarding()` — context state swap (`isFirstRun = true`) triggers `OnboardingNavigator` automatically. Eliminates race condition where navigator hasn't swapped yet.
- **Story 2 (task-dismiss-api):** Add `completed_status` param to `api.completeTask()` method. Add `dismissTask(taskId)` and `dismissAllPending()` to `useTasks` hook — claims then completes with SKIPPED status.
- **Story 3 (task-dismiss-ux):** Swipe-to-dismiss on pending task cards via `react-native-gesture-handler`. "Clear All" button in header when Pending filter is active. Confirmation alert before bulk dismiss. Haptic feedback. `GestureHandlerRootView` wraps app root.

### Files changed
- `SettingsScreen.tsx` — remove `navigation.navigate('Home')` (1 line)
- `api.ts` — `completeTask` now accepts optional params object with `completed_status`
- `useTasks.ts` — add `dismissTask`, `dismissAllPending`, extract `refetch`
- `TasksScreen.tsx` — `Swipeable` wrapper on pending cards, Clear All button, new styles
- `App.tsx` — `GestureHandlerRootView` wrapper at root
- `package.json` — `react-native-gesture-handler` dependency

## Test plan
- [ ] Settings > Replay Walkthrough > Confirm > WelcomeScreen appears (no Home flash)
- [ ] Pending task > swipe left > Dismiss > task gone, badge updates
- [ ] Pending filter > Clear All > confirm > all pending cleared
- [ ] Active/Done tasks are NOT swipeable
- [ ] Existing "Complete" button on TaskDetail still works
- [ ] `npx expo start` builds without errors