### PR TITLE
fix(rules): HR-4 — email_verified gate + scope authorizedEmails reads

### DIFF
--- a/infra/firestore.rules
+++ b/infra/firestore.rules
@@ -152,17 +152,26 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Authorized emails: readable by authenticated users (for auto-linking check)
+    // Authorized emails: a signed-in principal may read ONLY its own verified
+    // email doc (the auto-linking check needs no more). Previously any authed
+    // Google account could enumerate the entire allowlist. Rule get()/exists()
+    // calls bypass these read rules, so auto-linking is unaffected.
     match /authorizedEmails/{email} {
-      allow read: if isAuth();
+      allow read: if isAuth() &&
+        request.auth.token.email_verified == true &&
+        request.auth.token.email == email;
       allow write: if false;
     }
 
     // User links: readable by the linked user, auto-created for authorized emails
     match /userLinks/{linkId} {
       allow read: if isAuth() && request.auth.uid == linkId;
-      // Allow auto-linking: user can create their own link if their email is in authorizedEmails
+      // Allow auto-linking: user can create their own link if their email is in
+      // authorizedEmails AND is verified. The email_verified gate blocks the
+      // PR #339-class vector: a non-Google provider letting an attacker register
+      // Flynn's email unverified, auto-link, and read the entire tenant.
       allow create: if isAuth() && request.auth.uid == linkId &&
+        request.auth.token.email_verified == true &&
         exists(/databases/$(database)/documents/authorizedEmails/$(request.auth.token.email)) &&
         request.resource.data.dataUid == get(/databases/$(database)/documents/authorizedEmails/$(request.auth.token.email)).data.dataUid &&
         request.resource.data.keys().hasOnly(['dataUid']);


### PR DESCRIPTION
## SARK HR-4 — live-layer firestore.rules fixes

From SARK's ADR-012 Grid Brain assessment (`grid/decisions/sark-assessment-grid-brain.md`, rezzedai/grid PR #672), HR-4. These apply to the **already-deployed** Grid Portal's shared `cachebash-app` Firestore backend, independent of the Grid Brain garden work. Dispatched by Flynn via VECTOR (task `OmORcqB1xG4PD0XkPhQ0`).

### Findings fixed in this PR (`infra/firestore.rules`)

**1. `userLinks` auto-link create lacked `email_verified` (HIGHEST — auth-bypass class)**
Same class as the PR #339 GitHub-unverified-email vector. The create rule gated only on `request.auth.token.email ∈ authorizedEmails`. If any non-Google provider is ever enabled on `cachebash-app`, an attacker registers Flynn's email *unverified* → auto-links → **reads the entire tenant** (tasks, relay, program state, GSP, fleet). Now requires `request.auth.token.email_verified == true`.

**2. `authorizedEmails/{email}` allowlist enumeration**
Was `allow read: if isAuth()` — any authenticated Google account could enumerate the entire allowlist. Restricted to the caller's own **verified** email doc (`request.auth.token.email == email`). Rule `get()`/`exists()` calls bypass read rules, so the auto-linking check is unaffected.

### Sibling PR (separate repo)
grid-portal: CSP header (HR-4 finding 4) + removal of the `VITE_CACHEBASH_API_KEY` client fallback (HR-4 finding 3). Linked in thread `portal-hr4-fix`.

### Out of scope / fast-follow
HR-4 finding 3 (no `cb_` key in client artifacts) is addressed in the grid-portal PR. The current Portal `dist/` bundle is already key-clean (verified — no `.env`, fallback inlined empty); the grid-portal change removes the *latent* embed path. Emulator-based rules tests for the two gates above are a suggested fast-follow (no rules-test harness exists in this repo yet) — happy to add if SARK wants them gating.

### ⛔ Deploy gate
SARK found these — **SARK re-review required before `firebase deploy --only firestore:rules`**. Do not self-deploy. Routing back to SARK on thread `portal-hr4-fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)