### PR TITLE
fix: sync lockfile with @rezzed.ai/cachebash scope rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4008,6 +4008,10 @@
         "nanoid": "^3.3.11"
       }
     },
+    "node_modules/@rezzed.ai/cachebash": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -5101,10 +5105,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/cachebash": {
-      "resolved": "packages/cli",
-      "link": true
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -13694,7 +13694,7 @@
       }
     },
     "packages/cli": {
-      "name": "cachebash",
+      "name": "@rezzed.ai/cachebash",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Regenerates `package-lock.json` after PR #171 renamed `cachebash` → `@rezzed.ai/cachebash`
- `npm ci` was failing with `Missing: @rezzed.ai/cachebash@0.1.0 from lock file`
- Verified `npm ci` passes clean with updated lockfile

## Test plan
- [x] `npm ci` succeeds locally
- [x] CI should pass once merged