### PR TITLE
fix: single NavigationContainer for onboarding swap

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { NavigationContainer } from '@react-navigation/native';
+import { navigationRef } from './src/utils/navigationRef';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
 import { OnboardingProvider, useOnboarding } from './src/contexts/OnboardingContext';
 import { NotificationProvider } from './src/contexts/NotificationContext';
@@ -67,15 +69,17 @@ function AppContentWithOnboarding() {
     return <LoadingScreen />;
   }
 
-  if (isFirstRun) {
-    return <OnboardingNavigator />;
-  }
-
   return (
-    <NotificationProvider>
-      <ConnectionBanner />
-      <AppNavigation />
-    </NotificationProvider>
+    <NavigationContainer ref={navigationRef}>
+      {isFirstRun ? (
+        <OnboardingNavigator />
+      ) : (
+        <NotificationProvider>
+          <ConnectionBanner />
+          <AppNavigation />
+        </NotificationProvider>
+      )}
+    </NavigationContainer>
   );
 }
 

--- a/apps/mobile/src/navigation/OnboardingNavigator.tsx
+++ b/apps/mobile/src/navigation/OnboardingNavigator.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { NavigationContainer } from '@react-navigation/native';
-import { navigationRef } from '../utils/navigationRef';
 import WelcomeScreen from '../screens/onboarding/WelcomeScreen';
 import ConnectAgentScreen from '../screens/onboarding/ConnectAgentScreen';
 import FirstTaskScreen from '../screens/onboarding/FirstTaskScreen';
@@ -11,19 +9,17 @@ const Stack = createNativeStackNavigator();
 
 export default function OnboardingNavigator() {
   return (
-    <NavigationContainer ref={navigationRef}>
-      <Stack.Navigator
-        screenOptions={{
-          headerShown: false,
-          animation: 'slide_from_right',
-          contentStyle: { backgroundColor: '#0a0a0f' },
-        }}
-      >
-        <Stack.Screen name="Welcome" component={WelcomeScreen} />
-        <Stack.Screen name="ConnectAgent" component={ConnectAgentScreen} />
-        <Stack.Screen name="FirstTask" component={FirstTaskScreen} />
-        <Stack.Screen name="Completion" component={CompletionScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        animation: 'slide_from_right',
+        contentStyle: { backgroundColor: '#0a0a0f' },
+      }}
+    >
+      <Stack.Screen name="Welcome" component={WelcomeScreen} />
+      <Stack.Screen name="ConnectAgent" component={ConnectAgentScreen} />
+      <Stack.Screen name="FirstTask" component={FirstTaskScreen} />
+      <Stack.Screen name="Completion" component={CompletionScreen} />
+    </Stack.Navigator>
   );
 }

--- a/apps/mobile/src/navigation/index.tsx
+++ b/apps/mobile/src/navigation/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { ParamListBase } from '@react-navigation/native';
@@ -19,7 +18,6 @@ import FleetHealthScreen from '../screens/FleetHealthScreen';
 import UsageScreen from '../screens/UsageScreen';
 import KeyManagementScreen from '../screens/KeyManagementScreen';
 import ComposeMessageScreen from '../screens/ComposeMessageScreen';
-import { navigationRef } from '../utils/navigationRef';
 import { useTasks } from '../hooks/useTasks';
 import { useMessages } from '../hooks/useMessages';
 
@@ -217,31 +215,29 @@ export default function AppNavigation() {
   const { unreadCount } = useMessages();
 
   return (
-    <NavigationContainer ref={navigationRef}>
-      <Tab.Navigator
-        screenOptions={({ route }) => ({
-          tabBarIcon: ({ focused }) => {
-            let badge: number | undefined;
-            if (route.name === 'Messages') badge = unreadCount;
-            if (route.name === 'Tasks') badge = pendingCount;
-            return <TabIcon routeName={route.name} focused={focused} badge={badge} />;
-          },
-          tabBarShowLabel: true,
-          tabBarStyle: {
-            backgroundColor: '#0a0a0f',
-            borderTopColor: '#1a1a24',
-            paddingTop: 8,
-          },
-          tabBarActiveTintColor: '#00d4ff',
-          tabBarInactiveTintColor: '#6b7280',
-          headerShown: false,
-        })}
-      >
-        <Tab.Screen name="Home" component={HomeStackScreen} />
-        <Tab.Screen name="Messages" component={MessagesStackScreen} />
-        <Tab.Screen name="Tasks" component={TasksStackScreen} />
-        <Tab.Screen name="Settings" component={SettingsStackScreen} />
-      </Tab.Navigator>
-    </NavigationContainer>
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ focused }) => {
+          let badge: number | undefined;
+          if (route.name === 'Messages') badge = unreadCount;
+          if (route.name === 'Tasks') badge = pendingCount;
+          return <TabIcon routeName={route.name} focused={focused} badge={badge} />;
+        },
+        tabBarShowLabel: true,
+        tabBarStyle: {
+          backgroundColor: '#0a0a0f',
+          borderTopColor: '#1a1a24',
+          paddingTop: 8,
+        },
+        tabBarActiveTintColor: '#00d4ff',
+        tabBarInactiveTintColor: '#6b7280',
+        headerShown: false,
+      })}
+    >
+      <Tab.Screen name="Home" component={HomeStackScreen} />
+      <Tab.Screen name="Messages" component={MessagesStackScreen} />
+      <Tab.Screen name="Tasks" component={TasksStackScreen} />
+      <Tab.Screen name="Settings" component={SettingsStackScreen} />
+    </Tab.Navigator>
   );
 }


### PR DESCRIPTION
Dual NavigationContainer with shared navigationRef silently fails when React swaps between OnboardingNavigator and AppNavigation. Moves NavigationContainer to App.tsx so both navigators share one container.