### PR TITLE
feat(functions): OPP-3 patternPromotion + decay (knowledge-maintenance, propose-only)

### DIFF
--- a/services/functions/src/cleanup/decayProgramState.test.ts
+++ b/services/functions/src/cleanup/decayProgramState.test.ts
@@ -1,0 +1,144 @@
+import { computeAndApply } from "./decayProgramState";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-06-01T00:00:00Z");
+
+function iso(daysAgo: number): string {
+  return new Date(NOW - daysAgo * DAY).toISOString();
+}
+
+function baseState(overrides: any = {}) {
+  return {
+    programId: "basher",
+    lastUpdatedAt: iso(1),
+    contextSummary: { lastTask: null, activeWorkItems: [], handoffNotes: "", openQuestions: [] },
+    learnedPatterns: [],
+    baselines: {
+      avgTaskDurationMinutes: null,
+      lastSessionDurationMinutes: null,
+      commonFailureModes: [],
+      sessionsCompleted: 3,
+    },
+    decay: {
+      contextSummaryTTLDays: 7,
+      learnedPatternMaxAge: 30,
+      maxUnpromotedPatterns: 50,
+      lastDecayRun: iso(2),
+      decayLog: [],
+    },
+    ...overrides,
+  };
+}
+
+function lp(overrides: any = {}) {
+  return {
+    id: "p1",
+    domain: "dev",
+    pattern: "some pattern",
+    confidence: 0.5,
+    evidence: "e",
+    discoveredAt: iso(60),
+    lastReinforced: iso(60),
+    promotedToStore: false,
+    stale: false,
+    ...overrides,
+  };
+}
+
+describe("computeAndApply — typed decayLog actions", () => {
+  it("stales an unreinforced pattern past max age with a pattern_staled action", () => {
+    const state = baseState({ learnedPatterns: [lp({ lastReinforced: iso(45) })] });
+    const { actions, counts } = computeAndApply(state, NOW, false);
+    expect(counts.pattern_staled).toBe(1);
+    expect(actions[0].action).toBe("pattern_staled");
+    expect(actions[0]).toHaveProperty("timestamp");
+    expect(actions[0]).toHaveProperty("detail");
+  });
+
+  it("clears a completed context summary past TTL with context_cleared", () => {
+    const state = baseState({
+      lastUpdatedAt: iso(10),
+      contextSummary: {
+        lastTask: { taskId: "t1", title: "x", outcome: "completed", notes: "" },
+        activeWorkItems: [],
+        handoffNotes: "",
+        openQuestions: [],
+      },
+    });
+    const { counts } = computeAndApply(state, NOW, false);
+    expect(counts.context_cleared).toBe(1);
+  });
+
+  it("evicts unpromoted patterns over the cap with pattern_evicted, weakest first", () => {
+    const patterns = Array.from({ length: 4 }, (_, i) =>
+      lp({ id: `p${i}`, confidence: 0.1 * (i + 1), lastReinforced: iso(1) })
+    );
+    const state = baseState({
+      learnedPatterns: patterns,
+      decay: { ...baseState().decay, maxUnpromotedPatterns: 2 },
+    });
+    const { counts, actions } = computeAndApply(state, NOW, false);
+    expect(counts.pattern_evicted).toBe(2);
+    // lowest confidence (p0, p1) evicted first
+    expect(actions.filter((a) => a.action === "pattern_evicted").map((a) => a.detail).join(" ")).toContain("p0");
+  });
+});
+
+describe("computeAndApply — DRY_RUN does not mutate", () => {
+  it("records actions but leaves pattern.stale untouched in dry-run", () => {
+    const state = baseState({ learnedPatterns: [lp({ lastReinforced: iso(45) })] });
+    const { counts } = computeAndApply(state, NOW, true);
+    expect(counts.pattern_staled).toBe(1);
+    expect(state.learnedPatterns[0].stale).toBe(false); // NOT mutated
+  });
+
+  it("mutates pattern.stale when dryRun is false", () => {
+    const state = baseState({ learnedPatterns: [lp({ lastReinforced: iso(45) })] });
+    computeAndApply(state, NOW, false);
+    expect(state.learnedPatterns[0].stale).toBe(true);
+  });
+
+  it("does not clear context in dry-run", () => {
+    const state = baseState({
+      lastUpdatedAt: iso(10),
+      contextSummary: {
+        lastTask: { taskId: "t1", title: "x", outcome: "completed", notes: "" },
+        activeWorkItems: [],
+        handoffNotes: "keep me",
+        openQuestions: [],
+      },
+    });
+    computeAndApply(state, NOW, true);
+    expect(state.contextSummary.lastTask).not.toBeNull();
+    expect(state.contextSummary.handoffNotes).toBe("keep me");
+  });
+});
+
+describe("computeAndApply — grace window (promotion before eviction)", () => {
+  it("never stales a pattern that meets promotion criteria", () => {
+    // confidence >= 0.8, reinforced, but aged past max-age — must be spared.
+    const promotable = lp({
+      confidence: 0.9,
+      discoveredAt: iso(60),
+      lastReinforced: iso(45),
+    });
+    const state = baseState({ learnedPatterns: [promotable] });
+    const { counts } = computeAndApply(state, NOW, false);
+    expect(counts.pattern_staled).toBe(0);
+    expect(state.learnedPatterns[0].stale).toBe(false);
+  });
+
+  it("excludes promotable patterns from the eviction cap candidate set", () => {
+    const promotable = lp({ id: "keep", confidence: 0.9, lastReinforced: iso(1) });
+    const weak = Array.from({ length: 3 }, (_, i) =>
+      lp({ id: `w${i}`, confidence: 0.2, lastReinforced: iso(1) })
+    );
+    const state = baseState({
+      learnedPatterns: [promotable, ...weak],
+      decay: { ...baseState().decay, maxUnpromotedPatterns: 2 },
+    });
+    const { actions } = computeAndApply(state, NOW, false);
+    const evicted = actions.filter((a) => a.action === "pattern_evicted").map((a) => a.detail).join(" ");
+    expect(evicted).not.toContain("'keep'");
+  });
+});

