### PR TITLE
fix: align @types/node in functions workspace

### DIFF
--- a/services/functions/package.json
+++ b/services/functions/package.json
@@ -17,16 +17,16 @@
     "node": "22"
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.1",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^5.0.0",
-    "@octokit/rest": "^22.0.1"
+    "firebase-functions": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.3.0",
-    "jest": "^29.0.0",
     "@types/jest": "^29.0.0",
-    "ts-jest": "^29.0.0"
+    "@types/node": "^20.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.3.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- Relaxes `@types/node` from `^22.19.12` to `^20.0.0` in `services/functions/package.json`
- Fixes Firebase Cloud Build `npm ci` failure — root lock file hoists `@types/node@20.19.33` (shared by mcp-server + cli workspaces) which didn't satisfy the `^22` constraint
- Type defs are compatible for the firebase-functions v1 API surface

## Test plan
- [ ] `firebase deploy --only functions` succeeds after merge