### PR TITLE
fix: CLI auth URL → working Firebase Hosting domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13695,7 +13695,7 @@
     },
     "packages/cli": {
       "name": "@rezzed.ai/cachebash",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "open": "~10.1.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rezzed.ai/cachebash",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CacheBash CLI — MCP agent coordination for AI workflows",
   "bin": { "cachebash": "./bin/cachebash.js" },
   "main": "dist/index.js",

--- a/packages/cli/src/auth/browser-auth.ts
+++ b/packages/cli/src/auth/browser-auth.ts
@@ -1,8 +1,11 @@
 import { randomBytes } from "node:crypto";
 import { Spinner, printStep, printWarning, printError } from "../ui/output.js";
 
-const CLI_AUTH_BASE = "https://cachebash.rezzed.ai/cli-auth";
-const POLL_URL = "https://us-central1-cachebash-app.cloudfunctions.net/cliAuthStatus";
+const CLI_AUTH_BASE =
+  process.env.CACHEBASH_AUTH_URL ?? "https://cachebash-app.web.app/cli-auth";
+const POLL_URL =
+  process.env.CACHEBASH_POLL_URL ??
+  "https://us-central1-cachebash-app.cloudfunctions.net/cliAuthStatus";
 const POLL_INTERVAL_MS = 2000;
 const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 


### PR DESCRIPTION
## Summary
- **CLI auth was broken**: `cachebash.rezzed.ai/cli-auth` has no DNS record — fresh users hit dead page
- **Updated `CLI_AUTH_BASE`** to `cachebash-app.web.app/cli-auth` (deployed & verified 200 OK)
- **Deployed hosting**: `firebase deploy --only hosting` — cli-auth.html now live
- **Added env var overrides**: `CACHEBASH_AUTH_URL` and `CACHEBASH_POLL_URL` for future migration to `app.cachebash.dev`
- **Bumped CLI to v0.1.1**

## What's NOT in this PR (requires manual action)
- **Story 1 — DNS**: `app.cachebash.dev` needs to be connected to Firebase Hosting via console + DNS registrar. Firebase CLI has no custom domain commands. Once DNS is ready, update the default URL.
- **Story 3 — E2E**: Needs browser-based OAuth test. Auth page is live at `cachebash-app.web.app/cli-auth` — can be tested manually.
- **npm publish**: `npm publish` for `@rezzed.ai/cachebash@0.1.1` — needs npm auth credentials.

## Tech debt logged
- Migrate `cliAuthApprove`/`cliAuthStatus` from Cloud Functions to Cloud Run under `api.cachebash.dev`

## Test plan
- [x] `firebase deploy --only hosting` — success
- [x] `curl cachebash-app.web.app/cli-auth` — 200 OK
- [x] `tsc --noEmit` — clean build
- [ ] Manual: `npx @rezzed.ai/cachebash init` → browser → OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)