### PR TITLE
chore: scope CLI package name to @rezzed.ai/cachebash

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cachebash",
+  "name": "@rezzed.ai/cachebash",
   "version": "0.1.0",
   "description": "CacheBash CLI — MCP agent coordination for AI workflows",
   "bin": { "cachebash": "./bin/cachebash.js" },


### PR DESCRIPTION
## Summary
- Scoped CLI package name from `cachebash` to `@rezzed.ai/cachebash`
- npm blocked unscoped name (too similar to existing `cache-base` package)
- Published and verified as `@rezzed.ai/cachebash@0.1.0`

## Test plan
- [x] `npx @rezzed.ai/cachebash@0.1.0 --help` returns expected output