### PR TITLE
fix: keyboard dismiss on onboarding FirstTaskScreen

### DIFF
--- a/apps/mobile/src/screens/onboarding/FirstTaskScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/FirstTaskScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, Keyboard, TouchableWithoutFeedback, KeyboardAvoidingView, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../contexts/AuthContext';
@@ -43,7 +43,8 @@ export default function FirstTaskScreen({ navigation }: Props) {
   };
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top + 40 }]}>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+    <KeyboardAvoidingView style={[styles.container, { paddingTop: insets.top + 40 }]} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
       <View style={styles.content}>
         <Text style={styles.stepLabel}>Step 2 of 2</Text>
         <Text style={styles.title}>Send Your First Task</Text>
@@ -59,7 +60,8 @@ export default function FirstTaskScreen({ navigation }: Props) {
           onChangeText={setTitle}
           multiline
           maxLength={200}
-          autoFocus
+          returnKeyType="done"
+          blurOnSubmit
         />
 
         <Text style={styles.hint}>
@@ -86,7 +88,8 @@ export default function FirstTaskScreen({ navigation }: Props) {
           <Text style={styles.skipText}>Skip setup</Text>
         </TouchableOpacity>
       </View>
-    </View>
+    </KeyboardAvoidingView>
+    </TouchableWithoutFeedback>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wraps screen in `TouchableWithoutFeedback` + `KeyboardAvoidingView` so tapping outside dismisses the keyboard
- Removes `autoFocus` — let users read the screen first
- Adds `returnKeyType="done"` + `blurOnSubmit` so pressing Done on keyboard dismisses it

## Test plan
- [ ] Open onboarding Step 2 of 2 → keyboard does NOT auto-open
- [ ] Tap input → keyboard opens → tap outside → keyboard dismisses
- [ ] Type text → press Done → keyboard dismisses
- [ ] Buttons remain visible when keyboard is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)