### PR TITLE
fix: suppress OAuth discovery hijack on static API key 401s

### DIFF
--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -764,12 +764,14 @@ async function main() {
       const clientIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown';
       const proto = req.headers["x-forwarded-proto"] || "https";
       const host = req.headers.host || "localhost";
-      const wwwAuth = `Bearer resource_metadata="${proto}://${host}/.well-known/oauth-authorization-server"`;
+      const oauthWwwAuth = `Bearer resource_metadata="${proto}://${host}/.well-known/oauth-authorization-server"`;
+      const plainWwwAuth = `Bearer realm="cachebash"`;
 
       const token = extractBearerToken(req.headers.authorization);
       if (!token) {
         checkAuthRateLimit(clientIp);
-        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": wwwAuth });
+        // No token at all — advertise OAuth discovery for OAuth-capable clients
+        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": oauthWwwAuth });
         res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
         return;
       }
@@ -779,6 +781,10 @@ async function main() {
         if (!checkAuthRateLimit(clientIp)) {
           return sendJson(res, 429, { error: "Too many authentication attempts. Try again later." });
         }
+        // Static API key (cb_ prefix) failed — don't advertise OAuth discovery.
+        // Claude Code follows resource_metadata URLs, abandons the static token, and fails.
+        // Only advertise OAuth when an OAuth token (cbo_) was presented.
+        const wwwAuth = token.startsWith("cbo_") ? oauthWwwAuth : plainWwwAuth;
         res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": wwwAuth });
         res.end(JSON.stringify({ error: "unauthorized", error_description: "Invalid or expired token" }));
         return;


### PR DESCRIPTION
## Summary

- **P0 fix** — CacheBash MCP server returns `www-authenticate` with `resource_metadata` URL on ALL 401 responses at `/v1/mcp`
- Claude Code follows the OAuth discovery URL per MCP OAuth 2.1 spec, abandons the static Bearer token from `.mcp.json`, and fails to connect
- Fix: make `WWW-Authenticate` header conditional on token type:
  - **No token** → advertise OAuth discovery (`resource_metadata`) for OAuth-capable clients
  - **OAuth token (`cbo_` prefix)** → advertise OAuth discovery
  - **Static API key (`cb_` prefix)** → plain `Bearer realm="cachebash"` (no `resource_metadata`)

## Root Cause

Council assessments (ALAN, SARK, CLU) confirm at 92% confidence. GitHub issue #7290 confirms Anthropic will not fix client-side — the server must not trigger OAuth discovery for static Bearer token auth.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Full test suite — 503/503 passing
- [ ] Deploy to Cloud Run and verify Claude Code MCP connectivity
- [ ] Verify OAuth flow still works for `cbo_` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)