### PR TITLE
fix: multi-tenant isolation — fail-closed capabilities

### DIFF
--- a/apps/mobile/src/screens/onboarding/ConnectAgentScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/ConnectAgentScreen.tsx
@@ -16,7 +16,7 @@ export default function ConnectAgentScreen({ navigation }: Props) {
   const configSnippet = `{
   "mcpServers": {
     "cachebash": {
-      "url": "https://cachebash-mcp-922749444863.us-central1.run.app/v1/mcp",
+      "url": "https://api.cachebash.dev/v1/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_KEY"
       }

--- a/services/functions/src/auth/onUserCreate.ts
+++ b/services/functions/src/auth/onUserCreate.ts
@@ -40,7 +40,14 @@ export const onUserCreate = functions.auth.user().onCreate(async (user) => {
       userId: uid,
       programId: "default",
       label: "Default API Key",
-      capabilities: ["*"],
+      capabilities: [
+        "dispatch.read", "dispatch.write",
+        "relay.read", "relay.write",
+        "pulse.read",
+        "signal.read", "signal.write",
+        "sprint.read",
+        "metrics.read", "fleet.read",
+      ],
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
       active: true,
     });

--- a/services/mcp-server/src/__tests__/capabilities.test.ts
+++ b/services/mcp-server/src/__tests__/capabilities.test.ts
@@ -130,8 +130,8 @@ describe('Capability System', () => {
       expect(getDefaultCapabilities('builder')).toContain('dispatch.read');
     });
 
-    it('returns wildcard for unknown programs (fail-open)', () => {
-      expect(getDefaultCapabilities('unknown_program')).toEqual(['*']);
+    it('returns empty capabilities for unknown programs (fail-closed)', () => {
+      expect(getDefaultCapabilities('unknown_program')).toEqual([]);
     });
   });
 });

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -116,6 +116,10 @@ export const DEFAULT_CAPABILITIES: Record<string, Capability[]> = {
   oauth: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
     "pulse.read", "pulse.write", "signal.read", "signal.write",
     "state.read", "state.write", "sprint.read"],
+  // External users — restricted, no admin/audit/keys/state-write
+  default: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "signal.read", "signal.write",
+    "sprint.read", "metrics.read", "fleet.read"],
 };
 
 /**
@@ -148,8 +152,13 @@ export function checkToolCapability(
 
 /**
  * Get default capabilities for a program.
- * Returns ["*"] for unknown programs (fail-open for now, tighten in Phase 5).
+ * Fail-closed: unknown programs get no capabilities.
  */
 export function getDefaultCapabilities(programId: string): Capability[] {
-  return DEFAULT_CAPABILITIES[programId] || ["*"];
+  const caps = DEFAULT_CAPABILITIES[programId];
+  if (!caps) {
+    console.warn(`[Capabilities] Unknown programId "${programId}" — returning empty capabilities`);
+    return [];
+  }
+  return caps;
 }


### PR DESCRIPTION
## Summary

Ship-blocker: external CacheBash users could see Grid task queue and access admin-level tools due to wildcard capability grants.

**Root causes fixed:**
- `onUserCreate` Cloud Function provisioned new API keys with `capabilities: ["*"]` (full admin access) — now grants explicit restricted set matching `DEFAULT_CAPABILITIES["default"]`
- `getDefaultCapabilities()` returned `["*"]` for unknown programIds (fail-open) — now returns empty array (fail-closed) with warning log
- Cleanup loop assumed single-tenant (broke after first session) — now iterates all distinct tenant userIds
- ConnectAgentScreen exposed raw Cloud Run URL — changed to `api.cachebash.dev`
- Added `[TENANT]` logging at tool handler entry for multi-tenant audit trail

**Files changed:**
- `services/functions/src/auth/onUserCreate.ts` — restricted default key capabilities
- `services/mcp-server/src/middleware/capabilities.ts` — fail-closed + "default" role entry
- `services/mcp-server/src/index.ts` — tenant logging + multi-tenant cleanup loop
- `apps/mobile/src/screens/onboarding/ConnectAgentScreen.tsx` — public API URL
- `services/mcp-server/src/__tests__/capabilities.test.ts` — updated assertion

## Test plan
- [x] 195 unit tests pass (including updated fail-closed assertion)
- [x] TypeScript builds clean (mcp-server + functions)
- [ ] Deploy functions: `firebase deploy --only functions:onUserCreate`
- [ ] Deploy mcp-server: `gcloud run deploy` from `services/mcp-server/`
- [ ] Verify new user signup gets restricted capabilities (not wildcard)
- [ ] Verify existing Grid programs (orchestrator, builder, etc.) still get correct capabilities