### PR TITLE
fix: strip undefined values before Firestore write in emitEvent()

### DIFF
--- a/services/mcp-server/src/modules/events.ts
+++ b/services/mcp-server/src/modules/events.ts
@@ -97,8 +97,12 @@ export function computeHash(content: string): string {
 export function emitEvent(userId: string, data: EventData): void {
   try {
     const db = getFirestore();
+    // Strip undefined values — Firestore rejects them
+    const cleaned = Object.fromEntries(
+      Object.entries(data).filter(([, v]) => v !== undefined)
+    );
     db.collection(`tenants/${userId}/events`).add({
-      ...data,
+      ...cleaned,
       timestamp: serverTimestamp(),
     }).catch((err) => {
       console.error("[Events] Failed to write event:", err);


### PR DESCRIPTION
## Summary
- Cloud Run logs show repeated Firestore errors: `Cannot use "undefined" as a Firestore value (found in field "tokens_in")`
- Root cause: `emitEvent()` spreads caller data directly into a Firestore `add()` call. When optional telemetry fields (`tokens_in`, `tokens_out`, `cost_usd`) are omitted by callers, they spread as `undefined`
- Fix: filter `undefined` entries from the data object before the Firestore write

## Test plan
- [ ] Deploy to Cloud Run and verify no more `undefined` Firestore errors in logs
- [ ] Confirm events still write correctly when all fields are present
- [ ] Confirm events write correctly when optional telemetry fields are omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)