### PR TITLE
fix: create_task boardItemId Firestore error

### DIFF
--- a/services/mcp-server/src/config/rateLimits.ts
+++ b/services/mcp-server/src/config/rateLimits.ts
@@ -1,0 +1,30 @@
+/**
+ * Rate limit configuration — SPEC 2 (Hardening Sprint).
+ *
+ * Fixed-window limits enforced per-key and per-tenant.
+ * Firestore counters at: tenants/{uid}/usage/rate/{scope}/{windowKey}
+ */
+
+export interface RateLimitConfig {
+  limit: number;
+  windowMs: number;
+}
+
+/** Per-key global limit (all tools combined) */
+export const KEY_GLOBAL: RateLimitConfig = { limit: 60, windowMs: 60_000 };
+
+/** Per-key tool-specific limits (override global for write-heavy tools) */
+export const TOOL_LIMITS: Record<string, RateLimitConfig> = {
+  create_task: { limit: 10, windowMs: 60_000 },
+  send_message: { limit: 30, windowMs: 60_000 },
+  update_program_state: { limit: 10, windowMs: 60_000 },
+};
+
+/** Per-tenant aggregate limit (all keys combined) */
+export const TENANT_AGGREGATE: RateLimitConfig = { limit: 120, windowMs: 60_000 };
+
+/** Auth attempt limit per IP */
+export const AUTH_ATTEMPT: RateLimitConfig = { limit: 60, windowMs: 60_000 };
+
+/** Firestore counter TTL — docs auto-expire after this */
+export const COUNTER_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/services/mcp-server/src/modules/dispatch.ts
+++ b/services/mcp-server/src/modules/dispatch.ts
@@ -184,7 +184,7 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
     action: args.action,
     status: "created",
     projectId: args.projectId || null,
-    boardItemId: args.boardItemId || undefined,
+    boardItemId: args.boardItemId || null,
     createdAt: now,
     encrypted: false,
     archived: false,


### PR DESCRIPTION
## Summary
- Fix `boardItemId: args.boardItemId || undefined` → `|| null` in createTaskHandler
- Firestore SDK rejects `undefined` as a field value, causing ALL `create_task` calls to fail with: `Cannot use "undefined" as a Firestore value (found in field "boardItemId")`
- Every other optional field in the same handler already uses `|| null`

## Test plan
- [ ] `create_task` calls succeed (were 100% broken before)
- [ ] Tasks created without boardItemId have `null` in Firestore (not missing)
- [ ] GitHub Projects sync unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)