### PR TITLE
fix: suppress OAuth discovery on ALL 401s, disable metadata endpoint

### DIFF
--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -337,9 +337,12 @@ async function main() {
     }
 
     // OAuth endpoints (public — no Bearer auth required)
-    if (url === "/.well-known/oauth-authorization-server" && req.method === "GET") {
-      return handleOAuthMetadata(req, res);
-    }
+    // DISABLED: OAuth metadata discovery causes Claude Code to abandon static Bearer auth
+    // and attempt OAuth 2.1 flow, which fails. See: GitHub #7290, grid/assessments/*mcp-connectivity*
+    // Re-enable when CacheBash has real OAuth client support for external consumers.
+    // if (url === "/.well-known/oauth-authorization-server" && req.method === "GET") {
+    //   return handleOAuthMetadata(req, res);
+    // }
     if (url === "/register" && req.method === "POST") {
       // Pass optional Bearer auth for service account registration
       const regToken = extractBearerToken(req.headers.authorization);
@@ -770,8 +773,10 @@ async function main() {
       const token = extractBearerToken(req.headers.authorization);
       if (!token) {
         checkAuthRateLimit(clientIp);
-        // No token at all — advertise OAuth discovery for OAuth-capable clients
-        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": oauthWwwAuth });
+        // No token — use plain Bearer header. OAuth discovery (resource_metadata) causes
+        // Claude Code to abandon static Bearer auth and attempt OAuth 2.1 flow, which fails.
+        // See: grid/assessments/*mcp-connectivity*2026-03-18*, GitHub #7290
+        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": plainWwwAuth });
         res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
         return;
       }


### PR DESCRIPTION
## Summary
- Prior fix (#326) only suppressed `resource_metadata` on invalid-token 401s
- Claude Code probes WITHOUT a token first, gets the OAuth header, and never sends the configured Bearer token
- This fix: suppress `resource_metadata` on ALL 401s + disable `/.well-known/oauth-authorization-server` endpoint

## Root cause
Claude Code's HTTP transport probes unauthenticated → server returns `www-authenticate: Bearer resource_metadata=...` → Claude Code follows OAuth discovery → abandons static Bearer token → fails. GitHub #7290 confirms this is by-design in Claude Code.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] CI (Build, Test, Typecheck)
- [ ] Deploy to Cloud Run
- [ ] Verify: unauthenticated 401 returns `Bearer realm="cachebash"` (no resource_metadata)
- [ ] Verify: `/.well-known/oauth-authorization-server` returns 404
- [ ] Verify: Claude Code MCP connects on fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)