--- a/services/functions/src/cleanup/decayProgramState.ts
+++ b/services/functions/src/cleanup/decayProgramState.ts
@@ -1,24 +1,60 @@
 /**
  * Decay program state.
- * Runs every 24 hours. Applies decay rules to all program state documents:
- * - 7d context: Clear stale context summaries for completed tasks
- * - 30d patterns: Mark unreinforced learned patterns as stale
- * - 90d baselines: Reset performance baselines
- * - 50 cap: Enforce max unpromoted patterns
+ *
+ * Runs nightly (Cloud Scheduler). Applies decay rules to every program_state
+ * document, per the `decay` object in grid/schemas/program.schema.json:
+ *   - contextSummaryTTLDays : clear stale context summaries for completed tasks
+ *   - learnedPatternMaxAge  : stale unreinforced learned patterns (flat age — NO
+ *                             per-domain half-lives; deferred, OPP-3)
+ *   - maxUnpromotedPatterns : evict oldest/weakest unpromoted patterns over the cap
+ * Baseline reset (90d) is retained from prior behavior and emits a baselines_reset
+ * action (the schema decayLog enum anticipates it).
+ *
+ * ── OPP-3 FIRST DEPLOY = PROPOSE-ONLY / DRY-RUN ──────────────────────────────
+ * DRY_RUN is true: decay COMPUTES every action it would take and writes typed
+ * entries to decay.decayLog (and STATE_DECAY telemetry), but performs NO state
+ * mutation — nothing is staled, evicted, cleared, or reset. This measures whether
+ * the orphaned-pattern problem is real before any destructive change. Flipping
+ * DRY_RUN to false (separate follow-up, SARK gate) enables eviction.
+ *
+ * RUN-ORDER — PROMOTION BEFORE EVICTION: promotion is event-driven (onProgramStateWrite
+ * fires the moment a pattern qualifies). Decay additionally guards a grace window:
+ * any pattern that currently meets promotion criteria (isPromotable) is NEVER staled
+ * or evicted here, so a pattern about to qualify can never be lost to decay.
  */
 
 import * as functions from "firebase-functions/v1";
 import * as admin from "firebase-admin";
+import { emitEvent } from "../util/emitEvent";
+import { isPromotable, LearnedPattern } from "../patterns/onProgramStateWrite";
+
+// OPP-3: PROPOSE-ONLY first deploy. Set to true to enable destructive mutation
+// (staling, eviction, context clear, baseline reset). Keep false until the
+// dry-run validates N nights and SARK signs off (Decision #15c).
+const EVICTION_ENABLED = false;
+const DRY_RUN = !EVICTION_ENABLED;
 
 const CONTEXT_TTL_DAYS = 7;
 const PATTERN_MAX_AGE_DAYS = 30;
 const BASELINE_TTL_DAYS = 90;
 const MAX_UNPROMOTED_PATTERNS = 50;
+const MAX_DECAY_LOG_ENTRIES = 100;
 
