### PR TITLE
feat(mcp-server): re-enable OAuth 2.1 with SCALAR program binding (claude.ai web+mobile) [SARK-gated deploy]

### DIFF
--- a/services/mcp-server/src/__tests__/integration/oauth-flow.test.ts
+++ b/services/mcp-server/src/__tests__/integration/oauth-flow.test.ts
@@ -348,6 +348,133 @@ describe("OAuth 2.1 End-to-End Flow", () => {
       expect(accessDoc.data()?.active).toBe(true);
     });
 
+    it("should bind token to SCALAR program when selected on consent", async () => {
+      // Authorization request
+      const authReq = createMockRequest(
+        "GET",
+        `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+          redirectUri
+        )}&code_challenge=${pkce.challenge}&code_challenge_method=S256&state=${state}&scope=mcp:full`
+      );
+      const authMock = createMockResponse();
+      await handleOAuthAuthorize(authReq, authMock.res);
+      const pendingAuthId = new URL(
+        authMock.getHeaders()["Location"] as string,
+        "http://localhost"
+      ).searchParams.get("pending")!;
+
+      // Consent GET renders the program identity selector
+      const consentGetReq = createMockRequest("GET", `/oauth/consent?pending=${pendingAuthId}`);
+      const consentGetMock = createMockResponse();
+      await handleOAuthConsent(consentGetReq, consentGetMock.res);
+      expect(consentGetMock.getBody()).toContain('name="program"');
+      expect(consentGetMock.getBody()).toContain('value="scalar"');
+
+      // Consent POST (allow) with program=scalar
+      const consentPostReq = createMockRequest(
+        "POST",
+        "/oauth/consent",
+        `pending=${pendingAuthId}&action=allow&program=scalar`,
+        { "content-type": "application/x-www-form-urlencoded" }
+      );
+      const consentPostMock = createMockResponse();
+      await handleOAuthConsent(consentPostReq, consentPostMock.res);
+      expect(consentPostMock.getStatus()).toBe(200);
+
+      // Consent persisted the program identity on the pending auth
+      const pendingDoc = await db.doc(`oauthPendingAuth/${pendingAuthId}`).get();
+      expect(pendingDoc.data()?.programId).toBe("scalar");
+
+      // Simulate the callback's code write (Firebase Auth bypassed — no Auth
+      // emulator in CI) including the programId the callback copies forward
+      const authCode = crypto.randomBytes(32).toString("hex");
+      const codeHash = crypto.createHash("sha256").update(authCode).digest("hex");
+      const now = new Date();
+      await db.doc(`oauthCodes/${codeHash}`).set({
+        codeHash,
+        clientId,
+        userId,
+        redirectUri,
+        codeChallenge: pkce.challenge,
+        codeChallengeMethod: "S256",
+        state,
+        scope: "mcp:full",
+        programId: pendingDoc.data()?.programId,
+        createdAt: admin.firestore.Timestamp.fromDate(now),
+        expiresAt: admin.firestore.Timestamp.fromDate(new Date(now.getTime() + 10 * 60 * 1000)),
+        used: false,
+      });
+      await db.doc(`oauthPendingAuth/${pendingAuthId}`).delete();
+
+      // Token exchange
+      const tokenReq = createMockRequest(
+        "POST",
+        "/token",
+        `grant_type=authorization_code&code=${authCode}&redirect_uri=${encodeURIComponent(
+          redirectUri
+        )}&client_id=${clientId}&code_verifier=${pkce.verifier}`,
+        { "content-type": "application/x-www-form-urlencoded" }
+      );
+      const tokenMock = createMockResponse();
+      await handleOAuthToken(tokenReq, tokenMock.res);
+      expect(tokenMock.getStatus()).toBe(200);
+      const tokenResponse = JSON.parse(tokenMock.getBody());
+
+      // Auth context resolves to SCALAR with its explicit capability set
+      const authContext = await validateAuth(tokenResponse.access_token);
+      expect(authContext).not.toBeNull();
+      expect(authContext!.programId).toBe("scalar");
+      expect(authContext!.capabilities).toContain("dispatch.write");
+      expect(authContext!.capabilities).toContain("gsp.write");
+      expect(authContext!.capabilities).not.toContain("*");
+      expect(authContext!.capabilities).not.toContain("keys.write");
+      expect(authContext!.capabilities).not.toContain("keys.read");
+      expect(authContext!.capabilities).not.toContain("programs.write");
+
+      // Refresh rotation carries the SCALAR binding forward
+      const refreshReq = createMockRequest(
+        "POST",
+        "/token",
+        `grant_type=refresh_token&refresh_token=${tokenResponse.refresh_token}&client_id=${clientId}`,
+        { "content-type": "application/x-www-form-urlencoded" }
+      );
+      const refreshMock = createMockResponse();
+      await handleOAuthToken(refreshReq, refreshMock.res);
+      expect(refreshMock.getStatus()).toBe(200);
+      const refreshed = JSON.parse(refreshMock.getBody());
+      const refreshedContext = await validateAuth(refreshed.access_token);
+      expect(refreshedContext!.programId).toBe("scalar");
+    });
+
+    it("should degrade unknown program selection to generic oauth identity", async () => {
+      const authReq = createMockRequest(
+        "GET",
+        `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+          redirectUri
+        )}&code_challenge=${pkce.challenge}&code_challenge_method=S256&state=${state}&scope=mcp:full`
+      );
+      const authMock = createMockResponse();
+      await handleOAuthAuthorize(authReq, authMock.res);
+      const pendingAuthId = new URL(
+        authMock.getHeaders()["Location"] as string,
+        "http://localhost"
+      ).searchParams.get("pending")!;
+
+      // Attempt to bind a privileged Grid identity — must degrade to "oauth"
+      const consentPostReq = createMockRequest(
+        "POST",
+        "/oauth/consent",
+        `pending=${pendingAuthId}&action=allow&program=basher`,
+        { "content-type": "application/x-www-form-urlencoded" }
+      );
+      const consentPostMock = createMockResponse();
+      await handleOAuthConsent(consentPostReq, consentPostMock.res);
+      expect(consentPostMock.getStatus()).toBe(200);
+
+      const pendingDoc = await db.doc(`oauthPendingAuth/${pendingAuthId}`).get();
+      expect(pendingDoc.data()?.programId).toBe("oauth");
+    });
+
     it("should reject authorization without state parameter (SARK F-1)", async () => {
       const authReq = createMockRequest(
         "GET",

--- a/services/mcp-server/src/__tests__/oauth-scalar-binding.test.ts
+++ b/services/mcp-server/src/__tests__/oauth-scalar-binding.test.ts
@@ -1,0 +1,102 @@
+/**
+ * OAuth → SCALAR program binding — unit tests (no emulator required).
+ *
+ * Covers the pure logic behind the claude.ai web/mobile connector enablement:
+ * 1. Consent-screen program allowlist (scalar | oauth only, never Grid "*"-roles)
+ * 2. SCALAR's explicit capability set (no keys.*, no admin, no wildcard)
+ * 3. OAuth scope enforcement on canonical (domain-prefixed) tool names
+ */
+
+import { OAUTH_PROGRAM_OPTIONS, DEFAULT_OAUTH_PROGRAM, isAllowedOAuthProgram } from "../oauth/consent";
+import { checkToolScope } from "../oauth/scopes";
+import { DEFAULT_CAPABILITIES, getDefaultCapabilities } from "../middleware/capabilities";
+import { isRegisteredProgram, isValidProgram, PROGRAM_REGISTRY } from "../config/programs";
+
+describe("OAuth program binding allowlist", () => {
+  it("allows only scalar and oauth identities", () => {
+    expect(OAUTH_PROGRAM_OPTIONS.map((p) => p.id).sort()).toEqual(["oauth", "scalar"]);
+    expect(isAllowedOAuthProgram("scalar")).toBe(true);
+    expect(isAllowedOAuthProgram("oauth")).toBe(true);
+  });
+
+  it("rejects privileged Grid identities and unknowns", () => {
+    for (const id of ["basher", "iso", "vector", "sark", "admin", "legacy", "dispatcher", "", "oauth-service"]) {
+      expect(isAllowedOAuthProgram(id)).toBe(false);
+    }
+  });
+
+  it("pre-selects SCALAR on the consent screen", () => {
+    expect(DEFAULT_OAUTH_PROGRAM).toBe("scalar");
+    expect(isAllowedOAuthProgram(DEFAULT_OAUTH_PROGRAM)).toBe(true);
+  });
+});
+
+describe("SCALAR program registration", () => {
+  it("is a registered program with display metadata", () => {
+    expect(isRegisteredProgram("scalar")).toBe(true);
+    expect(isValidProgram("scalar")).toBe(true);
+    expect(PROGRAM_REGISTRY.scalar?.displayName).toBe("SCALAR");
+  });
+});
+
+describe("SCALAR capability set", () => {
+  const caps = getDefaultCapabilities("scalar");
+
+  it("grants the minted operational read+write set", () => {
+    for (const cap of [
+      "dispatch.read", "dispatch.write",
+      "relay.read", "relay.write",
+      "pulse.read", "pulse.write",
+      "signal.read", "signal.write",
+      "gsp.read", "gsp.write",
+      "state.read", "state.write",
+      "sprint.read", "metrics.read", "fleet.read", "programs.read",
+    ]) {
+      expect(caps).toContain(cap);
+    }
+  });
+
+  it("never grants wildcard, keys, audit, or programs.write", () => {
+    expect(caps).not.toContain("*");
+    expect(caps).not.toContain("keys.read");
+    expect(caps).not.toContain("keys.write");
+    expect(caps).not.toContain("audit.read");
+    expect(caps).not.toContain("programs.write");
+    expect(caps).not.toContain("sprint.write");
+  });
+
+  it("is strictly narrower than Grid program wildcards", () => {
+    expect(DEFAULT_CAPABILITIES.basher).toEqual(["*"]);
+    expect(DEFAULT_CAPABILITIES.scalar).not.toContain("*");
+  });
+});
+
+describe("OAuth scope enforcement on canonical tool names", () => {
+  it("requires mcp:write for canonical write tools", () => {
+    expect(checkToolScope("dispatch_create_task", ["mcp:read"])).toMatch(/mcp:write/);
+    expect(checkToolScope("relay_send_message", ["mcp:read"])).toMatch(/mcp:write/);
+    expect(checkToolScope("dispatch_create_task", ["mcp:write"])).toBeNull();
+    expect(checkToolScope("dispatch_create_task", ["mcp:full"])).toBeNull();
+  });
+
+  it("allows canonical read tools with mcp:read", () => {
+    expect(checkToolScope("dispatch_get_tasks", ["mcp:read"])).toBeNull();
+    expect(checkToolScope("pulse_get_fleet_health", ["mcp:read"])).toBeNull();
+  });
+
+  it("requires mcp:admin for key management", () => {
+    expect(checkToolScope("keys_create_key", ["mcp:full"])).toMatch(/mcp:admin/);
+    expect(checkToolScope("keys_rotate_key", ["mcp:full"])).toMatch(/mcp:admin/);
+    expect(checkToolScope("keys_create_key", ["mcp:admin"])).toBeNull();
+  });
+
+  it("still enforces legacy flat aliases via the explicit map", () => {
+    expect(checkToolScope("create_task", ["mcp:read"])).toMatch(/mcp:write/);
+    expect(checkToolScope("get_tasks", ["mcp:read"])).toBeNull();
+    expect(checkToolScope("create_key", ["mcp:full"])).toMatch(/mcp:admin/);
+  });
+
+  it("permits unknown tools (capability gate still applies)", () => {
+    expect(checkToolScope("totally_unknown_tool", ["mcp:read"])).toBeNull();
+  });
+});

--- a/services/mcp-server/src/auth/oauthTokenValidator.ts
+++ b/services/mcp-server/src/auth/oauthTokenValidator.ts
@@ -47,9 +47,13 @@ export async function validateOAuthToken(token: string): Promise<AuthContext | n
     // Fire-and-forget: update lastUsedAt
     db.doc(`oauthTokens/${tokenHash}`).update({ lastUsedAt: FieldValue.serverTimestamp() }).catch(() => {});
 
-    // Load capabilities — use token's programId (oauth or oauth-service)
+    // Resolve the program identity bound at consent time (e.g. "scalar").
+    // Token docs are server-written only, but enforce an allowlist anyway —
+    // anything unexpected degrades to the generic "oauth" identity.
+    // Capabilities come from DEFAULT_CAPABILITIES for that identity, never "*"-roles.
+    const OAUTH_BINDABLE_PROGRAMS = new Set(["scalar", "oauth", "oauth-service"]);
     const { getDefaultCapabilities } = await import("../middleware/capabilities.js");
-    const programId = data.programId === "oauth-service" ? "oauth-service" : "oauth";
+    const programId = OAUTH_BINDABLE_PROGRAMS.has(data.programId) ? data.programId : "oauth";
 
     // Pass granted scopes through capabilities for scope enforcement
     const grantedScopes = data.grantedScopes || (data.scope ? data.scope.split(" ") : ["mcp:full"]);

--- a/services/mcp-server/src/config/programs.ts
+++ b/services/mcp-server/src/config/programs.ts
@@ -11,7 +11,7 @@ export const REGISTERED_PROGRAMS = [
   'sage', 'link', 'gateway', 'healthbot', 'bit', 'byte',
   'tester', 'admin-mirror', 'council', 'codex', 'strategist', 'vector',
   // Grid program identities (named programs)
-  'basher', 'alan', 'sark', 'quorra', 'casp', 'ram', 'radia', 'castor', 'able', 'beck',
+  'basher', 'alan', 'sark', 'quorra', 'casp', 'ram', 'radia', 'castor', 'able', 'beck', 'scalar',
   // CIS enrichment processors (ephemeral, dispatcher-spawned)
   'sonnet-enrichment', 'opus-enrichment',
 ] as const;
@@ -78,6 +78,7 @@ export const PROGRAM_REGISTRY: Partial<Record<ProgramId, ProgramMeta>> = {
   alan:         { displayName: "ALAN",          color: "#6FC3DF", role: "Historian & Analyst" },
   sark:         { displayName: "SARK",          color: "#C44040", role: "Security & Risk" },
   quorra:       { displayName: "QUORRA",        color: "#9B6FC0", role: "Orchestrator" },
+  scalar:       { displayName: "SCALAR",        color: "#5EEAD4", role: "Web/Mobile Interface" },
   "sonnet-enrichment": { displayName: "Sonnet Enrichment", color: "#40C4FF", role: "CIS Enrichment (Sonnet)" },
   "opus-enrichment":   { displayName: "Opus Enrichment",   color: "#FF6E40", role: "CIS Enrichment (Opus)" },
 };

--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -31,7 +31,7 @@ import { executeSchedulesForUser } from "./modules/schedule-executor.js";
 import { checkSessionCompliance, resetTransportCompliance } from "./middleware/sessionCompliance.js";
 import { checkPricing } from "./middleware/pricingEnforce.js";
 import { incrementUsage } from "./middleware/usage.js";
-import { handleOAuthMetadata } from "./oauth/metadata.js";
+import { handleOAuthMetadata, handleOAuthProtectedResource } from "./oauth/metadata.js";
 import { handleOAuthRegister, cleanupDcrRateLimits } from "./oauth/register.js";
 import { handleOAuthAuthorize, cleanupOAuthRateLimits } from "./oauth/authorize.js";
 import { handleOAuthConsent } from "./oauth/consent.js";
@@ -336,12 +336,46 @@ async function main() {
       return handleGithubWebhook(req, res);
     }
 
-    // OAuth endpoints — DISABLED. Claude Code's HTTP transport creates an OAuth auth provider
-    // for ALL HTTP MCP servers (#34008). These endpoints explicitly return 404 to prevent
-    // Claude Code from attempting an OAuth 2.1 flow. Use API key auth via Authorization header.
+    // OAuth 2.1 + PKCE + DCR — RE-ENABLED for claude.ai web/mobile connectors
+    // (SCALAR identity binding via the consent screen). Previously hard-404'd
+    // for Claude Code bug #34008. Safety holds because:
+    //   1. Bearer-key auth on /v1/mcp is unchanged — a valid cb_ key never
+    //      touches OAuth (all Grid CC clients use the stdio proxy with keys).
+    //   2. A 401 for an INVALID cb_ key still returns a plain WWW-Authenticate
+    //      (no resource_metadata), so a CC client with a bad key won't pivot
+    //      into a hanging OAuth flow. See /v1/mcp handler below.
     // See: GitHub #7290, grid/assessments/*mcp-connectivity*
-    if (url === "/authorize" || url === "/token" || url === "/register" || url === "/revoke" || url?.startsWith("/oauth/consent") || url === "/authorize/callback") {
-      return sendJson(res, 404, { error: "not_found", error_description: "OAuth not supported. Use API key auth via Authorization header." });
+
+    // Discovery metadata (RFC 8414 + RFC 9728). startsWith covers the
+    // path-suffixed variants (e.g. /.well-known/oauth-protected-resource/v1/mcp).
+    if (req.method === "GET" && url?.startsWith("/.well-known/oauth-authorization-server")) {
+      return handleOAuthMetadata(req, res);
+    }
+    if (req.method === "GET" && url?.startsWith("/.well-known/oauth-protected-resource")) {
+      return handleOAuthProtectedResource(req, res);
+    }
+
+    if (url === "/authorize" && req.method === "GET") {
+      return handleOAuthAuthorize(req, res);
+    }
+    if (url === "/token" && req.method === "POST") {
+      return handleOAuthToken(req, res);
+    }
+    if (url === "/register" && req.method === "POST") {
+      // Public DCR (RFC 7591). If a Bearer token is presented, resolve it so
+      // service-account registration stays tenant-scoped.
+      const dcrToken = extractBearerToken(req.headers.authorization);
+      const dcrAuth = dcrToken ? await validateAuth(dcrToken) : null;
+      return handleOAuthRegister(req, res, dcrAuth?.userId);
+    }
+    if (url === "/revoke" && req.method === "POST") {
+      return handleOAuthRevoke(req, res);
+    }
+    if (url?.startsWith("/oauth/consent")) {
+      return handleOAuthConsent(req, res);
+    }
+    if (url === "/authorize/callback" && req.method === "GET") {
+      return handleOAuthCallback(req, res);
     }
 
     // Service account management (requires Bearer auth)
@@ -741,16 +775,19 @@ async function main() {
       const clientIp = req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim() || req.socket.remoteAddress || 'unknown';
       const proto = req.headers["x-forwarded-proto"] || "https";
       const host = req.headers.host || "localhost";
-      const oauthWwwAuth = `Bearer resource_metadata="${proto}://${host}/.well-known/oauth-authorization-server"`;
+      const oauthWwwAuth = `Bearer resource_metadata="${proto}://${host}/.well-known/oauth-protected-resource"`;
       const plainWwwAuth = `Bearer realm="cachebash"`;
 
       const token = extractBearerToken(req.headers.authorization);
       if (!token) {
         checkAuthRateLimit(clientIp);
-        // No token — use plain Bearer header. OAuth discovery (resource_metadata) causes
-        // Claude Code to abandon static Bearer auth and attempt OAuth 2.1 flow, which fails.
-        // See: grid/assessments/*mcp-connectivity*2026-03-18*, GitHub #7290
-        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": plainWwwAuth });
+        // No token — advertise OAuth discovery (RFC 9728 resource_metadata) so
+        // claude.ai web/mobile connectors can run the OAuth 2.1 flow.
+        // #34008 note: all Grid Claude Code clients send a static cb_ key via
+        // the stdio proxy and never hit this branch. A client with a key but
+        // an INVALID one still gets the plain header below — it must not be
+        // lured into OAuth discovery.
+        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": oauthWwwAuth });
         res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
         return;
       }

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -176,6 +176,13 @@ export const DEFAULT_CAPABILITIES: Record<string, Capability[]> = {
     "pulse.read", "pulse.write", "signal.read", "signal.write",
     "state.read", "state.write", "sprint.read", "programs.read", "programs.write",
     "gsp.read", "gsp.write"],
+  // SCALAR — Flynn's web/mobile Grid identity (OAuth-bound, claude.ai connector).
+  // Explicit minted set: operational read+write, observability read-only.
+  // Deliberately NO keys.*, NO audit, NO programs.write, NO wildcard.
+  scalar: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
+    "pulse.read", "pulse.write", "signal.read", "signal.write",
+    "gsp.read", "gsp.write", "state.read", "state.write",
+    "sprint.read", "metrics.read", "fleet.read", "programs.read"],
   // Grid programs — full operational access
   iso: ["*"],
   basher: ["*"],

--- a/services/mcp-server/src/oauth/callback.ts
+++ b/services/mcp-server/src/oauth/callback.ts
@@ -85,6 +85,8 @@ export async function handleOAuthCallback(req: http.IncomingMessage, res: http.S
         codeChallengeMethod: pending.codeChallengeMethod,
         state: pending.state,
         scope: pending.scope,
+        // Program identity selected on the consent screen (allowlist-validated there)
+        programId: pending.programId || "oauth",
         createdAt: Timestamp.fromDate(now),
         expiresAt: Timestamp.fromDate(codeExpiresAt),
         used: false,

--- a/services/mcp-server/src/oauth/consent.ts
+++ b/services/mcp-server/src/oauth/consent.ts
@@ -10,6 +10,24 @@ import type http from "http";
 import { getFirestore } from "../firebase/client.js";
 import { getScopeDisplayInfo, SCOPE_DEFINITIONS } from "./scopes.js";
 
+/**
+ * Program identities an OAuth grant may bind to. Selected on the consent
+ * screen, stored on the pending auth, carried through code → token docs.
+ * Capabilities for each are fixed server-side in DEFAULT_CAPABILITIES —
+ * selecting "scalar" grants LESS than generic "oauth" (no programs.write).
+ * Anything outside this list is rejected and falls back to "oauth".
+ */
+export const OAUTH_PROGRAM_OPTIONS: ReadonlyArray<{ id: string; label: string; description: string }> = [
+  { id: "scalar", label: "SCALAR", description: "Web & mobile interface identity" },
+  { id: "oauth", label: "Generic", description: "Standard OAuth client identity" },
+];
+
+export const DEFAULT_OAUTH_PROGRAM = "scalar";
+
+export function isAllowedOAuthProgram(id: string): boolean {
+  return OAUTH_PROGRAM_OPTIONS.some((p) => p.id === id);
+}
+
 function sendHtml(res: http.ServerResponse, status: number, html: string): void {
   res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
   res.end(html);
@@ -108,6 +126,12 @@ async function handleConsentPost(req: http.IncomingMessage, res: http.ServerResp
     return sendHtml(res, 400, errorPage("Authorization request has expired"));
   }
 
+  // Program identity binding: validate against the allowlist; a missing or
+  // unexpected value degrades to the generic "oauth" identity, never escalates.
+  // (DEFAULT_OAUTH_PROGRAM only pre-selects the dropdown — binding to SCALAR
+  // requires the form to submit it explicitly.)
+  const programId = form.program && isAllowedOAuthProgram(form.program) ? form.program : "oauth";
+
   if (action === "deny") {
     // Clean up pending auth
     await db.doc(`oauthPendingAuth/${pendingAuthId}`).delete();
@@ -121,7 +145,11 @@ async function handleConsentPost(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  // action === "allow" — redirect to Firebase Auth sign-in
+  // action === "allow" — persist the chosen program identity on the pending
+  // auth so callback → code → token carry it forward.
+  await db.doc(`oauthPendingAuth/${pendingAuthId}`).update({ programId });
+
+  // Redirect to Firebase Auth sign-in
   // After Firebase Auth, user is redirected to /authorize/callback
   const issuer = getIssuer(req);
   const callbackUrl = `${issuer}/authorize/callback?pending=${pendingAuthId}`;
@@ -220,6 +248,23 @@ const BRAND_CSS = `
     color: #71717A;
     margin-top: 2px;
   }
+  .program-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: #A1A1AA;
+    margin-bottom: 6px;
+  }
+  .program-select {
+    width: 100%;
+    background: #1F1F23;
+    color: #E4E4E7;
+    border: 1px solid #27272A;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 14px;
+    margin-bottom: 20px;
+  }
   .actions {
     display: flex;
     gap: 12px;
@@ -290,6 +335,9 @@ const BRAND_CSS = `
 
 function consentPage(clientName: string, pendingAuthId: string, scopes: string[] = ["mcp:full"]): string {
   const escapedName = clientName.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  const programOptionsHtml = OAUTH_PROGRAM_OPTIONS.map((p) =>
+    `<option value="${p.id}"${p.id === DEFAULT_OAUTH_PROGRAM ? " selected" : ""}>${p.label} — ${p.description}</option>`
+  ).join("\n        ");
   const scopeDisplay = getScopeDisplayInfo(scopes);
   const scopeHtml = scopeDisplay.map((s) =>
     `<li class="scope-item">
@@ -322,6 +370,10 @@ function consentPage(clientName: string, pendingAuthId: string, scopes: string[]
     </ul>
     <form method="POST" action="/oauth/consent">
       <input type="hidden" name="pending" value="${pendingAuthId}">
+      <label class="program-label" for="program">Connect as</label>
+      <select name="program" id="program" class="program-select">
+        ${programOptionsHtml}
+      </select>
       <div class="actions">
         <button type="submit" name="action" value="deny" class="deny">Deny</button>
         <button type="submit" name="action" value="allow" class="allow">Allow</button>

--- a/services/mcp-server/src/oauth/metadata.ts
+++ b/services/mcp-server/src/oauth/metadata.ts
@@ -1,9 +1,9 @@
 /**
  * OAuth 2.1 Authorization Server Metadata
- * GET /.well-known/oauth-authorization-server
+ * GET /.well-known/oauth-authorization-server  (RFC 8414)
+ * GET /.well-known/oauth-protected-resource    (RFC 9728)
  *
- * Returns static JSON per RFC 8414.
- * Issuer derived from OAUTH_ISSUER env var or request Host header.
+ * Returns static JSON. Issuer derived from OAUTH_ISSUER env var or request Host header.
  */
 
 import type http from "http";
@@ -31,6 +31,29 @@ export function handleOAuthMetadata(req: http.IncomingMessage, res: http.ServerR
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
     scopes_supported: ["mcp:full", "mcp:read", "mcp:write", "mcp:admin"],
+  };
+
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Cache-Control": "public, max-age=3600",
+  });
+  res.end(JSON.stringify(metadata));
+}
+
+/**
+ * Protected Resource Metadata (RFC 9728) — advertised via the WWW-Authenticate
+ * resource_metadata hint on 401s from /v1/mcp. Points OAuth-capable clients
+ * (claude.ai web/mobile connectors) at this authorization server.
+ */
+export function handleOAuthProtectedResource(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const issuer = getIssuer(req);
+
+  const metadata = {
+    resource: `${issuer}/v1/mcp`,
+    authorization_servers: [issuer],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["mcp:full", "mcp:read", "mcp:write", "mcp:admin"],
+    resource_name: "CacheBash MCP",
   };
 
   res.writeHead(200, {

--- a/services/mcp-server/src/oauth/scopes.ts
+++ b/services/mcp-server/src/oauth/scopes.ts
@@ -5,6 +5,9 @@
  *            mcp:admin = mcp:full + admin tools
  */
 
+import { resolveToolAlias } from "../tools/tool-aliases.js";
+import { TOOL_CAPABILITIES } from "../middleware/capabilities.js";
+
 export interface ScopeDefinition {
   scope: string;
   label: string;
@@ -141,12 +144,28 @@ export const TOOL_SCOPE_MAP: Record<string, string> = {
 };
 
 /**
+ * Derive the required scope for a tool from its capability requirement.
+ * keys.write → mcp:admin; *.write → mcp:write; *.read → mcp:read.
+ * Covers domain-prefixed canonical names that the explicit map predates.
+ */
+function scopeFromCapability(toolName: string): string | null {
+  const capability = TOOL_CAPABILITIES[toolName];
+  if (!capability) return null;
+  if (capability === "keys.write") return "mcp:admin";
+  if (capability.endsWith(".write")) return "mcp:write";
+  return "mcp:read";
+}
+
+/**
  * Check if OAuth scopes permit a tool invocation.
  * Returns null if allowed, or an error string if denied.
  * Non-OAuth auth (API keys) bypass this check entirely.
+ * Resolves aliases first: legacy flat names use the explicit map,
+ * canonical names fall back to capability-derived scopes.
  */
 export function checkToolScope(toolName: string, grantedScopes: string[]): string | null {
-  const required = TOOL_SCOPE_MAP[toolName];
+  const canonical = resolveToolAlias(toolName);
+  const required = TOOL_SCOPE_MAP[toolName] || TOOL_SCOPE_MAP[canonical] || scopeFromCapability(canonical);
   if (!required) return null; // Unknown tool or no scope requirement
   if (hasScope(grantedScopes, required)) return null;
   return `insufficient_scope: "${toolName}" requires "${required}"`;

--- a/services/mcp-server/src/oauth/token.ts
+++ b/services/mcp-server/src/oauth/token.ts
@@ -118,6 +118,9 @@ async function handleAuthorizationCodeGrant(params: URLSearchParams, res: http.S
     // Resolve granted scopes from the scope string
     const grantedScopes = result.scope ? result.scope.split(" ").filter(Boolean) : ["mcp:full"];
 
+    // Program identity carried from the consent screen via the code doc
+    const programId = result.programId || "oauth";
+
     // Store access token (1 hour TTL)
     const accessExpiresAt = new Date(now.getTime() + 3600 * 1000);
     await db.doc(`oauthTokens/${accessHash}`).set({
@@ -128,7 +131,7 @@ async function handleAuthorizationCodeGrant(params: URLSearchParams, res: http.S
       userId: result.userId,
       scope: result.scope,
       grantedScopes,
-      programId: "oauth",
+      programId,
       familyId,
       createdAt: Timestamp.fromDate(now),
       expiresAt: Timestamp.fromDate(accessExpiresAt),
@@ -147,7 +150,7 @@ async function handleAuthorizationCodeGrant(params: URLSearchParams, res: http.S
       userId: result.userId,
       scope: result.scope,
       grantedScopes,
-      programId: "oauth",
+      programId,
       familyId,
       createdAt: Timestamp.fromDate(now),
       expiresAt: Timestamp.fromDate(refreshExpiresAt),
@@ -218,8 +221,9 @@ async function handleRefreshTokenGrant(params: URLSearchParams, res: http.Server
     const newAccessHash = hashToken(newAccessToken);
     const newRefreshHash = hashToken(newRefreshToken);
 
-    // Carry forward granted scopes
+    // Carry forward granted scopes and program identity
     const grantedScopes = tokenData.grantedScopes || (tokenData.scope ? tokenData.scope.split(" ").filter(Boolean) : ["mcp:full"]);
+    const programId = tokenData.programId || "oauth";
 
     // Store new access token
     const accessExpiresAt = new Date(now.getTime() + 3600 * 1000);
@@ -231,7 +235,7 @@ async function handleRefreshTokenGrant(params: URLSearchParams, res: http.Server
       userId: tokenData.userId,
       scope: tokenData.scope,
       grantedScopes,
-      programId: "oauth",
+      programId,
       familyId: tokenData.familyId,
       createdAt: Timestamp.fromDate(now),
       expiresAt: Timestamp.fromDate(accessExpiresAt),
@@ -250,7 +254,7 @@ async function handleRefreshTokenGrant(params: URLSearchParams, res: http.Server
       userId: tokenData.userId,
       scope: tokenData.scope,
       grantedScopes,
-      programId: "oauth",
+      programId,
       familyId: tokenData.familyId,
       createdAt: Timestamp.fromDate(now),
       expiresAt: Timestamp.fromDate(refreshExpiresAt),


### PR DESCRIPTION
## What

Re-enables the OAuth 2.1 + PKCE + DCR stack (previously hard-404'd for Claude Code bug #34008) and binds OAuth grants to a **program identity** chosen on the consent screen, so a claude.ai web/mobile connector authenticates as **SCALAR** with an explicit, narrow capability set. One OAuth enablement covers both web and mobile (mobile syncs the connector from web).

## Why

claude.ai's "Add custom connector" only supports OAuth (URL + optional DCR) — no bearer field. OAuth is the only path to putting SCALAR on those surfaces. The handlers already existed in-tree (SARK F-1..F-10 hardened); they were gated off at the router.

## Changes

**Routing (`index.ts`)**
- Kill-switch removed; mounts `/authorize`, `/token`, `/register` (public DCR; bearer-resolved for tenant-scoped service accounts), `/revoke`, `/oauth/consent`, `/authorize/callback`
- Serves `/.well-known/oauth-authorization-server` (RFC 8414) + `/.well-known/oauth-protected-resource` (RFC 9728, incl. path-suffixed variants)
- `/v1/mcp` 401 semantics (the #34008-critical surface):
  - **no token** → `WWW-Authenticate: Bearer resource_metadata="…/oauth-protected-resource"` (claude.ai discovery)
  - **invalid `cb_` key** → plain `Bearer realm="cachebash"` — unchanged, so a static-key client is never lured into OAuth
  - **invalid `cbo_` token** → resource_metadata (unchanged behavior, updated target)
  - **valid `cb_` key** → 200, identical code path, zero OAuth involvement

**Program binding (consent → code → token → validator)**
- Consent screen gains a "Connect as" selector (SCALAR pre-selected); allowlist `scalar|oauth`; missing/unknown values **degrade to generic `oauth`, never escalate** (tested with `program=basher` → `oauth`)
- `programId` persisted on `oauthPendingAuth` → copied to the code doc → stamped into access+refresh token docs → carried through refresh rotation
- `oauthTokenValidator` resolves the bound program via allowlist (`scalar|oauth|oauth-service`), loads `DEFAULT_CAPABILITIES` for it

**SCALAR identity (`config/programs.ts`, `middleware/capabilities.ts`)**
- Registered program + display meta
- Explicit caps: dispatch/relay/pulse/signal/gsp/state **read+write**; sprint/metrics/fleet/programs **read**; **NO** `keys.*`, **NO** `audit`, **NO** `programs.write`, **NO** wildcard. Strictly narrower than the generic `oauth` role (which has `programs.write`).

**Scope enforcement fix (`oauth/scopes.ts`)**
- Pre-existing gap: `checkToolScope` only matched legacy flat names (`get_tasks`), so canonical calls (`dispatch_get_tasks`) bypassed OAuth scope checks entirely. Now resolves aliases and derives scope from `TOOL_CAPABILITIES` (`keys.write`→`mcp:admin`, `*.write`→`mcp:write`, `*.read`→`mcp:read`).

## Verification

- `tsc --noEmit` clean; **515 unit tests pass** (12 new in `oauth-scalar-binding.test.ts`)
- **23 integration tests pass** against the Firestore emulator (2 new: SCALAR e2e binding incl. refresh carry-forward; privileged-identity degradation)
- Local server smoke test: all routes mounted; 401 header semantics verified exactly as above (no-token → discovery, bad `cb_` → plain, bad `cbo_` → discovery); metadata docs serve with correct issuer derivation

## ⚠️ SARK review focus — #34008 client audit

The "all Grid CC clients use the stdio proxy" assumption is **FALSE**. Found two **direct-HTTP** Claude Code clients with bearer keys:
- `1p-projects/basher/.mcp.json` → `type: http` direct to `https://api.cachebash.dev/v1/mcp`
- `1p-projects/cachebash/.mcp.json` → same
- (`rezzed-ai/.mcp.json` correctly uses `grid/tools/mcp-stdio-proxy.mjs`)

These send valid keys → 200 → never hit the 401 path. Risk: if Claude Code's HTTP transport *proactively* probes `.well-known` (the original #34008 behavior), those endpoints now serve 200 instead of 404. **Recommended pre-deploy mitigation: switch both `.mcp.json` files to the stdio proxy** (local config change, no code). Post-deploy, verify an existing CC session still connects.

## Deploy (GATED — do not deploy until SARK approves)

1. Switch the two direct-HTTP `.mcp.json` clients to the stdio proxy (above)
2. `cd services/mcp-server && npm run build`
3. `gcloud run deploy cachebash-mcp --source . --region us-central1 --project cachebash-app --update-env-vars OAUTH_ISSUER=https://api.cachebash.dev`
4. GCP console: add `api.cachebash.dev` to Firebase Auth **authorized domains** (cachebash-app) — required for the consent sign-in popup
5. Verify: metadata endpoints on prod, bearer path regression (`curl /v1/mcp` with a valid `cb_` key + this CC session), then full claude.ai connector flow

