### PR TITLE
fix: MCP cleanup — indexes, notification 202, OAuth 404, audit cap

### DIFF
--- a/infra/firestore.indexes.json
+++ b/infra/firestore.indexes.json
@@ -522,13 +522,30 @@
       ]
     },
     {
+      "collectionGroup": "ledger",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "entries",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "tier", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
-    }
+    },
+    {
+      "collectionGroup": "tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "completedAt", "order": "ASCENDING" },
+        { "fieldPath": "cost_usd", "order": "ASCENDING" }
+      ]
+    },
     {
       "collectionGroup": "schedules",
       "queryScope": "COLLECTION",

--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -336,38 +336,12 @@ async function main() {
       return handleGithubWebhook(req, res);
     }
 
-    // OAuth endpoints (public — no Bearer auth required)
-    // DISABLED: OAuth metadata discovery causes Claude Code to abandon static Bearer auth
-    // and attempt OAuth 2.1 flow, which fails. See: GitHub #7290, grid/assessments/*mcp-connectivity*
-    // Re-enable when CacheBash has real OAuth client support for external consumers.
-    // if (url === "/.well-known/oauth-authorization-server" && req.method === "GET") {
-    //   return handleOAuthMetadata(req, res);
-    // }
-    if (url === "/register" && req.method === "POST") {
-      // Pass optional Bearer auth for service account registration
-      const regToken = extractBearerToken(req.headers.authorization);
-      let regUserId: string | undefined;
-      if (regToken) {
-        const regProgramId = req.headers["x-program-id"] as string | undefined;
-        const regAuth = await validateAuth(regToken, regProgramId);
-        if (regAuth) regUserId = regAuth.userId;
-      }
-      return handleOAuthRegister(req, res, regUserId);
-    }
-    if (url === "/authorize" && req.method === "GET") {
-      return handleOAuthAuthorize(req, res);
-    }
-    if (url?.startsWith("/oauth/consent")) {
-      return handleOAuthConsent(req, res);
-    }
-    if (url === "/authorize/callback" && req.method === "GET") {
-      return handleOAuthCallback(req, res);
-    }
-    if (url === "/token" && req.method === "POST") {
-      return handleOAuthToken(req, res);
-    }
-    if (url === "/revoke" && req.method === "POST") {
-      return handleOAuthRevoke(req, res);
+    // OAuth endpoints — DISABLED. Claude Code's HTTP transport creates an OAuth auth provider
+    // for ALL HTTP MCP servers (#34008). These endpoints explicitly return 404 to prevent
+    // Claude Code from attempting an OAuth 2.1 flow. Use API key auth via Authorization header.
+    // See: GitHub #7290, grid/assessments/*mcp-connectivity*
+    if (url === "/authorize" || url === "/token" || url === "/register" || url === "/revoke" || url?.startsWith("/oauth/consent") || url === "/authorize/callback") {
+      return sendJson(res, 404, { error: "not_found", error_description: "OAuth not supported. Use API key auth via Authorization header." });
     }
 
     // Service account management (requires Bearer auth)

--- a/services/mcp-server/src/modules/audit.ts
+++ b/services/mcp-server/src/modules/audit.ts
@@ -5,7 +5,7 @@
  */
 
 import { getFirestore } from "../firebase/client.js";
-import { isAdmin } from "../middleware/gate.js";
+import { isAdmin, hasCapability } from "../middleware/gate.js";
 import { AuthContext } from "../auth/authValidator.js";
 import { z } from "zod";
 
@@ -22,11 +22,10 @@ function jsonResult(data: unknown): ToolResult {
 }
 
 export async function getAuditHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
-  // Admin only (legacy/mobile keys)
-  if (!isAdmin(auth)) {
+  if (!isAdmin(auth) && !hasCapability(auth, "audit.read")) {
     return jsonResult({
       success: false,
-      error: "Audit log is only accessible by admin.",
+      error: "get_audit requires audit.read capability.",
     });
   }
 

--- a/services/mcp-server/src/transport/CustomHTTPTransport.ts
+++ b/services/mcp-server/src/transport/CustomHTTPTransport.ts
@@ -164,6 +164,17 @@ export class CustomHTTPTransport implements Transport {
       });
       return new Response(null, { status: 204, headers: { "Mcp-Session-Id": this.sessionId } });
     }
+
+    // Notification recognition: messages without an `id` field are fire-and-forget per JSON-RPC spec.
+    // Accept immediately with 202, dispatch async. No response expected by the client.
+    const allNotifications = messages.every((m: any) => !("id" in m));
+    if (allNotifications) {
+      this.currentAuth = authContext;
+      for (const msg of messages) {
+        this.onmessage?.(msg);
+      }
+      return new Response(null, { status: 202, headers: { "Mcp-Session-Id": this.sessionId } });
+    }
     }
 
     // Set current auth for tool handler to read (stateless — derived from Bearer token this request)


### PR DESCRIPTION
## Summary
- **Firestore index**: Added composite index for `cost_forecast` (status/completedAt/cost_usd). Fixed pre-existing JSON syntax error.
- **Notification 202**: MCP notifications (no `id` field) now return HTTP 202 immediately instead of hanging until timeout.
- **OAuth 404**: All OAuth endpoints (`/authorize`, `/token`, `/register`, `/revoke`, `/oauth/consent`, `/authorize/callback`) now return 404 JSON. Prevents Claude Code HTTP transport from attempting OAuth 2.1 flow.
- **Audit capability**: `audit_get_audit` now accepts `audit.read` capability (not just `isAdmin`). Added ledger composite index (type/timestamp).
- **API key**: Grid key updated with `audit.read`, `dream.read`, `keys.read` capabilities (Firestore direct update).

## Test plan
- [x] `metrics_get_cost_forecast` returns data (not index error)
- [x] Notification POST returns 202 in ~1.3s (not hang)
- [x] `curl /authorize` → 404, `curl /token` → 404
- [x] `dream_peek`, `keys_list_keys` return data (not permission error)
- [x] `audit_get_audit` passes auth gate (ledger index building)
- [x] 503 tests pass across all deploys
- [x] Deployed as revs 00141-00143, all verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)