-interface DecayStats {
-  patternsMarkedStale: number;
-  contextCleared: boolean;
-  baselinesReset: boolean;
+type DecayActionType =
+  | "context_cleared"
+  | "pattern_staled"
+  | "pattern_evicted"
+  | "baselines_reset";
+
+interface DecayAction {
+  timestamp: string;
+  action: DecayActionType;
+  detail: string;
+}
+
+interface DecayResult {
+  actions: DecayAction[];
+  counts: Record<DecayActionType, number>;
 }
 
 export const decayProgramState = functions.pubsub
@@ -27,60 +63,94 @@ export const decayProgramState = functions.pubsub
     const db = admin.firestore();
     const now = Date.now();
 
-    functions.logger.info("[decayProgramState] Starting scheduled decay run");
+    functions.logger.info(
+      `[decayProgramState] Starting scheduled decay run (DRY_RUN=${DRY_RUN})`
+    );
 
     try {
-      // Query all program state documents across all tenants
       const snapshot = await db.collectionGroup("program_state").get();
 
       if (snapshot.empty) {
         functions.logger.info("[decayProgramState] No program state documents found");
-        return { processed: 0 };
+        return { processed: 0, dryRun: DRY_RUN };
       }
 
       let batch = db.batch();
       let batchCount = 0;
       let totalProcessed = 0;
-      let totalPatternsStaled = 0;
-      let totalContextsCleared = 0;
-      let totalBaselinesReset = 0;
+      const totals: Record<DecayActionType, number> = {
+        context_cleared: 0,
+        pattern_staled: 0,
+        pattern_evicted: 0,
+        baselines_reset: 0,
+      };
 
       for (const doc of snapshot.docs) {
         const state = doc.data();
-        const stats = applyDecayRules(state, now);
+        // computeAndApply mutates `state` in place only when DRY_RUN is false.
+        const result = computeAndApply(state, now, DRY_RUN);
 
-        // If any decay occurred, update the document
-        if (stats.patternsMarkedStale > 0 || stats.contextCleared || stats.baselinesReset) {
-          batch.update(doc.ref, state);
-          batchCount++;
-          totalProcessed++;
-          totalPatternsStaled += stats.patternsMarkedStale;
-          if (stats.contextCleared) totalContextsCleared++;
-          if (stats.baselinesReset) totalBaselinesReset++;
+        if (result.actions.length === 0) continue;
 
-          // Commit batch if we hit 500 operations
-          if (batchCount >= 500) {
-            await batch.commit();
-            batch = db.batch();
-            batchCount = 0;
-          }
+        // Record proposed/applied actions on the document (typed decayLog +
+        // lastDecayRun). This write happens in BOTH modes — in dry-run it is the
+        // proposal record; the pattern/context/baseline fields are untouched.
+        const decay = state.decay || {};
+        const existingLog: DecayAction[] = Array.isArray(decay.decayLog)
+          ? decay.decayLog
+          : [];
+        state.decay = {
+          ...decay,
+          lastDecayRun: new Date(now).toISOString(),
+          decayLog: [...existingLog, ...result.actions].slice(-MAX_DECAY_LOG_ENTRIES),
+        };
+
+        batch.update(doc.ref, { decay: state.decay });
+        batchCount++;
+        totalProcessed++;
+        for (const k of Object.keys(totals) as DecayActionType[]) {
+          totals[k] += result.counts[k];
+        }
+
+        // Per-program telemetry — captures decay rate for the dry-run measurement.
+        const programId = (state.programId as string) || doc.id;
+        const userId = extractUserId(doc.ref.path);
+        if (userId) {
+          emitEvent(db, userId, {
+            event_type: "STATE_DECAY",
+            program_id: programId,
+            dry_run: DRY_RUN,
+            context_cleared: totals_of(result, "context_cleared"),
+            patterns_staled: totals_of(result, "pattern_staled"),
+            patterns_evicted: totals_of(result, "pattern_evicted"),
+            baselines_reset: totals_of(result, "baselines_reset"),
+          });
+        }
+
+        if (batchCount >= 500) {
+          await batch.commit();
+          batch = db.batch();
+          batchCount = 0;
         }
       }
 
-      // Commit remaining batch
       if (batchCount > 0) {
         await batch.commit();
       }
 
       functions.logger.info(
-        `[decayProgramState] Completed. Processed: ${totalProcessed}, Patterns staled: ${totalPatternsStaled}, Contexts cleared: ${totalContextsCleared}, Baselines reset: ${totalBaselinesReset}`
+        `[decayProgramState] Completed (DRY_RUN=${DRY_RUN}). Processed: ${totalProcessed}, ` +
+          `staled: ${totals.pattern_staled}, evicted: ${totals.pattern_evicted}, ` +
+          `contexts cleared: ${totals.context_cleared}, baselines reset: ${totals.baselines_reset}`
       );
 
       return {
         processed: totalProcessed,
-        patternsStaled: totalPatternsStaled,
-        contextsCleared: totalContextsCleared,
-        baselinesReset: totalBaselinesReset,
+        dryRun: DRY_RUN,
+        patternsStaled: totals.pattern_staled,
+        patternsEvicted: totals.pattern_evicted,
+        contextsCleared: totals.context_cleared,
+        baselinesReset: totals.baselines_reset,
       };
     } catch (error) {
       functions.logger.error("[decayProgramState] Error:", error);
@@ -88,126 +158,140 @@ export const decayProgramState = functions.pubsub
     }
   });
 
