### PR TITLE
fix: sync package-lock.json for EAS builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4221,9 +4221,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.34.tgz",
+      "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -13818,7 +13818,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.0.0",
-        "@types/node": "^22.0.0",
+        "@types/node": "^20.0.0",
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "typescript": "^5.3.0"


### PR DESCRIPTION
## Summary
- Regenerate package-lock.json to sync @types/node version (20.19.33 → 20.19.34)
- PR #168 bumped the version in package.json but lockfile wasn't updated
- This causes all EAS iOS builds to fail at dependency install (`npm ci` requires exact sync)

## Test plan
- [ ] EAS build succeeds after merge
- [ ] `npm ci` runs clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)