### PR TITLE
feat: atomic key rotation — rotateApiKey Cloud Function

### DIFF
--- a/services/functions/src/index.ts
+++ b/services/functions/src/index.ts
@@ -6,7 +6,7 @@ admin.initializeApp();
 export { onUserCreate } from "./auth/onUserCreate";
 
 // Key management (callable)
-export { createUserKey, revokeUserKey, updateKeyLabel } from "./auth/keyManagement";
+export { createUserKey, revokeUserKey, rotateApiKey, updateKeyLabel } from "./auth/keyManagement";
 
 // CLI auth (HTTP)
 export { cliAuthApprove, cliAuthStatus } from "./auth/cliAuth";


### PR DESCRIPTION
## Summary
- **`rotateApiKey`** callable Cloud Function: revoke old key + issue new key in a single Firestore transaction
- Preserves capabilities, programId, and label from the old key
- Adds `rotatedFrom`/`rotatedTo` audit chain and `revokedReason` field (`manual` | `rotation` | `admin`)
- Rejects rotation of already-revoked keys
- Also fixes `createUserKey` wildcard capabilities — now uses scoped set matching `onUserCreate`

Sprint: giCfkKCjlsHLapBGabtM / Story: key-rotation

## Schema additions (keyIndex docs)
```
rotatedFrom?: string      // predecessor key hash
rotatedTo?: string        // successor key hash
revokedReason?: string    // 'manual' | 'rotation' | 'admin'
```

## Test plan
- [ ] Call rotateApiKey with valid keyHash → new key returned, old key revoked
- [ ] Old key returns 401 after rotation
- [ ] New key works with same capabilities as old key
- [ ] rotatedFrom/rotatedTo chain visible in key docs
- [ ] Cannot rotate already-revoked key
- [ ] Cannot rotate another user's key

## Not included (future PRs)
- 30s grace window via Cloud Tasks (needs API enablement check)
- CLI `npx cachebash rotate` command
- Mobile Settings UI for rotation