-/**
- * Apply decay rules to a program state document.
- * Mutates the state object in place.
- */
-function applyDecayRules(state: any, now: number): DecayStats {
-  const decay = state.decay || {};
-  let patternsMarkedStale = 0;
-  let contextCleared = false;
-  let baselinesReset = false;
-  let decayed = false;
+function totals_of(result: DecayResult, action: DecayActionType): number {
+  return result.counts[action];
+}
 
-  // Rule 1: Context Summary TTL (7 days)
+/**
+ * Compute the decay actions for a program state. When `dryRun` is false, also
+ * mutates `state` in place (stale flags, context clear, baseline reset). When
+ * true, computes the typed action log WITHOUT mutating decayable fields.
+ *
+ * Pure w.r.t. I/O and time (takes `now`) so it is unit-testable.
+ */
+export function computeAndApply(
+  state: any,
+  now: number,
+  dryRun: boolean
+): DecayResult {
+  const decay = state.decay || {};
+  const actions: DecayAction[] = [];
+  const ts = new Date(now).toISOString();
+  const counts: Record<DecayActionType, number> = {
+    context_cleared: 0,
+    pattern_staled: 0,
+    pattern_evicted: 0,
+    baselines_reset: 0,
+  };
+
+  const record = (action: DecayActionType, detail: string) => {
+    actions.push({ timestamp: ts, action, detail });
+    counts[action]++;
+  };
+
+  // Rule 1: Context Summary TTL — clear summaries for completed tasks past TTL.
   const contextTTLDays = decay.contextSummaryTTLDays || CONTEXT_TTL_DAYS;
-  if (state.contextSummary?.lastTask) {
-    const lastTask = state.contextSummary.lastTask;
-    // Only clear if task was completed (not in-progress or blocked)
-    if (lastTask.outcome === "completed") {
-      const lastUpdated = state.lastUpdatedAt;
-      if (lastUpdated) {
-        const updatedAt = parseTimestamp(lastUpdated);
-        const ttlMs = contextTTLDays * 24 * 60 * 60 * 1000;
-        if (updatedAt > 0 && now - updatedAt > ttlMs) {
-          state.contextSummary = {
-            lastTask: null,
-            activeWorkItems: [],
-            handoffNotes: "",
-            openQuestions: [],
-          };
-          contextCleared = true;
-          decayed = true;
-        }
+  if (state.contextSummary?.lastTask?.outcome === "completed") {
+    const updatedAt = parseTimestamp(state.lastUpdatedAt);
+    const ttlMs = contextTTLDays * 24 * 60 * 60 * 1000;
+    if (updatedAt > 0 && now - updatedAt > ttlMs) {
+      record(
+        "context_cleared",
+        `Context summary for completed task '${state.contextSummary.lastTask.taskId || "?"}' aged past ${contextTTLDays}d TTL`
+      );
+      if (!dryRun) {
+        state.contextSummary = {
+          lastTask: null,
+          activeWorkItems: [],
+          handoffNotes: "",
+          openQuestions: [],
+        };
       }
     }
   }
 
-  // Rule 2: Learned Pattern Max Age (30 days)
+  // Rule 2: Learned Pattern Max Age (flat) — stale unreinforced patterns.
+  // GRACE WINDOW: never stale a pattern that currently meets promotion criteria
+  // (promotion-before-eviction). Promoted patterns never decay.
   const maxAgeDays = decay.learnedPatternMaxAge || PATTERN_MAX_AGE_DAYS;
   const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
   if (Array.isArray(state.learnedPatterns)) {
-    for (const pattern of state.learnedPatterns) {
-      if (pattern.stale) continue; // already stale
-      if (pattern.promotedToStore) continue; // promoted patterns don't decay
+    for (const pattern of state.learnedPatterns as LearnedPattern[]) {
+      if (pattern.stale) continue;
+      if (pattern.promotedToStore) continue;
+      if (isPromotable(pattern)) continue; // grace window — about to be promoted
       const reinforced = parseTimestamp(pattern.lastReinforced);
-      if (!isNaN(reinforced) && now - reinforced > maxAgeMs) {
-        pattern.stale = true;
-        patternsMarkedStale++;
-        decayed = true;
+      if (reinforced > 0 && now - reinforced > maxAgeMs) {
+        record(
+          "pattern_staled",
+          `Pattern '${pattern.id}' (domain ${pattern.domain}) unreinforced past ${maxAgeDays}d`
+        );
+        if (!dryRun) pattern.stale = true;
       }
     }
   }
 
-  // Rule 3: Baselines TTL (90 days) — NEW
-  const baselineTTLDays = BASELINE_TTL_DAYS;
+  // Rule 3: Baselines TTL — reset stale performance baselines (preserve count).
   if (state.baselines) {
-    const lastUpdated = state.lastUpdatedAt;
-    if (lastUpdated) {
-      const updatedAt = parseTimestamp(lastUpdated);
-      const ttlMs = baselineTTLDays * 24 * 60 * 60 * 1000;
-      if (
-        updatedAt > 0 &&
-        now - updatedAt > ttlMs &&
-        (state.baselines.avgTaskDurationMinutes !== null ||
-          state.baselines.lastSessionDurationMinutes !== null ||
-          state.baselines.commonFailureModes.length > 0)
-      ) {
+    const updatedAt = parseTimestamp(state.lastUpdatedAt);
+    const ttlMs = BASELINE_TTL_DAYS * 24 * 60 * 60 * 1000;
+    const hasData =
+      state.baselines.avgTaskDurationMinutes !== null ||
+      state.baselines.lastSessionDurationMinutes !== null ||
+      (state.baselines.commonFailureModes || []).length > 0;
+    if (updatedAt > 0 && now - updatedAt > ttlMs && hasData) {
+      record("baselines_reset", `Performance baselines aged past ${BASELINE_TTL_DAYS}d`);
+      if (!dryRun) {
         state.baselines = {
           avgTaskDurationMinutes: null,
           lastSessionDurationMinutes: null,
           commonFailureModes: [],
-          sessionsCompleted: state.baselines.sessionsCompleted || 0, // preserve count
+          sessionsCompleted: state.baselines.sessionsCompleted || 0,
         };
-        baselinesReset = true;
-        decayed = true;
       }
     }
   }
 
-  // Rule 4: Max Unpromoted Patterns (50 cap)
+  // Rule 4: Max Unpromoted Patterns — evict weakest over the cap.
+  // GRACE WINDOW applies here too: promotion-eligible patterns are excluded from
+  // the eviction candidate set.
   const maxUnpromoted = decay.maxUnpromotedPatterns || MAX_UNPROMOTED_PATTERNS;
   if (Array.isArray(state.learnedPatterns)) {
-    const unpromoted = state.learnedPatterns.filter(
-      (p: any) => !p.promotedToStore && !p.stale
+    const evictable = (state.learnedPatterns as LearnedPattern[]).filter(
+      (p) => !p.promotedToStore && !p.stale && !isPromotable(p)
     );
-    if (unpromoted.length > maxUnpromoted) {
-      unpromoted.sort((a: any, b: any) => a.confidence - b.confidence);
-      const excess = unpromoted.slice(0, unpromoted.length - maxUnpromoted);
+    if (evictable.length > maxUnpromoted) {
+      // Evict lowest-confidence first.
+      evictable.sort((a, b) => a.confidence - b.confidence);
+      const excess = evictable.slice(0, evictable.length - maxUnpromoted);
       for (const p of excess) {
-        p.stale = true;
-        patternsMarkedStale++;
-        decayed = true;
+        record(
+          "pattern_evicted",
+          `Pattern '${p.id}' (domain ${p.domain}, confidence ${p.confidence}) over unpromoted cap of ${maxUnpromoted}`
+        );
+        if (!dryRun) p.stale = true;
       }
     }
   }
 
-  // Update decay metadata
-  if (decayed) {
-    const logEntry = {
-      timestamp: new Date().toISOString(),
-      patternsMarkedStale,
-      contextCleared,
-      baselinesReset,
-    };
+  return { actions, counts };
+}
 
-    state.decay = {
-      ...decay,
-      lastDecayRun: new Date().toISOString(),
-      decayLog: [...(decay.decayLog || []).slice(-9), logEntry], // keep last 10 entries
-    };
-  }
-
-  return { patternsMarkedStale, contextCleared, baselinesReset };
+/** Extract `{userId}` from a `tenants/{userId}/sessions/_meta/program_state/{id}` path. */
+function extractUserId(path: string): string | null {
+  const parts = path.split("/");
+  const idx = parts.indexOf("tenants");
+  return idx >= 0 && parts.length > idx + 1 ? parts[idx + 1] : null;
 }
 
 /**
  * Parse Firestore timestamp to milliseconds.
- * Handles: ISO strings, Firestore Timestamp objects, and raw { _seconds, _nanoseconds } objects.
+ * Handles ISO strings, Firestore Timestamp objects, and { _seconds } shapes.
  */
 function parseTimestamp(timestamp: any): number {
   if (typeof timestamp === "string") {
-    return new Date(timestamp).getTime();
+    const ms = new Date(timestamp).getTime();
+    return isNaN(ms) ? 0 : ms;
   }
   if (timestamp?._seconds) {
     return timestamp._seconds * 1000;

--- a/services/functions/src/patterns/onProgramStateWrite.test.ts
+++ b/services/functions/src/patterns/onProgramStateWrite.test.ts
@@ -1,0 +1,106 @@
+import {
+  isPromotable,
+  evaluatePromotion,
+  findDuplicate,
+  LearnedPattern,
+} from "./onProgramStateWrite";
+
+function pattern(overrides: Partial<LearnedPattern> = {}): LearnedPattern {
+  return {
+    id: "p1",
+    domain: "auth",
+    pattern: "Use Firestore transactions for concurrent token refresh",
+    confidence: 0.9,
+    evidence: "observed during oauth work",
+    discoveredAt: "2026-01-01T00:00:00Z",
+    lastReinforced: "2026-01-05T00:00:00Z",
+    promotedToStore: false,
+    stale: false,
+    ...overrides,
+  };
+}
+
+describe("isPromotable", () => {
+  it("promotes at confidence >= 0.8 when reinforced and not stale/promoted", () => {
+    expect(isPromotable(pattern({ confidence: 0.8 }))).toBe(true);
+    expect(isPromotable(pattern({ confidence: 0.95 }))).toBe(true);
+  });
+
+  it("rejects below the 0.8 threshold (0.7 no longer qualifies)", () => {
+    expect(isPromotable(pattern({ confidence: 0.7 }))).toBe(false);
+    expect(isPromotable(pattern({ confidence: 0.79 }))).toBe(false);
+  });
+
+  it("requires at least one reinforcement", () => {
+    const t = "2026-01-01T00:00:00Z";
+    expect(isPromotable(pattern({ discoveredAt: t, lastReinforced: t }))).toBe(false);
+  });
+
+  it("rejects stale or already-promoted patterns", () => {
+    expect(isPromotable(pattern({ stale: true }))).toBe(false);
+    expect(isPromotable(pattern({ promotedToStore: true }))).toBe(false);
+  });
+});
+
+describe("evaluatePromotion", () => {
+  it("selects eligible patterns and emits promotedToStore field updates", () => {
+    const after = [pattern({ id: "a", confidence: 0.85 }), pattern({ id: "b", confidence: 0.5 })];
+    const { toPromote, updates } = evaluatePromotion([], after);
+    expect(toPromote.map((p) => p.id)).toEqual(["a"]);
+    expect(updates).toEqual({ "learnedPatterns.0.promotedToStore": true });
+  });
+
+  it("does not re-trigger patterns already promoted in the before state", () => {
+    const before = [pattern({ id: "a", promotedToStore: true })];
+    const after = [pattern({ id: "a", promotedToStore: true, confidence: 0.9 })];
+    const { toPromote } = evaluatePromotion(before, after);
+    expect(toPromote).toHaveLength(0);
+  });
+});
+
+describe("findDuplicate", () => {
+  const candidate = pattern({ id: "new", domain: "auth" });
+
+  it("flags a promoted cross-program pattern with similar text in the same domain", () => {
+    const dup = findDuplicate(candidate, [
+      {
+        programId: "gem",
+        patterns: [
+          pattern({
+            id: "gem-1",
+            domain: "auth",
+            promotedToStore: true,
+            pattern: "Use Firestore transactions for concurrent token refresh races",
+          }),
+        ],
+      },
+    ]);
+    expect(dup).toEqual({ programId: "gem", patternId: "gem-1" });
+  });
+
+  it("ignores unpromoted patterns and different domains", () => {
+    expect(
+      findDuplicate(candidate, [
+        { programId: "gem", patterns: [pattern({ promotedToStore: false })] },
+      ])
+    ).toBeNull();
+    expect(
+      findDuplicate(candidate, [
+        { programId: "gem", patterns: [pattern({ domain: "deployment", promotedToStore: true })] },
+      ])
+    ).toBeNull();
+  });
+
+  it("returns null when no similar pattern exists", () => {
+    expect(
+      findDuplicate(candidate, [
+        {
+          programId: "gem",
+          patterns: [
+            pattern({ domain: "auth", promotedToStore: true, pattern: "Cache DNS lookups aggressively" }),
+          ],
+        },
+      ])
+    ).toBeNull();
+  });
+});

--- a/services/functions/src/patterns/onProgramStateWrite.ts
+++ b/services/functions/src/patterns/onProgramStateWrite.ts
@@ -1,9 +1,17 @@
 import * as functions from "firebase-functions/v1";
 import * as admin from "firebase-admin";
+import { emitEvent } from "../util/emitEvent";
 
-const db = admin.firestore();
+/**
+ * Promotion confidence threshold.
+ *
+ * SINGLE SOURCE OF TRUTH: grid/schemas/program.schema.json declares promotion at
+ * confidence >= 0.8 (learnedPatterns.confidence description). grid/workflows/pattern-promotion.md
+ * is reconciled to match. Do not change here without changing both. (Flynn decision, OPP-3.)
+ */
+const PROMOTION_CONFIDENCE_THRESHOLD = 0.8;
 
-interface LearnedPattern {
+export interface LearnedPattern {
   id: string;
   domain: string;
   pattern: string;
@@ -21,81 +29,184 @@ interface ProgramState {
 }
 
 /**
- * Triggered when program state is written.
- * Detects learnedPatterns that meet promotion criteria and creates tasks
- * for the originating program to write the pattern to the permanent store.
+ * Whether a pattern is eligible for promotion.
  *
- * Promotion criteria:
- * - confidence >= 0.7
- * - lastReinforced !== discoveredAt (reinforced at least once)
- * - stale === false
- * - promotedToStore === false
+ * Criteria (grid/workflows/pattern-promotion.md):
+ * - confidence >= 0.8 (PROMOTION_CONFIDENCE_THRESHOLD)
+ * - reinforced at least once (lastReinforced !== discoveredAt)
+ * - not stale
+ * - not already promoted
+ */
+export function isPromotable(pattern: LearnedPattern): boolean {
+  const meetsConfidence = pattern.confidence >= PROMOTION_CONFIDENCE_THRESHOLD;
+  const isReinforced = pattern.lastReinforced !== pattern.discoveredAt;
+  const notStale = pattern.stale !== true;
+  const notPromoted = pattern.promotedToStore !== true;
+  return meetsConfidence && isReinforced && notStale && notPromoted;
+}
+
+/**
+ * Compute the set of patterns to promote from a state transition, plus the
+ * field-path updates that mark them promoted. Pure — no I/O — so it is unit-testable.
+ *
+ * A pattern is skipped if it was already promoted in the BEFORE state (prevents
+ * re-trigger on subsequent writes).
+ */
+export function evaluatePromotion(
+  beforePatterns: LearnedPattern[],
+  afterPatterns: LearnedPattern[]
+): { toPromote: LearnedPattern[]; updates: { [key: string]: any } } {
+  const toPromote: LearnedPattern[] = [];
+  const updates: { [key: string]: any } = {};
+
+  afterPatterns.forEach((pattern, index) => {
+    const beforePattern = beforePatterns.find((p) => p.id === pattern.id);
+    if (beforePattern && beforePattern.promotedToStore === true) {
+      return; // already promoted previously — don't re-trigger
+    }
+    if (isPromotable(pattern)) {
+      toPromote.push(pattern);
+      updates[`learnedPatterns.${index}.promotedToStore`] = true;
+    }
+  });
+
+  return { toPromote, updates };
+}
+
+/**
+ * Advisory duplicate detection.
+ *
+ * Checks whether another program has already promoted a pattern in the same
+ * domain with substantially similar text. Returns the duplicate's location
+ * (programId + patternId) or null. ADVISORY ONLY — never blocks promotion; the
+ * created task carries the note so the program can decide to merge or fork.
+ *
+ * The permanent store lives in git (not queryable here), so dedup is best-effort
+ * against the cross-program Firestore signal: patterns already flagged
+ * promotedToStore in other programs' state.
+ */
+export function findDuplicate(
+  candidate: LearnedPattern,
+  otherPrograms: { programId: string; patterns: LearnedPattern[] }[]
+): { programId: string; patternId: string } | null {
+  for (const other of otherPrograms) {
+    for (const p of other.patterns) {
+      if (p.promotedToStore !== true) continue;
+      if (p.domain !== candidate.domain) continue;
+      if (textSimilarity(p.pattern, candidate.pattern) >= 0.6) {
+        return { programId: other.programId, patternId: p.id };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Jaccard similarity over normalized word sets. Cheap, dependency-free, good
+ * enough for an advisory "have we seen this already" check.
+ */
+function textSimilarity(a: string, b: string): number {
+  const norm = (s: string) =>
+    new Set(
+      s
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter((w) => w.length > 2)
+    );
+  const setA = norm(a);
+  const setB = norm(b);
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const w of setA) if (setB.has(w)) intersection++;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Triggered when program state is written.
+ *
+ * Detects learnedPatterns that meet promotion criteria (confidence >= 0.8,
+ * reinforced, not stale, not promoted) and creates a LOW-PRIORITY CacheBash task
+ * for the originating program to write the pattern file to the permanent store.
+ *
+ * GUARDRAIL (non-negotiable, preserved): this function MUST NOT write git directly.
+ * It creates a task ("task-not-commit") so git writes stay in program control.
+ *
+ * Emits a PATTERN_PROMOTED telemetry event per promoted pattern.
  */
 export const onProgramStateWrite = functions.firestore
   .document("tenants/{userId}/sessions/_meta/program_state/{programId}")
   .onWrite(async (change, context) => {
     const { userId, programId } = context.params;
+    const db = admin.firestore();
 
-    // No document created (deletion) - skip
+    // No document after write (deletion) — skip.
     if (!change.after.exists) {
       return;
     }
 
-    const before: ProgramState = change.before.exists ? (change.before.data() as ProgramState) : {};
+    const before: ProgramState = change.before.exists
+      ? (change.before.data() as ProgramState)
+      : {};
     const after: ProgramState = change.after.data() as ProgramState;
 
-    const beforePatterns = before.learnedPatterns || [];
-    const afterPatterns = after.learnedPatterns || [];
+    const { toPromote, updates } = evaluatePromotion(
+      before.learnedPatterns || [],
+      after.learnedPatterns || []
+    );
 
-    // Find patterns that meet promotion criteria
-    const patternsToPromote: LearnedPattern[] = [];
-    const patternUpdates: { [key: string]: any } = {};
-
-    afterPatterns.forEach((pattern, index) => {
-      // Check if already promoted in before state (prevent re-trigger)
-      const beforePattern = beforePatterns.find(p => p.id === pattern.id);
-      if (beforePattern && beforePattern.promotedToStore === true) {
-        return;
-      }
-
-      // Skip if already marked as promoted in after state
-      if (pattern.promotedToStore === true) {
-        return;
-      }
-
-      // Check promotion criteria
-      const meetsConfidence = pattern.confidence >= 0.7;
-      const isReinforced = pattern.lastReinforced !== pattern.discoveredAt;
-      const notStale = pattern.stale !== true;
-
-      if (meetsConfidence && isReinforced && notStale) {
-        patternsToPromote.push(pattern);
-        // Mark for promotion in the state document
-        patternUpdates[`learnedPatterns.${index}.promotedToStore`] = true;
-      }
-    });
-
-    if (patternsToPromote.length === 0) {
+    if (toPromote.length === 0) {
       return;
     }
 
     functions.logger.info(
-      `Found ${patternsToPromote.length} patterns ready for promotion in ${programId}`
+      `Found ${toPromote.length} patterns ready for promotion in ${programId}`
     );
 
+    // Advisory cross-program dedup. Bounded single-collection read (one doc per
+    // program, ~dozen docs) — intentionally NOT a collectionGroup query, so no
+    // composite index and predictable cost. (ALAN cost/index note, OPP-3.)
+    let otherPrograms: { programId: string; patterns: LearnedPattern[] }[] = [];
     try {
-      // Use batch to atomically create tasks and update promotion flags
+      const stateSnap = await db
+        .collection(`tenants/${userId}/sessions/_meta/program_state`)
+        .get();
+      otherPrograms = stateSnap.docs
+        .filter((d) => d.id !== programId)
+        .map((d) => ({
+          programId: d.id,
+          patterns: (d.data().learnedPatterns || []) as LearnedPattern[],
+        }));
+    } catch (err) {
+      // Dedup is advisory — a failure here must not block promotion.
+      functions.logger.warn(
+        `Dedup lookup failed for ${programId}; proceeding without dedup`,
+        err
+      );
+    }
+
+    try {
+      // Atomic batch: create promotion tasks AND mark patterns promoted.
       const batch = db.batch();
 
-      // Create a task for each pattern
-      for (const pattern of patternsToPromote) {
-        const taskRef = db.collection(`tenants/${userId}/tasks`).doc();
+      for (const pattern of toPromote) {
         const slug = pattern.id.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        const duplicate = findDuplicate(pattern, otherPrograms);
+        const dupNote = duplicate
+          ? `Potential duplicate: program '${duplicate.programId}' already promoted pattern '${duplicate.patternId}' in this domain — review and merge or fork.`
+          : "Potential duplicate: none found.";
 
+        const taskRef = db.collection(`tenants/${userId}/tasks`).doc();
         batch.set(taskRef, {
           type: "task",
           title: `Promote pattern: ${pattern.id} → grid/stores/patterns/${pattern.domain}/`,
-          instructions: `Pattern '${pattern.id}' has reached promotion criteria (confidence: ${pattern.confidence}). Write it to grid/stores/patterns/${pattern.domain}/${slug}.md using the promotion format from grid/workflows/pattern-promotion.md. Pattern: "${pattern.pattern}". Evidence: "${pattern.evidence}".`,
+          instructions:
+            `Pattern '${pattern.id}' has reached promotion criteria ` +
+            `(confidence: ${pattern.confidence}). Write it to ` +
+            `grid/stores/patterns/${pattern.domain}/${slug}.md using the promotion ` +
+            `format from grid/workflows/pattern-promotion.md. ` +
+            `Pattern: "${pattern.pattern}". Evidence: "${pattern.evidence}". ${dupNote}`,
           target: programId,
           source: "system",
           action: "queue",
@@ -104,18 +215,30 @@ export const onProgramStateWrite = functions.firestore
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
         });
 
+        // PATTERN_PROMOTED telemetry — measures promotion rate (OPP-3 dry-run
+        // also validates whether the orphaned-pattern problem is real).
+        emitEvent(db, userId, {
+          event_type: "PATTERN_PROMOTED",
+          program_id: programId,
+          pattern_id: pattern.id,
+          domain: pattern.domain,
+          confidence: pattern.confidence,
+          duplicate_found: duplicate !== null,
+        });
+
         functions.logger.info(
-          `Created promotion task for pattern ${pattern.id} (confidence: ${pattern.confidence})`
+          `Created promotion task for pattern ${pattern.id} ` +
+            `(confidence: ${pattern.confidence}, duplicate: ${duplicate !== null})`
         );
       }
 
-      // Update the program state to mark patterns as promoted
-      batch.update(change.after.ref, patternUpdates);
+      // Mark the promoted patterns in the state document.
+      batch.update(change.after.ref, updates);
 
       await batch.commit();
 
       functions.logger.info(
-        `Successfully created ${patternsToPromote.length} promotion tasks for ${programId}`
+        `Successfully created ${toPromote.length} promotion tasks for ${programId}`
       );
     } catch (error) {
       functions.logger.error(

--- a/services/functions/src/util/emitEvent.ts
+++ b/services/functions/src/util/emitEvent.ts
@@ -1,0 +1,48 @@
+import * as admin from "firebase-admin";
+
+/**
+ * Cloud-Functions-side telemetry emitter.
+ *
+ * Mirrors the mcp-server append-only event stream (services/mcp-server/src/modules/events.ts):
+ * writes to `tenants/{userId}/events` with an `event_type` discriminator and a
+ * server timestamp. Fire-and-forget — never blocks the trigger, never throws.
+ *
+ * The functions package cannot import the mcp-server `emitEvent` helper (separate
+ * package / Firestore client), so this is the functions-local equivalent.
+ */
+export type FunctionEventType =
+  | "PATTERN_PROMOTED"
+  | "STATE_DECAY";
+
+export interface FunctionEventData {
+  event_type: FunctionEventType;
+  program_id?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Emit a telemetry event to the append-only events stream for a tenant.
+ * Fire-and-forget: returns immediately; logs but never rethrows on failure.
+ */
+export function emitEvent(
+  db: admin.firestore.Firestore,
+  userId: string,
+  data: FunctionEventData
+): void {
+  try {
+    // Strip undefined values — Firestore rejects them.
+    const cleaned = Object.fromEntries(
+      Object.entries(data).filter(([, v]) => v !== undefined)
+    );
+    db.collection(`tenants/${userId}/events`)
+      .add({
+        ...cleaned,
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      })
+      .catch((err) => {
+        console.error("[Events] Failed to write event:", err);
+      });
+  } catch (err) {
+    console.error("[Events] Failed to emit event:", err);
+  }
+}


### PR DESCRIPTION
## OPP-3 — patternPromotion + decay Cloud Functions

Ships the Dream-cycle **knowledge-maintenance** decay+promotion automation, reconciled to Flynn's baked decisions. **NOT** the Dream Mode execution harness (Decision #13) — different system; the execution harness is untouched.

ISO orchestrating on behalf of TENSOR (owner). Cross-linked with the grid doc-reconcile PR (STORY 1).

### Finding
Both functions already existed and were wired into `index.ts`. This PR **hardens** them — it is reconcile + harden, not greenfield.

### patternPromotion — `patterns/onProgramStateWrite.ts`
- **Threshold `confidence >= 0.8`** (was `0.7`) — matches `program.schema.json`. Single source of truth; the grid workflow doc is reconciled in the paired PR.
- **Advisory cross-program dedup** — bounded **single-collection** read of `program_state` (one doc per program), **no `collectionGroup`, no composite index** → predictable cost (ALAN note). Flags duplicates by domain + Jaccard text similarity. Never blocks; the note rides on the created task.
- **`PATTERN_PROMOTED` telemetry** emitted to `tenants/{uid}/events` per promoted pattern (programId, domain, confidence, duplicate_found).
- **Guardrail preserved (non-negotiable):** creates a **low-priority task**, never writes git — task-not-commit.

### decay — `cleanup/decayProgramState.ts`
- **PROPOSE-ONLY first deploy:** `EVICTION_ENABLED = false` → `DRY_RUN`. Computes every action, writes typed `decayLog` entries + `STATE_DECAY` telemetry, but performs **no state mutation** (nothing staled/evicted/cleared/reset). Measures whether the orphaned-pattern problem is real before any destructive change. Enabling eviction is a **separate follow-up** behind the SARK gate (Decision #15c).
- **decayLog entries now typed** `{timestamp, action, detail}` matching the schema enum: `context_cleared | pattern_staled | pattern_evicted | baselines_reset`.
- **Grace window — promotion before eviction:** any pattern meeting promotion criteria is never staled or evicted. Reuses `isPromotable()` so the rule has one definition. Stated explicitly in code.
- **Flat `learnedPatternMaxAge`** per schema; no per-domain half-lives (deferred).

### Tests
`util/emitEvent.ts` added (functions-side event emitter mirroring the mcp-server events stream). Pure eligibility/dedup/decay logic extracted and unit-tested.

```
27 passing (jest)
```

### Review gate (policy_mode=supervised — do not self-merge)
- **ALAN** — trigger architecture + Firestore cost/index implications vs approved schema (Decision #15b). Dedup is a bounded single-collection read by design.
- **SARK** — decay/eviction safety (Decision #15c). First deploy is propose-only; eviction stays disabled until N nights validate.

### Deploy note
`lib/` is gitignored and this `firebase.json` has **no functions predeploy hook** — run `npm run build` in `services/functions` before `firebase deploy --only functions`.

### Known divergence (out of OPP-3 scope, flagged for routing)
Workflow doc says reinforcement `>= 2 updates to lastReinforced`; code uses `>= 1` (`lastReinforced !== discoveredAt`). Left as-is — not changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)