### PR TITLE
fix: CLI auth TOCTOU race, idempotency, CORS lockdown

### DIFF
--- a/services/functions/src/auth/cliAuth.ts
+++ b/services/functions/src/auth/cliAuth.ts
@@ -16,23 +16,38 @@ import { randomBytes, createHash } from "crypto";
 const db = admin.firestore();
 const SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
-/**
- * POST — Called by the browser after user authenticates via Firebase Auth.
- * Creates a CLI session with an auto-generated API key.
- *
- * Body: { sessionToken: string, idToken: string }
- * The idToken is verified to get the userId.
- */
-export const cliAuthApprove = functions.https.onRequest(async (req, res) => {
-  // CORS
-  res.set("Access-Control-Allow-Origin", "*");
-  res.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+// CORS: only allow the Firebase Hosting origin (where cli-auth.html is served)
+const ALLOWED_ORIGINS = [
+  "https://cachebash-app.web.app",
+  "https://cachebash-app.firebaseapp.com",
+  "https://app.cachebash.dev",
+];
+
+function setCorsHeaders(req: functions.https.Request, res: functions.Response): boolean {
+  const origin = req.headers.origin as string | undefined;
+  if (origin && ALLOWED_ORIGINS.includes(origin)) {
+    res.set("Access-Control-Allow-Origin", origin);
+  }
+  res.set("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
   res.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.set("Vary", "Origin");
 
   if (req.method === "OPTIONS") {
     res.status(204).send("");
-    return;
+    return true;
   }
+  return false;
+}
+
+/**
+ * POST — Called by the browser after user authenticates via Firebase Auth.
+ * Idempotent: if session is already approved, returns success without creating
+ * a new key. Uses a transaction to prevent concurrent approve races.
+ *
+ * Body: { sessionToken: string, idToken: string }
+ */
+export const cliAuthApprove = functions.https.onRequest(async (req, res) => {
+  if (setCorsHeaders(req, res)) return;
 
   if (req.method !== "POST") {
     res.status(405).json({ error: "Method not allowed" });
@@ -51,52 +66,69 @@ export const cliAuthApprove = functions.https.onRequest(async (req, res) => {
     const decoded = await admin.auth().verifyIdToken(idToken);
     const userId = decoded.uid;
 
-    // Generate API key (same pattern as keyManagement.ts)
-    const rawKey = `cb_live_${randomBytes(24).toString("hex")}`;
-    const keyHash = createHash("sha256").update(rawKey).digest("hex");
+    const sessionRef = db.collection("cli_sessions").doc(sessionToken);
 
-    // Check active key count (max 10)
-    const existingKeys = await db
-      .collection("keyIndex")
-      .where("userId", "==", userId)
-      .where("active", "==", true)
-      .get();
+    await db.runTransaction(async (tx) => {
+      const sessionDoc = await tx.get(sessionRef);
 
-    if (existingKeys.size >= 10) {
-      res.status(400).json({ error: "Maximum 10 active API keys. Revoke an existing key first." });
-      return;
-    }
+      // Idempotent: if already approved, do nothing
+      if (sessionDoc.exists && sessionDoc.data()?.status === "approved") {
+        return;
+      }
 
-    // Write API key to keyIndex (canonical path — matches onUserCreate)
-    const now = admin.firestore.FieldValue.serverTimestamp();
-    await db.collection("keyIndex").doc(keyHash).set({
-      userId,
-      programId: "default",
-      label: "CLI (auto-generated)",
-      capabilities: [
-        "dispatch.read", "dispatch.write",
-        "relay.read", "relay.write",
-        "pulse.read",
-        "signal.read", "signal.write",
-        "sprint.read",
-        "metrics.read", "fleet.read",
-      ],
-      active: true,
-      createdAt: now,
-      createdBy: "cli-auth",
-    });
+      // Check active key count (max 10)
+      const existingKeys = await db
+        .collection("keyIndex")
+        .where("userId", "==", userId)
+        .where("active", "==", true)
+        .get();
 
-    // Store CLI session (for polling)
-    await db.collection("cli_sessions").doc(sessionToken).set({
-      userId,
-      apiKey: rawKey,
-      status: "approved",
-      expiresAt: new Date(Date.now() + SESSION_TTL_MS),
-      createdAt: now,
+      if (existingKeys.size >= 10) {
+        throw new functions.https.HttpsError(
+          "resource-exhausted",
+          "Maximum 10 active API keys. Revoke an existing key first."
+        );
+      }
+
+      // Generate API key
+      const rawKey = `cb_live_${randomBytes(24).toString("hex")}`;
+      const keyHash = createHash("sha256").update(rawKey).digest("hex");
+      const now = admin.firestore.FieldValue.serverTimestamp();
+
+      // Write API key to keyIndex
+      tx.set(db.collection("keyIndex").doc(keyHash), {
+        userId,
+        programId: "default",
+        label: "CLI (auto-generated)",
+        capabilities: [
+          "dispatch.read", "dispatch.write",
+          "relay.read", "relay.write",
+          "pulse.read",
+          "signal.read", "signal.write",
+          "sprint.read",
+          "metrics.read", "fleet.read",
+        ],
+        active: true,
+        createdAt: now,
+        createdBy: "cli-auth",
+      });
+
+      // Store CLI session (for polling)
+      tx.set(sessionRef, {
+        userId,
+        apiKey: rawKey,
+        status: "approved",
+        expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+        createdAt: now,
+      });
     });
 
     res.status(200).json({ success: true });
   } catch (err: any) {
+    if (err.code === "resource-exhausted") {
+      res.status(400).json({ error: err.message });
+      return;
+    }
     console.error("[cliAuth] Approve failed:", err);
     res.status(500).json({ error: "Authentication failed" });
   }
@@ -104,22 +136,14 @@ export const cliAuthApprove = functions.https.onRequest(async (req, res) => {
 
 /**
  * GET — Called by CLI polling for approval status.
+ * Uses a transaction to atomically read + delete the session (TOCTOU fix).
+ * Only the first successful poll gets the API key; subsequent calls get 404.
  *
  * Query: ?session={token}
  * Returns: { status: "pending" | "approved" | "expired", apiKey?, userId? }
- *
- * After first successful retrieval, deletes the session (one-time use).
  */
 export const cliAuthStatus = functions.https.onRequest(async (req, res) => {
-  // CORS
-  res.set("Access-Control-Allow-Origin", "*");
-  res.set("Access-Control-Allow-Methods", "GET, OPTIONS");
-  res.set("Access-Control-Allow-Headers", "Content-Type");
-
-  if (req.method === "OPTIONS") {
-    res.status(204).send("");
-    return;
-  }
+  if (setCorsHeaders(req, res)) return;
 
   if (req.method !== "GET") {
     res.status(405).json({ error: "Method not allowed" });
@@ -134,35 +158,44 @@ export const cliAuthStatus = functions.https.onRequest(async (req, res) => {
   }
 
   try {
-    const doc = await db.collection("cli_sessions").doc(sessionToken).get();
+    const sessionRef = db.collection("cli_sessions").doc(sessionToken);
 
-    if (!doc.exists) {
-      res.status(200).json({ status: "pending" });
-      return;
+    interface StatusResult {
+      status: string;
+      apiKey?: string;
+      userId?: string;
     }
 
-    const data = doc.data()!;
+    const result = await db.runTransaction<StatusResult>(async (tx) => {
+      const doc = await tx.get(sessionRef);
 
-    // Check expiration
-    const expiresAt = data.expiresAt?.toDate?.() || new Date(data.expiresAt);
-    if (expiresAt < new Date()) {
-      await doc.ref.delete();
-      res.status(200).json({ status: "expired" });
-      return;
-    }
+      if (!doc.exists) {
+        return { status: "pending" };
+      }
 
-    if (data.status === "approved") {
-      // One-time use — delete after retrieval
-      await doc.ref.delete();
-      res.status(200).json({
-        status: "approved",
-        apiKey: data.apiKey,
-        userId: data.userId,
-      });
-      return;
-    }
+      const data = doc.data()!;
 
-    res.status(200).json({ status: data.status || "pending" });
+      // Check expiration
+      const expiresAt = data.expiresAt?.toDate?.() || new Date(data.expiresAt);
+      if (expiresAt < new Date()) {
+        tx.delete(sessionRef);
+        return { status: "expired" };
+      }
+
+      if (data.status === "approved") {
+        // Atomic read + delete — only first caller gets the key
+        tx.delete(sessionRef);
+        return {
+          status: "approved",
+          apiKey: data.apiKey,
+          userId: data.userId,
+        };
+      }
+
+      return { status: data.status || "pending" };
+    });
+
+    res.status(200).json(result);
   } catch (err: any) {
     console.error("[cliAuth] Status check failed:", err);
     res.status(500).json({ error: "Status check failed" });


### PR DESCRIPTION
## Summary
- **B-1 (TOCTOU):** `cliAuthStatus` now uses Firestore transaction for atomic read+delete. Only the first poll gets the API key — concurrent polls see the doc already deleted.
- **B-2 (Idempotency):** `cliAuthApprove` uses a transaction. If session is already approved, returns success without creating a duplicate key. Prevents orphaned active keys.
- **H-1 (CORS):** Replace wildcard `*` CORS with allowlist — Firebase Hosting origins only (`cachebash-app.web.app`, `cachebash-app.firebaseapp.com`, `app.cachebash.dev`). CLI polls from localhost don't send Origin headers so aren't affected.

Sprint: giCfkKCjlsHLapBGabtM
Refs: ALAN PR#312, SARK PR#314, task E4O72HUyaK7FH4XIUIrm

## Test plan
- [ ] Two concurrent cliAuthStatus polls → only first gets the key, second gets `{ status: "pending" }`
- [ ] Two concurrent cliAuthApprove calls → only one key created, both return success
- [ ] CORS preflight from unauthorized origin → no Access-Control-Allow-Origin header
- [ ] Normal flow: CLI init → browser auth → poll gets key → works