### PR TITLE
fix: remove expiresAt TTL from firstKey doc

### DIFF
--- a/services/functions/src/auth/onUserCreate.ts
+++ b/services/functions/src/auth/onUserCreate.ts
@@ -56,10 +56,8 @@ export const onUserCreate = functions.auth.user().onCreate(async (user) => {
     await db.doc(`tenants/${uid}/config/firstKey`).set({
       key: Buffer.from(rawKey).toString("base64"),
       keyHash,
-      expiresAt: admin.firestore.Timestamp.fromDate(
-        new Date(Date.now() + 24 * 60 * 60 * 1000)
-      ),
       retrieved: false,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
     });
 
     // 6. Create billing config (free tier default)


### PR DESCRIPTION
## Summary
- Remove redundant 24h `expiresAt` TTL from firstKey document in `onUserCreate`
- The `retrieved` flag is the real gate — TTL could delete the doc before slow onboarding completes
- Mobile already checks `retrieved`, not `expiresAt`

Sprint: giCfkKCjlsHLapBGabtM / Story: firstkey-ttl

## Test plan
- [ ] firstKey doc no longer has expiresAt field
- [ ] Key still shows on mobile until retrieved=true
- [ ] Existing users with TTL'd docs unaffected