### PR TITLE
fix: Firestore onboarding config rules

### DIFF
--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -86,11 +86,15 @@ service cloud.firestore {
       allow read, write: if isOwner(userId);
     }
 
-    // Config: read for owner, limited update for firstKey retrieval marking
+    // Config: read for owner, scoped writes per document
     match /tenants/{userId}/config/{configDoc} {
       allow read: if isOwner(userId);
+      // firstKey: mark as retrieved
       allow update: if isOwner(userId) && configDoc == 'firstKey'
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['retrieved']);
+      // onboarding: mobile client creates and updates progress
+      allow create: if isOwner(userId) && configDoc == 'onboarding';
+      allow update: if isOwner(userId) && configDoc == 'onboarding';
     }
 
     // Feedback: read own, write via Admin SDK only


### PR DESCRIPTION
## Summary
- Adds `create` and `update` rules for the `onboarding` config doc under `tenants/{userId}/config/`
- Previously only `firstKey` had update permission — onboarding reads failed silently, catch block set `isFirstRun=false`, hiding onboarding entirely
- Root cause of "Replay Walkthrough" not working and no onboarding on first sign-in

## Test plan
- [ ] Deploy rules: `firebase deploy --only firestore:rules --project cachebash-app`
- [ ] Verify on simulator: sign in → onboarding appears
- [ ] Verify replay: Settings → Replay Walkthrough → onboarding restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)