### PR TITLE
fix: GSP namespace listing endpoint + Firestore rule fixes

### DIFF
--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -58,10 +58,11 @@ service cloud.firestore {
       allow write: if false;
     }
     
-    // Sessions: read-only. Server manages via Admin SDK.
-    match /tenants/{userId}/sessions/{document=**} {
+    // Sessions: read for owner, scoped updates for portal actions (pin/complete/archive)
+    match /tenants/{userId}/sessions/{sessionId} {
       allow read: if isOwner(userId);
-      allow write: if false;
+      allow update: if isOwner(userId) &&
+        request.resource.data.diff(resource.data).affectedKeys().hasOnly(['state', 'archived', 'lastUpdate']);
     }
     
     // MCP Sessions: read-only. Server-side session management.
@@ -95,6 +96,12 @@ service cloud.firestore {
       // onboarding: mobile client creates and updates progress
       allow create: if isOwner(userId) && configDoc == 'onboarding';
       allow update: if isOwner(userId) && configDoc == 'onboarding';
+    }
+
+    // Content Ideas: full CRUD for owner (Command Center)
+    match /tenants/{userId}/content_ideas/{ideaId} {
+      allow read, create, update: if isOwner(userId);
+      allow delete: if isOwner(userId);
     }
 
     // Projects: full CRUD for owner (Command Center)

--- a/services/mcp-server/src/modules/gsp.ts
+++ b/services/mcp-server/src/modules/gsp.ts
@@ -109,6 +109,49 @@ Rule: Tier can be dynamically adjusted. Demote trivial Specialist tasks to Worke
 
 Full Constitution: CONSTITUTION.md`;
 
+// ── gsp_list_namespaces (REST-only, not an MCP tool) ────────────────────────
+
+export async function gspListNamespacesHandler(auth: AuthContext): Promise<{
+  success: boolean;
+  namespaces: Array<{ namespace: string; entryCount: number; lastUpdated: string | null; tier: string }>;
+  count: number;
+}> {
+  const db = getFirestore();
+  const userId = auth.userId;
+  const nsDocs = await db.collection(`tenants/${userId}/gsp`).listDocuments();
+
+  // Tier priority: constitutional > architectural > operational > runtime
+  const TIER_PRIORITY: Record<string, number> = { constitutional: 3, architectural: 2, operational: 1, runtime: 0 };
+
+  const namespaces: Array<{ namespace: string; entryCount: number; lastUpdated: string | null; tier: string }> = [];
+
+  for (const nsDoc of nsDocs) {
+    const entriesSnap = await db.collection(`${nsDoc.path}/entries`).get();
+    let lastUpdated: string | null = null;
+    let highestTier = "operational";
+
+    for (const entry of entriesSnap.docs) {
+      const data = entry.data();
+      if (data.tier && (TIER_PRIORITY[data.tier] ?? 0) > (TIER_PRIORITY[highestTier] ?? 0)) {
+        highestTier = data.tier;
+      }
+      const entryUpdated = data.updatedAt?.toDate?.()?.toISOString() || data.updatedAt;
+      if (entryUpdated && (!lastUpdated || entryUpdated > lastUpdated)) {
+        lastUpdated = entryUpdated;
+      }
+    }
+
+    namespaces.push({
+      namespace: nsDoc.id,
+      entryCount: entriesSnap.size,
+      lastUpdated,
+      tier: highestTier,
+    });
+  }
+
+  return { success: true, namespaces, count: namespaces.length };
+}
+
 // ── gsp_read ────────────────────────────────────────────────────────────────
 
 export async function gspReadHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -13,6 +13,7 @@ import { getFirestore } from "../firebase/client.js";
 import * as admin from "firebase-admin";
 import { generateCorrelationId, createAuditLogger } from "../middleware/gate.js";
 import { dreamPeekHandler, dreamActivateHandler } from "../modules/dream.js";
+import { gspListNamespacesHandler } from "../modules/gsp.js";
 import { enforceRateLimit, checkAuthRateLimit } from "../middleware/rateLimiter.js";
 import { checkSessionCompliance, resetTransportCompliance } from "../middleware/sessionCompliance.js";
 import { checkPricing } from "../middleware/pricingEnforce.js";
@@ -634,7 +635,7 @@ const routes: Route[] = [
     restResponse(res, true, data);
   }),
   route("GET", "/v1/gsp/namespaces", async (auth, req, res) => {
-    const data = await callTool(auth, req, "gsp_read", {});
+    const data = await gspListNamespacesHandler(auth);
     restResponse(res, true, data);
   }),
   route("GET", "/v1/gsp/namespaces/:namespace/entries", async (auth, req, res, p) => {


### PR DESCRIPTION
## Summary
- **GSP namespace listing**: Added `gspListNamespacesHandler` that enumerates namespaces via `listDocuments()` with entry counts, timestamps, and tier metadata. Fixes REST `/v1/gsp/namespaces` which was calling `gsp_read({})` — failing Zod validation since `namespace` is required.
- **Firestore rules**: Added `content_ideas` subcollection rule (portal Content tab was getting permissions error). Changed `sessions` rule from `allow write: if false` to scoped `allow update` for `state`, `archived`, `lastUpdate` fields (portal fleet actions were silently failing).

## Test plan
- [ ] Verify `GET /v1/gsp/namespaces` returns namespace list with entry counts
- [ ] Verify portal GSP tab loads namespaces
- [ ] Verify portal Content tab no longer shows permissions error
- [ ] Verify portal fleet session actions (archive, complete) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)