### PR TITLE
fix: remove deprecated node/installCommand from eas.json

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,8 +7,6 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      "node": "22.x",
-      "installCommand": "cd ../.. && npm install",
       "ios": {
         "simulator": true
       }
@@ -16,8 +14,6 @@
     "preview": {
       "distribution": "internal",
       "channel": "preview",
-      "node": "22.x",
-      "installCommand": "cd ../.. && npm install",
       "ios": {
         "buildConfiguration": "Release"
       },
@@ -27,8 +23,6 @@
     },
     "production": {
       "channel": "production",
-      "node": "22.x",
-      "installCommand": "cd ../.. && npm install",
       "ios": {
         "buildConfiguration": "Release",
         "autoIncrement": true


### PR DESCRIPTION
EAS CLI 18.x rejects node ranges and installCommand. npm workspaces handles monorepo install. Unblocks TestFlight 1.1.0 build.