### PR TITLE
fix: Firestore rules for GSP entries + programs collections

### DIFF
--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -134,6 +134,18 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // GSP entries: read-only for clients. Server writes via Admin SDK.
+    match /tenants/{userId}/gsp/{namespace}/entries/{entryId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
+    // Programs: read-only for clients. Server writes via Admin SDK.
+    match /tenants/{userId}/programs/{programId} {
+      allow read: if isOwner(userId);
+      allow write: if false;
+    }
+
     // User root document: read-only
     match /tenants/{userId} {
       allow read: if isOwner(userId);


### PR DESCRIPTION
## Summary
- Add read-only Firestore rules for `tenants/{uid}/gsp/{namespace}/entries/{entryId}` — used by Knowledge tab (PatternsView) and Home dashboard (knowledge patterns widget)
- Add read-only Firestore rules for `tenants/{uid}/programs/{programId}` — used by Agent Memory view

Both collections were hitting the default deny rule, causing "Missing or insufficient permissions" errors across multiple portal pages.

## Test plan
- [ ] Verify Knowledge tab loads patterns without permissions error
- [ ] Verify Home dashboard knowledge widget loads
- [ ] Verify Agent Memory view loads program list

🤖 Generated with [Claude Code](https://claude.com/claude-code)