### PR TITLE
fix(oauth): Flynn-only principal allowlist + consent locked to SCALAR [SARK re-review, pre-deploy gate]

### DIFF
--- a/services/mcp-server/src/__tests__/integration/oauth-flow.test.ts
+++ b/services/mcp-server/src/__tests__/integration/oauth-flow.test.ts
@@ -269,7 +269,7 @@ describe("OAuth 2.1 End-to-End Flow", () => {
       const consentPostReq = createMockRequest(
         "POST",
         "/oauth/consent",
-        `pending=${pendingAuthId}&action=allow`,
+        `pending=${pendingAuthId}&action=allow&program=scalar`,
         { "content-type": "application/x-www-form-urlencoded" }
       );
       const consentPostMock = createMockResponse();
@@ -446,33 +446,38 @@ describe("OAuth 2.1 End-to-End Flow", () => {
       expect(refreshedContext!.programId).toBe("scalar");
     });
 
-    it("should degrade unknown program selection to generic oauth identity", async () => {
-      const authReq = createMockRequest(
-        "GET",
-        `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
-          redirectUri
-        )}&code_challenge=${pkce.challenge}&code_challenge_method=S256&state=${state}&scope=mcp:full`
-      );
-      const authMock = createMockResponse();
-      await handleOAuthAuthorize(authReq, authMock.res);
-      const pendingAuthId = new URL(
-        authMock.getHeaders()["Location"] as string,
-        "http://localhost"
-      ).searchParams.get("pending")!;
+    it("should reject unknown, generic, or missing program selection (no fallback identity)", async () => {
+      // "basher" (privileged Grid identity), "oauth" (removed generic identity,
+      // grants programs.write), and a missing field must ALL be rejected — the
+      // authorization may never proceed under an unselected identity.
+      for (const programParam of ["&program=basher", "&program=oauth", ""]) {
+        const authReq = createMockRequest(
+          "GET",
+          `/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent(
+            redirectUri
+          )}&code_challenge=${pkce.challenge}&code_challenge_method=S256&state=${state}&scope=mcp:full`
+        );
+        const authMock = createMockResponse();
+        await handleOAuthAuthorize(authReq, authMock.res);
+        const pendingAuthId = new URL(
+          authMock.getHeaders()["Location"] as string,
+          "http://localhost"
+        ).searchParams.get("pending")!;
 
-      // Attempt to bind a privileged Grid identity — must degrade to "oauth"
-      const consentPostReq = createMockRequest(
-        "POST",
-        "/oauth/consent",
-        `pending=${pendingAuthId}&action=allow&program=basher`,
-        { "content-type": "application/x-www-form-urlencoded" }
-      );
-      const consentPostMock = createMockResponse();
-      await handleOAuthConsent(consentPostReq, consentPostMock.res);
-      expect(consentPostMock.getStatus()).toBe(200);
+        const consentPostReq = createMockRequest(
+          "POST",
+          "/oauth/consent",
+          `pending=${pendingAuthId}&action=allow${programParam}`,
+          { "content-type": "application/x-www-form-urlencoded" }
+        );
+        const consentPostMock = createMockResponse();
+        await handleOAuthConsent(consentPostReq, consentPostMock.res);
+        expect(consentPostMock.getStatus()).toBe(400);
 
-      const pendingDoc = await db.doc(`oauthPendingAuth/${pendingAuthId}`).get();
-      expect(pendingDoc.data()?.programId).toBe("oauth");
+        // No program identity bound, flow not advanced to sign-in
+        const pendingDoc = await db.doc(`oauthPendingAuth/${pendingAuthId}`).get();
+        expect(pendingDoc.data()?.programId).toBeUndefined();
+      }
     });
 
     it("should reject authorization without state parameter (SARK F-1)", async () => {

--- a/services/mcp-server/src/__tests__/oauth-scalar-binding.test.ts
+++ b/services/mcp-server/src/__tests__/oauth-scalar-binding.test.ts
@@ -8,19 +8,20 @@
  */
 
 import { OAUTH_PROGRAM_OPTIONS, DEFAULT_OAUTH_PROGRAM, isAllowedOAuthProgram } from "../oauth/consent";
+import { isAllowedPrincipal, getAllowedEmails, getAllowedUids } from "../oauth/callback";
 import { checkToolScope } from "../oauth/scopes";
 import { DEFAULT_CAPABILITIES, getDefaultCapabilities } from "../middleware/capabilities";
 import { isRegisteredProgram, isValidProgram, PROGRAM_REGISTRY } from "../config/programs";
 
 describe("OAuth program binding allowlist", () => {
-  it("allows only scalar and oauth identities", () => {
-    expect(OAUTH_PROGRAM_OPTIONS.map((p) => p.id).sort()).toEqual(["oauth", "scalar"]);
+  it("allows only the scalar identity (generic oauth removed — SARK gate)", () => {
+    expect(OAUTH_PROGRAM_OPTIONS.map((p) => p.id)).toEqual(["scalar"]);
     expect(isAllowedOAuthProgram("scalar")).toBe(true);
-    expect(isAllowedOAuthProgram("oauth")).toBe(true);
+    expect(isAllowedOAuthProgram("oauth")).toBe(false);
   });
 
   it("rejects privileged Grid identities and unknowns", () => {
-    for (const id of ["basher", "iso", "vector", "sark", "admin", "legacy", "dispatcher", "", "oauth-service"]) {
+    for (const id of ["basher", "iso", "vector", "sark", "admin", "legacy", "dispatcher", "", "oauth", "oauth-service"]) {
       expect(isAllowedOAuthProgram(id)).toBe(false);
     }
   });
@@ -28,6 +29,68 @@ describe("OAuth program binding allowlist", () => {
   it("pre-selects SCALAR on the consent screen", () => {
     expect(DEFAULT_OAUTH_PROGRAM).toBe("scalar");
     expect(isAllowedOAuthProgram(DEFAULT_OAUTH_PROGRAM)).toBe(true);
+  });
+});
+
+describe("Flynn-only principal allowlist (callback)", () => {
+  const ENV_KEYS = ["OAUTH_ALLOWED_EMAILS", "OAUTH_ALLOWED_UIDS"] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("defaults to Flynn's two emails and the rezzed.ai uid", () => {
+    expect(getAllowedEmails()).toEqual(["christianbourlier@gmail.com", "christian@rezzed.ai"]);
+    expect(getAllowedUids()).toEqual(["7viFKVtl5lgzguhFoZlnYYrqeDG2"]);
+  });
+
+  it("allows allowlisted principals with verified emails (case-insensitive)", () => {
+    expect(isAllowedPrincipal({ uid: "x", email: "christianbourlier@gmail.com", email_verified: true })).toBe(true);
+    expect(isAllowedPrincipal({ uid: "x", email: "christian@rezzed.ai", email_verified: true })).toBe(true);
+    expect(isAllowedPrincipal({ uid: "x", email: "ChristianBourlier@Gmail.com", email_verified: true })).toBe(true);
+  });
+
+  it("rejects unverified emails even when allowlisted (GitHub provider risk)", () => {
+    expect(isAllowedPrincipal({ uid: "x", email: "christianbourlier@gmail.com", email_verified: false })).toBe(false);
+    expect(isAllowedPrincipal({ uid: "x", email: "christianbourlier@gmail.com" })).toBe(false);
+  });
+
+  it("rejects non-allowlisted accounts", () => {
+    expect(isAllowedPrincipal({ uid: "attacker", email: "evil@example.com", email_verified: true })).toBe(false);
+    expect(isAllowedPrincipal({ uid: "attacker" })).toBe(false);
+    expect(isAllowedPrincipal({ uid: "attacker", email: "", email_verified: true })).toBe(false);
+  });
+
+  it("accepts the known uid regardless of email claims", () => {
+    expect(isAllowedPrincipal({ uid: "7viFKVtl5lgzguhFoZlnYYrqeDG2" })).toBe(true);
+    expect(isAllowedPrincipal({ uid: "7viFKVtl5lgzguhFoZlnYYrqeDG2", email: "anything@else.com", email_verified: false })).toBe(true);
+  });
+
+  it("honors env overrides without falling back to defaults", () => {
+    process.env.OAUTH_ALLOWED_EMAILS = " Alice@Example.com , bob@example.com ";
+    process.env.OAUTH_ALLOWED_UIDS = "uid-1, uid-2";
+    expect(getAllowedEmails()).toEqual(["alice@example.com", "bob@example.com"]);
+    expect(getAllowedUids()).toEqual(["uid-1", "uid-2"]);
+    // Defaults no longer apply when env is set
+    expect(isAllowedPrincipal({ uid: "x", email: "christianbourlier@gmail.com", email_verified: true })).toBe(false);
+    expect(isAllowedPrincipal({ uid: "7viFKVtl5lgzguhFoZlnYYrqeDG2" })).toBe(false);
+    expect(isAllowedPrincipal({ uid: "uid-1" })).toBe(true);
+    expect(isAllowedPrincipal({ uid: "x", email: "alice@example.com", email_verified: true })).toBe(true);
+  });
+
+  it("treats whitespace-only env as unset (defaults apply)", () => {
+    process.env.OAUTH_ALLOWED_EMAILS = "   ";
+    expect(getAllowedEmails()).toEqual(["christianbourlier@gmail.com", "christian@rezzed.ai"]);
   });
 });
 

--- a/services/mcp-server/src/oauth/callback.ts
+++ b/services/mcp-server/src/oauth/callback.ts
@@ -11,6 +11,45 @@ import admin from "firebase-admin";
 import { getFirestore } from "../firebase/client.js";
 import { Timestamp } from "firebase-admin/firestore";
 
+/**
+ * Flynn-only principal allowlist (SARK gate, task s0QMEUOc).
+ * verifyIdToken proves the token is signed by Firebase for cachebash-app
+ * (aud/iss bound) — but says nothing about WHO signed in. Without this gate
+ * any Google/GitHub account could complete consent and claim SCALAR's
+ * operational-write capabilities.
+ *
+ * A principal is allowed iff:
+ *   - their uid is explicitly allowlisted (stable, provider-independent), OR
+ *   - their email is allowlisted AND email_verified === true (GitHub tokens
+ *     can carry unverified emails — those are rejected).
+ * Configurable via OAUTH_ALLOWED_EMAILS / OAUTH_ALLOWED_UIDS (comma-separated)
+ * so the list is maintainable without a code change.
+ */
+const DEFAULT_ALLOWED_EMAILS = ["christianbourlier@gmail.com", "christian@rezzed.ai"];
+const DEFAULT_ALLOWED_UIDS = ["7viFKVtl5lgzguhFoZlnYYrqeDG2"]; // christian@rezzed.ai
+
+function parseListEnv(value: string | undefined, fallback: string[], lowercase: boolean): string[] {
+  if (!value || !value.trim()) return fallback;
+  return value
+    .split(",")
+    .map((s) => (lowercase ? s.trim().toLowerCase() : s.trim()))
+    .filter(Boolean);
+}
+
+export function getAllowedEmails(): string[] {
+  return parseListEnv(process.env.OAUTH_ALLOWED_EMAILS, DEFAULT_ALLOWED_EMAILS, true);
+}
+
+export function getAllowedUids(): string[] {
+  return parseListEnv(process.env.OAUTH_ALLOWED_UIDS, DEFAULT_ALLOWED_UIDS, false);
+}
+
+export function isAllowedPrincipal(p: { uid: string; email?: string; email_verified?: boolean }): boolean {
+  if (getAllowedUids().includes(p.uid)) return true;
+  if (p.email && p.email_verified === true && getAllowedEmails().includes(p.email.toLowerCase())) return true;
+  return false;
+}
+
 function sendHtml(res: http.ServerResponse, status: number, html: string): void {
   res.writeHead(status, { "Content-Type": "text/html; charset=utf-8" });
   res.end(html);
@@ -37,13 +76,13 @@ export async function handleOAuthCallback(req: http.IncomingMessage, res: http.S
   }
 
   // Verify Firebase ID token
-  let userId: string;
+  let decoded: admin.auth.DecodedIdToken;
   try {
-    const decoded = await admin.auth().verifyIdToken(idToken);
-    userId = decoded.uid;
+    decoded = await admin.auth().verifyIdToken(idToken);
   } catch (error) {
     return sendHtml(res, 401, errorPage("Authentication failed. Please try again."));
   }
+  const userId = decoded.uid;
 
   const db = getFirestore();
 
@@ -59,6 +98,24 @@ export async function handleOAuthCallback(req: http.IncomingMessage, res: http.S
   const expiresAt = pending.expiresAt?.toDate?.() || new Date(pending.expiresAt);
   if (new Date() > expiresAt) {
     return sendHtml(res, 400, errorPage("Authorization request has expired"));
+  }
+
+  // Flynn-only allowlist: deny non-allowlisted principals BEFORE any
+  // authorization code exists. The pending auth is consumed (deleted) and the
+  // client gets a standard access_denied redirect — redirectUri was validated
+  // against the registered client at /authorize, so this redirect is safe.
+  if (!isAllowedPrincipal(decoded)) {
+    console.warn(
+      `[OAuth] Denied non-allowlisted principal uid=${decoded.uid} email=${decoded.email || "none"} verified=${decoded.email_verified === true}`
+    );
+    await db.doc(`oauthPendingAuth/${pendingAuthId}`).delete();
+    const denyUrl = new URL(pending.redirectUri);
+    denyUrl.searchParams.set("error", "access_denied");
+    denyUrl.searchParams.set("error_description", "This account is not authorized for this server");
+    denyUrl.searchParams.set("state", pending.state);
+    res.writeHead(302, { Location: denyUrl.toString() });
+    res.end();
+    return;
   }
 
   // Generate authorization code (SARK F-9: 32 bytes entropy)

--- a/services/mcp-server/src/oauth/consent.ts
+++ b/services/mcp-server/src/oauth/consent.ts
@@ -13,13 +13,15 @@ import { getScopeDisplayInfo, SCOPE_DEFINITIONS } from "./scopes.js";
 /**
  * Program identities an OAuth grant may bind to. Selected on the consent
  * screen, stored on the pending auth, carried through code → token docs.
- * Capabilities for each are fixed server-side in DEFAULT_CAPABILITIES —
- * selecting "scalar" grants LESS than generic "oauth" (no programs.write).
- * Anything outside this list is rejected and falls back to "oauth".
+ * Capabilities are fixed server-side in DEFAULT_CAPABILITIES.
+ *
+ * SCALAR only (SARK gate, task s0QMEUOc): the generic "oauth" identity was
+ * removed from the consent screen because it grants programs.write — more
+ * than SCALAR. A missing or unrecognized program REJECTS the authorization;
+ * there is no fallback identity.
  */
 export const OAUTH_PROGRAM_OPTIONS: ReadonlyArray<{ id: string; label: string; description: string }> = [
   { id: "scalar", label: "SCALAR", description: "Web & mobile interface identity" },
-  { id: "oauth", label: "Generic", description: "Standard OAuth client identity" },
 ];
 
 export const DEFAULT_OAUTH_PROGRAM = "scalar";
@@ -126,12 +128,6 @@ async function handleConsentPost(req: http.IncomingMessage, res: http.ServerResp
     return sendHtml(res, 400, errorPage("Authorization request has expired"));
   }
 
-  // Program identity binding: validate against the allowlist; a missing or
-  // unexpected value degrades to the generic "oauth" identity, never escalates.
-  // (DEFAULT_OAUTH_PROGRAM only pre-selects the dropdown — binding to SCALAR
-  // requires the form to submit it explicitly.)
-  const programId = form.program && isAllowedOAuthProgram(form.program) ? form.program : "oauth";
-
   if (action === "deny") {
     // Clean up pending auth
     await db.doc(`oauthPendingAuth/${pendingAuthId}`).delete();
@@ -145,8 +141,16 @@ async function handleConsentPost(req: http.IncomingMessage, res: http.ServerResp
     return;
   }
 
-  // action === "allow" — persist the chosen program identity on the pending
-  // auth so callback → code → token carry it forward.
+  // action === "allow" — program identity binding. Validate against the
+  // allowlist; a missing or unrecognized program REJECTS the authorization
+  // outright (no fallback identity, no escalation path).
+  const programId = form.program;
+  if (!programId || !isAllowedOAuthProgram(programId)) {
+    return sendHtml(res, 400, errorPage("Invalid or missing program selection"));
+  }
+
+  // Persist the chosen program identity on the pending auth so
+  // callback → code → token carry it forward.
   await db.doc(`oauthPendingAuth/${pendingAuthId}`).update({ programId });
 
   // Redirect to Firebase Auth sign-in


### PR DESCRIPTION
## What

Closes SARK's security gate on the OAuth enablement (#338 follow-up, task `s0QMEUOc`): **Flynn-only principal allowlist** at the authorization callback + **consent locked to SCALAR** with no fallback identity.

## The hole being closed

`verifyIdToken` proves the Firebase token is signed for `cachebash-app` (aud/iss bound) — but said nothing about **who** signed in. Any Google/GitHub account could complete consent, select SCALAR, and receive a token with SCALAR's operational-write capabilities. OAuth endpoints are **already live on prod** (rev `cachebash-mcp-00147-dvv`), so this window is open until this PR deploys.

## Fix 1 — principal allowlist (`callback.ts`)

A principal is allowed **iff**:
- `uid` ∈ `OAUTH_ALLOWED_UIDS` (default: `7viFKVtl5lgzguhFoZlnYYrqeDG2` = christian@rezzed.ai), **or**
- `email` ∈ `OAUTH_ALLOWED_EMAILS` (default: `christianbourlier@gmail.com`, `christian@rezzed.ai`) **and** `email_verified === true`

Properties:
- **email_verified enforced** — GitHub-provider tokens with unverified email claims are rejected
- Email matching is case-insensitive; lists are env-configurable (comma-separated) with compiled-in defaults, so the allowlist is maintainable without a code change
- Denial happens **before any authorization code exists**: pending auth consumed (deleted), client receives a standard `access_denied` redirect to the **registered** redirect_uri (validated at `/authorize` — no open redirect), denial logged with uid/email/verified for audit

## Fix 2 — consent locked to SCALAR (`consent.ts`)

- Generic `oauth` identity **removed** from the consent screen (it grants `programs.write` — strictly more than SCALAR; your non-blocking note #1)
- Missing or unrecognized `program` now **rejects with 400** — the silent degrade-to-`oauth` fallback is gone entirely. There is no fallback identity.
- `token.ts` retains `|| "oauth"` only for legacy code docs lacking `programId` (10-min expiry; consent now guarantees the field). Validator allowlist (`scalar|oauth|oauth-service`) unchanged as defense-in-depth.

## SARK re-review focus (as requested)

1. **Allowlist can't be bypassed**: gate runs after `verifyIdToken` (signature + aud/iss), inputs are token claims only — no headers, no form fields, no query params feed the decision
2. **email_verified enforced** — see unit tests for the unverified-claim rejection
3. **No consent escalation**: `program=basher`, `program=oauth`, and missing-field all rejected 400 with no `programId` bound (integration-tested loop)
4. Env-override semantics: when `OAUTH_ALLOWED_*` is set, defaults do **not** apply (no additive surprise)

## Verification

- `tsc --noEmit` clean
- **522 unit tests** (7 new: both emails, case-insensitivity, unverified rejection, unknown rejection, uid accept, env override, whitespace-env)
- **23 emulator integration tests** (rejection loop for basher/oauth/missing program; main PKCE flow updated to explicit `program=scalar`)

## Deploy (VECTOR — after SARK approval; BASHER will not deploy)

```
cd services/mcp-server && npm run build
gcloud run deploy cachebash-mcp --source . --region us-central1 --project cachebash-app \
  --update-env-vars OAUTH_ALLOWED_EMAILS=christianbourlier@gmail.com,christian@rezzed.ai
```
(`OAUTH_ISSUER` already set on the service; `--update-env-vars` preserves it. Defaults make the env var optional but explicit is better.)

