### PR TITLE
fix(keys): owner-gate API key creation — close wildcard self-provision escalation

### DIFF
--- a/services/mcp-server/src/__tests__/integration/keys.test.ts
+++ b/services/mcp-server/src/__tests__/integration/keys.test.ts
@@ -42,6 +42,15 @@ beforeEach(async () => {
     capabilities: ["*"],
     rateLimitTier: "internal",
   };
+
+  // SARK keys.ts gate (fesTTlPTC): createKey is owner-gated. Treat this test's
+  // user as the platform owner so the lifecycle exercises the happy path; the
+  // gate's deny logic is unit-tested in ownerAuthz.test.ts.
+  process.env.OAUTH_ALLOWED_UIDS = testUser.userId;
+});
+
+afterAll(() => {
+  delete process.env.OAUTH_ALLOWED_UIDS;
 });
 
 describe("Keys Integration Tests", () => {

--- a/services/mcp-server/src/__tests__/integration/keys.test.ts
+++ b/services/mcp-server/src/__tests__/integration/keys.test.ts
@@ -34,23 +34,21 @@ beforeEach(async () => {
     createdBy: "system",
   });
 
+  // SARK keys.ts gate (#341): createKey requires a LITERAL keys.provision grant
+  // — NOT a uid allowlist. In prod auth.userId is the shared tenant uid, so a
+  // uid check is a no-op that passes the whole fleet (the #341 NO-GO). This auth
+  // models the real tenant-uid shape (userId = the tenant) and earns the gate via
+  // the capability: "*" + keys.provision. The literal cap passes the gate and the
+  // "*" clears the #341 capability ceiling, so the lifecycle exercises the happy
+  // path. The gate's deny logic is unit-tested in ownerAuthz.test.ts.
   auth = {
     userId: testUser.userId,
     apiKeyHash: testUser.apiKeyHash,
     programId: "orchestrator",
     encryptionKey: testUser.encryptionKey,
-    capabilities: ["*"],
+    capabilities: ["*", "keys.provision"],
     rateLimitTier: "internal",
   };
-
-  // SARK keys.ts gate (fesTTlPTC): createKey is owner-gated. Treat this test's
-  // user as the platform owner so the lifecycle exercises the happy path; the
-  // gate's deny logic is unit-tested in ownerAuthz.test.ts.
-  process.env.OAUTH_ALLOWED_UIDS = testUser.userId;
-});
-
-afterAll(() => {
-  delete process.env.OAUTH_ALLOWED_UIDS;
 });
 
 describe("Keys Integration Tests", () => {

--- a/services/mcp-server/src/__tests__/keys.test.ts
+++ b/services/mcp-server/src/__tests__/keys.test.ts
@@ -30,10 +30,12 @@ jest.mock("../middleware/capabilities", () => ({
 }));
 
 // Owner-authz gate: default-allow so the existing create tests exercise the
-// happy path. The gate's own logic is covered in auth/ownerAuthz.test.ts and
-// toggled per-test in the "createKeyHandler owner gate" block below.
+// happy path. The gate's own logic (and the #341 capability ceiling) is covered
+// in auth/ownerAuthz.test.ts; both are toggled per-test in the
+// "createKeyHandler owner gate" block below.
 jest.mock("../auth/ownerAuthz", () => ({
   isKeyProvisioner: jest.fn(() => true),
+  disallowedMintCapabilities: jest.fn(() => []),
   KEY_PROVISION_CAPABILITY: "keys.provision",
 }));
 
@@ -237,8 +239,8 @@ describe("Keys Module Unit Tests", () => {
     });
   });
 
-  describe("createKeyHandler owner gate (SARK fesTTlPTC)", () => {
-    const { isKeyProvisioner } = require("../auth/ownerAuthz");
+  describe("createKeyHandler owner gate (SARK fesTTlPTC + #341 ceiling)", () => {
+    const { isKeyProvisioner, disallowedMintCapabilities } = require("../auth/ownerAuthz");
     const { registerProgram } = require("../modules/programRegistry");
 
     it("rejects a caller that is not a key provisioner", async () => {
@@ -279,6 +281,26 @@ describe("Keys Module Unit Tests", () => {
       const data = JSON.parse(result.content[0].text);
       expect(data.success).toBe(true);
       expect(data.key).toMatch(/^cb_[0-9a-f]{64}$/);
+    });
+
+    it("rejects when requested caps exceed the caller's ceiling (#341 clamp), no side effects", async () => {
+      (isKeyProvisioner as jest.Mock).mockReturnValueOnce(true);
+      // Caller is a provisioner but does NOT hold relay.write.
+      (disallowedMintCapabilities as jest.Mock).mockReturnValueOnce(["relay.write"]);
+
+      const result = await createKeyHandler(mockAuth, {
+        programId: "basher",
+        label: "Over-broad",
+        capabilities: ["dispatch.read", "relay.write"],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Forbidden");
+      expect(data.error).toContain("relay.write");
+      // Ceiling is enforced before any write / program registration.
+      expect(Object.keys(mockKeyDocs)).toHaveLength(0);
+      expect(registerProgram).not.toHaveBeenCalled();
     });
   });
 

--- a/services/mcp-server/src/__tests__/keys.test.ts
+++ b/services/mcp-server/src/__tests__/keys.test.ts
@@ -29,6 +29,14 @@ jest.mock("../middleware/capabilities", () => ({
   getDefaultCapabilities: jest.fn(() => ["*"]),
 }));
 
+// Owner-authz gate: default-allow so the existing create tests exercise the
+// happy path. The gate's own logic is covered in auth/ownerAuthz.test.ts and
+// toggled per-test in the "createKeyHandler owner gate" block below.
+jest.mock("../auth/ownerAuthz", () => ({
+  isKeyProvisioner: jest.fn(() => true),
+  KEY_PROVISION_CAPABILITY: "keys.provision",
+}));
+
 // Mock Firestore
 const mockDb = {
   doc: jest.fn((path: string) => {
@@ -226,6 +234,51 @@ describe("Keys Module Unit Tests", () => {
       const data = JSON.parse(result.content[0].text);
       expect(data.success).toBe(false);
       expect(data.error).toContain("label is required");
+    });
+  });
+
+  describe("createKeyHandler owner gate (SARK fesTTlPTC)", () => {
+    const { isKeyProvisioner } = require("../auth/ownerAuthz");
+    const { registerProgram } = require("../modules/programRegistry");
+
+    it("rejects a caller that is not a key provisioner", async () => {
+      (isKeyProvisioner as jest.Mock).mockReturnValueOnce(false);
+
+      const result = await createKeyHandler(mockAuth, {
+        programId: "basher",
+        label: "Should Not Mint",
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Forbidden");
+      // No key written, no side effects (program registration) when denied.
+      expect(Object.keys(mockKeyDocs)).toHaveLength(0);
+      expect(registerProgram).not.toHaveBeenCalled();
+    });
+
+    it("denies BEFORE the missing-field checks (gate is first)", async () => {
+      (isKeyProvisioner as jest.Mock).mockReturnValueOnce(false);
+
+      // Missing programId AND label — gate must win, not the field validators.
+      const result = await createKeyHandler(mockAuth, {});
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Forbidden");
+    });
+
+    it("allows a permitted provisioner to mint", async () => {
+      (isKeyProvisioner as jest.Mock).mockReturnValueOnce(true);
+
+      const result = await createKeyHandler(mockAuth, {
+        programId: "basher",
+        label: "Permitted",
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(true);
+      expect(data.key).toMatch(/^cb_[0-9a-f]{64}$/);
     });
   });
 

--- a/services/mcp-server/src/__tests__/ownerAuthz.test.ts
+++ b/services/mcp-server/src/__tests__/ownerAuthz.test.ts
@@ -1,23 +1,22 @@
 /**
- * Owner-authz gate unit tests (SARK keys.ts gate, task fesTTlPTC).
+ * Owner-authz gate unit tests (SARK keys.ts gate, tasks fesTTlPTC + #341 re-review).
  *
  * The load-bearing assertion: a "*" wildcard key must NOT be able to provision
- * keys. Only the platform owner (uid allowlist) or an explicit, literal
- * keys.provision grant may.
+ * keys. The SOLE gate is a LITERAL keys.provision grant. uid is irrelevant —
+ * the #341 NO-GO proved the old uid/owner branch was a PROD NO-OP, because every
+ * cb_ key carries the shared TENANT uid (Flynn's allowlisted uid), not the
+ * calling principal, so the branch passed the entire fleet.
  */
-
-// Control the Flynn allowlist without pulling the real OAuth/Firestore chain.
-const mockGetAllowedUids = jest.fn<string[], []>(() => ["flynn-uid"]);
-jest.mock("../oauth/callback", () => ({
-  getAllowedUids: () => mockGetAllowedUids(),
-}));
-
 import type { AuthContext } from "../auth/authValidator";
-import { isKeyProvisioner, KEY_PROVISION_CAPABILITY } from "../auth/ownerAuthz";
+import {
+  isKeyProvisioner,
+  disallowedMintCapabilities,
+  KEY_PROVISION_CAPABILITY,
+} from "../auth/ownerAuthz";
 
 function authWith(partial: Partial<AuthContext>): AuthContext {
   return {
-    userId: "some-program-user",
+    userId: "shared-tenant-uid",
     apiKeyHash: "hash",
     programId: "basher",
     encryptionKey: Buffer.from("test-key-32-bytes-long-padding!!", "utf-8"),
@@ -28,36 +27,59 @@ function authWith(partial: Partial<AuthContext>): AuthContext {
 }
 
 describe("isKeyProvisioner", () => {
-  beforeEach(() => {
-    mockGetAllowedUids.mockReturnValue(["flynn-uid"]);
+  it("DENIES a wildcard '*' key (the core escalation fix)", () => {
+    expect(isKeyProvisioner(authWith({ capabilities: ["*"] }))).toBe(false);
   });
 
-  it("allows the platform owner (uid in allowlist) regardless of capabilities", () => {
-    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: [] }))).toBe(true);
-    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: ["dispatch.read"] }))).toBe(true);
+  it("denies keys.write (the wildcard-satisfiable middleware cap)", () => {
+    expect(isKeyProvisioner(authWith({ capabilities: ["keys.write"] }))).toBe(false);
   });
 
-  it("DENIES a wildcard '*' key that is not the owner (the core escalation fix)", () => {
-    expect(isKeyProvisioner(authWith({ userId: "leaked-builder", capabilities: ["*"] }))).toBe(false);
+  it("allows a caller holding an explicit, literal keys.provision grant", () => {
+    expect(isKeyProvisioner(authWith({ capabilities: [KEY_PROVISION_CAPABILITY] }))).toBe(true);
+    expect(isKeyProvisioner(authWith({ capabilities: ["dispatch.read", "keys.provision"] }))).toBe(true);
+    // The deliberate owner principal: "*" + keys.provision (granted by name).
+    expect(isKeyProvisioner(authWith({ capabilities: ["*", "keys.provision"] }))).toBe(true);
   });
 
-  it("denies keys.write (the wildcard-satisfiable middleware cap) when not owner", () => {
-    expect(isKeyProvisioner(authWith({ userId: "leaked-builder", capabilities: ["keys.write"] }))).toBe(false);
+  it("denies a caller with no provisioning grant", () => {
+    expect(isKeyProvisioner(authWith({ capabilities: [] }))).toBe(false);
+    expect(isKeyProvisioner(authWith({ capabilities: ["dispatch.read", "relay.write"] }))).toBe(false);
   });
 
-  it("allows a non-owner holding an explicit, literal keys.provision grant", () => {
-    expect(isKeyProvisioner(authWith({ userId: "provisioner", capabilities: [KEY_PROVISION_CAPABILITY] }))).toBe(true);
-    expect(isKeyProvisioner(authWith({ userId: "provisioner", capabilities: ["dispatch.read", "keys.provision"] }))).toBe(true);
+  // #341 REGRESSION: the prod no-op. Every cb_ key's userId is the shared tenant
+  // uid (Flynn's allowlisted uid). uid must NOT grant provisioning — only the
+  // literal cap does. A wildcard key carrying the real tenant uid is still DENIED.
+  it("ignores uid entirely — a tenant-uid wildcard key cannot provision (prod no-op fixed)", () => {
+    expect(isKeyProvisioner(authWith({
+      userId: "7viFKVtl5lgzguhFoZlnYYrqeDG2", // Flynn's allowlisted tenant uid
+      capabilities: ["*"],
+    }))).toBe(false);
   });
 
-  it("denies a non-owner with no provisioning grant", () => {
-    expect(isKeyProvisioner(authWith({ userId: "nobody", capabilities: [] }))).toBe(false);
-    expect(isKeyProvisioner(authWith({ userId: "nobody", capabilities: ["dispatch.read", "relay.write"] }))).toBe(false);
+  it("tolerates a missing/non-array capabilities field", () => {
+    expect(isKeyProvisioner(authWith({ capabilities: undefined as unknown as string[] }))).toBe(false);
+  });
+});
+
+describe("disallowedMintCapabilities (SARK #341 capability ceiling)", () => {
+  it("lets an owner '*' key grant anything", () => {
+    expect(disallowedMintCapabilities(["*"], ["dispatch.read", "relay.write", "*"])).toEqual([]);
+    expect(disallowedMintCapabilities(["*", "keys.provision"], ["*"])).toEqual([]);
   });
 
-  it("honors an env-driven allowlist change (no code change)", () => {
-    mockGetAllowedUids.mockReturnValue(["new-owner-uid"]);
-    expect(isKeyProvisioner(authWith({ userId: "new-owner-uid", capabilities: [] }))).toBe(true);
-    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: ["*"] }))).toBe(false);
+  it("clamps a bounded provisioner to caps it literally holds", () => {
+    const caller = ["dispatch.read", "keys.provision"];
+    expect(disallowedMintCapabilities(caller, ["dispatch.read"])).toEqual([]);
+    expect(disallowedMintCapabilities(caller, ["dispatch.read", "relay.write"])).toEqual(["relay.write"]);
+  });
+
+  it("blocks a bounded provisioner from laundering a wildcard (the whole point)", () => {
+    // A keys.provision holder that is NOT itself "*" cannot mint a "*" key.
+    expect(disallowedMintCapabilities(["dispatch.read", "keys.provision"], ["*"])).toEqual(["*"]);
+  });
+
+  it("treats a missing caller capabilities array as granting nothing", () => {
+    expect(disallowedMintCapabilities(undefined, ["dispatch.read"])).toEqual(["dispatch.read"]);
   });
 });

--- a/services/mcp-server/src/__tests__/ownerAuthz.test.ts
+++ b/services/mcp-server/src/__tests__/ownerAuthz.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Owner-authz gate unit tests (SARK keys.ts gate, task fesTTlPTC).
+ *
+ * The load-bearing assertion: a "*" wildcard key must NOT be able to provision
+ * keys. Only the platform owner (uid allowlist) or an explicit, literal
+ * keys.provision grant may.
+ */
+
+// Control the Flynn allowlist without pulling the real OAuth/Firestore chain.
+const mockGetAllowedUids = jest.fn<string[], []>(() => ["flynn-uid"]);
+jest.mock("../oauth/callback", () => ({
+  getAllowedUids: () => mockGetAllowedUids(),
+}));
+
+import type { AuthContext } from "../auth/authValidator";
+import { isKeyProvisioner, KEY_PROVISION_CAPABILITY } from "../auth/ownerAuthz";
+
+function authWith(partial: Partial<AuthContext>): AuthContext {
+  return {
+    userId: "some-program-user",
+    apiKeyHash: "hash",
+    programId: "basher",
+    encryptionKey: Buffer.from("test-key-32-bytes-long-padding!!", "utf-8"),
+    capabilities: [],
+    rateLimitTier: "internal",
+    ...partial,
+  } as AuthContext;
+}
+
+describe("isKeyProvisioner", () => {
+  beforeEach(() => {
+    mockGetAllowedUids.mockReturnValue(["flynn-uid"]);
+  });
+
+  it("allows the platform owner (uid in allowlist) regardless of capabilities", () => {
+    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: [] }))).toBe(true);
+    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: ["dispatch.read"] }))).toBe(true);
+  });
+
+  it("DENIES a wildcard '*' key that is not the owner (the core escalation fix)", () => {
+    expect(isKeyProvisioner(authWith({ userId: "leaked-builder", capabilities: ["*"] }))).toBe(false);
+  });
+
+  it("denies keys.write (the wildcard-satisfiable middleware cap) when not owner", () => {
+    expect(isKeyProvisioner(authWith({ userId: "leaked-builder", capabilities: ["keys.write"] }))).toBe(false);
+  });
+
+  it("allows a non-owner holding an explicit, literal keys.provision grant", () => {
+    expect(isKeyProvisioner(authWith({ userId: "provisioner", capabilities: [KEY_PROVISION_CAPABILITY] }))).toBe(true);
+    expect(isKeyProvisioner(authWith({ userId: "provisioner", capabilities: ["dispatch.read", "keys.provision"] }))).toBe(true);
+  });
+
+  it("denies a non-owner with no provisioning grant", () => {
+    expect(isKeyProvisioner(authWith({ userId: "nobody", capabilities: [] }))).toBe(false);
+    expect(isKeyProvisioner(authWith({ userId: "nobody", capabilities: ["dispatch.read", "relay.write"] }))).toBe(false);
+  });
+
+  it("honors an env-driven allowlist change (no code change)", () => {
+    mockGetAllowedUids.mockReturnValue(["new-owner-uid"]);
+    expect(isKeyProvisioner(authWith({ userId: "new-owner-uid", capabilities: [] }))).toBe(true);
+    expect(isKeyProvisioner(authWith({ userId: "flynn-uid", capabilities: ["*"] }))).toBe(false);
+  });
+});

--- a/services/mcp-server/src/auth/ownerAuthz.ts
+++ b/services/mcp-server/src/auth/ownerAuthz.ts
@@ -1,42 +1,78 @@
 /**
- * Owner authorization for key provisioning (SARK keys.ts gate, task fesTTlPTC).
+ * Owner authorization for key provisioning (SARK keys.ts gate, tasks fesTTlPTC
+ * + #341 re-review).
  *
  * createKey mints a NEW key under the caller's tenant with caller-chosen
  * capabilities. The capability middleware gates `keys_create_key` on
  * `keys.write` — but every "*" wildcard key satisfies that check, and every
  * Grid program defaults to ["*"]. So a leaked builder/wildcard key could mint
  * fresh admin keys for any program, turning a transient leak into durable
- * persistence (escalation). The comment in keys.ts long claimed "only Flynn's
- * userId can manage keys" but nothing enforced it.
+ * persistence (escalation).
  *
- * This adds a SECOND, independent gate on the mint path: the caller must be the
- * platform owner (Flynn) OR hold an explicit `keys.provision` grant that the
- * "*" wildcard does NOT imply.
+ * SARK NO-GO on the first attempt (PR #341): the original gate ALSO allowed
+ * `getAllowedUids().includes(auth.userId)`. That branch was a PROD NO-OP that
+ * passed EVERYTHING. The whole fleet is ONE tenant, so `auth.userId` for any
+ * cb_ key is the shared TENANT uid (Flynn's allowlisted uid), NOT the calling
+ * principal — authValidator stamps it, createKey copies it. Every program key
+ * — including ~50 wildcards — carried that uid, so the owner branch was always
+ * true and the literal keys.provision branch never ran. The unit test passed
+ * only because it fabricated per-program userIds that do not exist in prod.
+ *
+ * The fix: drop the uid/owner branch entirely. The SOLE gate on the mint path
+ * is a LITERAL `keys.provision` capability, matched by literal membership
+ * (never the wildcard-expanding matcher), so "*" does NOT satisfy it and no
+ * program key can self-provision. Flynn's provisioning principal is granted
+ * `keys.provision` by name. A capability ceiling (see
+ * `disallowedMintCapabilities`) additionally clamps minted caps to the caller's
+ * own grant, so `keys.provision` can never be used to launder wildcards.
  */
+import { hasCapability, type Capability } from "../middleware/capabilities.js";
 import type { AuthContext } from "./authValidator.js";
-// Reuse the Flynn-only principal allowlist that already gates the OAuth flow
-// (single source of truth, env-configurable via OAUTH_ALLOWED_UIDS). This is
-// the same principal SARK established in PR #339 — deliberately not duplicated.
-import { getAllowedUids } from "../oauth/callback.js";
 
 /**
  * Explicit, separate key-provisioning capability. It is checked by LITERAL
  * membership below — NOT via the wildcard-expanding `hasCapability` matcher —
  * so that a "*" key does NOT satisfy it. That independence from the wildcard is
- * the entire point: it lets a non-owner key provision others ONLY when granted
- * this capability by name, and never as a side effect of holding "*".
+ * the entire point: it lets a principal provision keys ONLY when granted this
+ * capability by name, and never as a side effect of holding "*". It is not in
+ * any DEFAULT_CAPABILITIES role — it must be granted explicitly.
  */
 export const KEY_PROVISION_CAPABILITY = "keys.provision";
 
 /**
- * True iff `auth` is permitted to provision (create) API keys.
- *   1. Platform owner — uid in the OAUTH_ALLOWED_UIDS allowlist (Flynn), OR
- *   2. an explicit, literal `keys.provision` grant (never implied by "*").
+ * True iff `auth` may provision (create) API keys.
+ *
+ * The SOLE gate is a LITERAL `keys.provision` grant. uid is deliberately NOT
+ * consulted: for cb_ keys it is the shared tenant uid (not the principal), so
+ * any uid/owner allowlist check is a no-op that passes the entire fleet — the
+ * exact prod no-op SARK rejected in #341. A "*" wildcard key fails the literal
+ * `.includes` and therefore CANNOT mint.
  */
 export function isKeyProvisioner(auth: AuthContext): boolean {
-  if (getAllowedUids().includes(auth.userId)) return true;
-  if (Array.isArray(auth.capabilities) && auth.capabilities.includes(KEY_PROVISION_CAPABILITY)) {
-    return true;
-  }
-  return false;
+  return Array.isArray(auth.capabilities)
+    && auth.capabilities.includes(KEY_PROVISION_CAPABILITY);
+}
+
+/**
+ * Capability ceiling for minted keys (SARK #341: clamp minted caps ⊆ caller's,
+ * else `keys.provision` launders wildcards). Returns the requested capabilities
+ * the caller is NOT entitled to grant.
+ *
+ * A caller "holds" a capability via standard `hasCapability` semantics — it has
+ * "*" or the literal cap. Consequences:
+ *   • An owner key holding "*" (e.g. ["*", "keys.provision"]) may mint anything
+ *     — "*" covers every requested cap. This is the deliberate owner principal.
+ *   • A BOUNDED provisioner (e.g. ["dispatch.read", "keys.provision"]) may mint
+ *     ONLY caps it literally holds. A request for "*" is rejected, because a
+ *     bounded caller does not literally hold "*" — this is what stops
+ *     keys.provision from laundering a wildcard into a freshly minted key.
+ *
+ * Empty array ⇒ every requested cap is within the caller's ceiling.
+ */
+export function disallowedMintCapabilities(
+  callerCaps: string[] | undefined,
+  requestedCaps: string[],
+): string[] {
+  if (!Array.isArray(callerCaps)) return [...requestedCaps];
+  return requestedCaps.filter((cap) => !hasCapability(callerCaps, cap as Capability));
 }

--- a/services/mcp-server/src/auth/ownerAuthz.ts
+++ b/services/mcp-server/src/auth/ownerAuthz.ts
@@ -1,0 +1,42 @@
+/**
+ * Owner authorization for key provisioning (SARK keys.ts gate, task fesTTlPTC).
+ *
+ * createKey mints a NEW key under the caller's tenant with caller-chosen
+ * capabilities. The capability middleware gates `keys_create_key` on
+ * `keys.write` — but every "*" wildcard key satisfies that check, and every
+ * Grid program defaults to ["*"]. So a leaked builder/wildcard key could mint
+ * fresh admin keys for any program, turning a transient leak into durable
+ * persistence (escalation). The comment in keys.ts long claimed "only Flynn's
+ * userId can manage keys" but nothing enforced it.
+ *
+ * This adds a SECOND, independent gate on the mint path: the caller must be the
+ * platform owner (Flynn) OR hold an explicit `keys.provision` grant that the
+ * "*" wildcard does NOT imply.
+ */
+import type { AuthContext } from "./authValidator.js";
+// Reuse the Flynn-only principal allowlist that already gates the OAuth flow
+// (single source of truth, env-configurable via OAUTH_ALLOWED_UIDS). This is
+// the same principal SARK established in PR #339 — deliberately not duplicated.
+import { getAllowedUids } from "../oauth/callback.js";
+
+/**
+ * Explicit, separate key-provisioning capability. It is checked by LITERAL
+ * membership below — NOT via the wildcard-expanding `hasCapability` matcher —
+ * so that a "*" key does NOT satisfy it. That independence from the wildcard is
+ * the entire point: it lets a non-owner key provision others ONLY when granted
+ * this capability by name, and never as a side effect of holding "*".
+ */
+export const KEY_PROVISION_CAPABILITY = "keys.provision";
+
+/**
+ * True iff `auth` is permitted to provision (create) API keys.
+ *   1. Platform owner — uid in the OAUTH_ALLOWED_UIDS allowlist (Flynn), OR
+ *   2. an explicit, literal `keys.provision` grant (never implied by "*").
+ */
+export function isKeyProvisioner(auth: AuthContext): boolean {
+  if (getAllowedUids().includes(auth.userId)) return true;
+  if (Array.isArray(auth.capabilities) && auth.capabilities.includes(KEY_PROVISION_CAPABILITY)) {
+    return true;
+  }
+  return false;
+}

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -18,6 +18,10 @@ export type Capability =
   | "dream.read" | "dream.write"
   | "sprint.read" | "sprint.write"
   | "keys.read" | "keys.write"
+  // keys.provision: explicit, owner-equivalent grant to CREATE keys. Checked by
+  // literal membership in auth/ownerAuthz (never implied by "*"); not in any
+  // DEFAULT_CAPABILITIES role — must be granted by name.
+  | "keys.provision"
   | "audit.read"
   | "state.read" | "state.write"
   | "metrics.read"

--- a/services/mcp-server/src/modules/keys.ts
+++ b/services/mcp-server/src/modules/keys.ts
@@ -9,7 +9,7 @@ import * as crypto from "crypto";
 import { getFirestore } from "../firebase/client.js";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import type { AuthContext } from "../auth/authValidator.js";
-import { isKeyProvisioner } from "../auth/ownerAuthz.js";
+import { isKeyProvisioner, disallowedMintCapabilities } from "../auth/ownerAuthz.js";
 import { isProgramRegistered, registerProgram } from "./programRegistry.js";
 import type { ApiKeyDoc } from "../types/apiKey.js";
 
@@ -26,15 +26,18 @@ function hashKey(key: string): string {
  * Returns the raw key — only time it's visible.
  */
 export async function createKeyHandler(auth: AuthContext, args: any) {
-  // SARK gate (task fesTTlPTC): provisioning keys is owner-only (or an explicit
-  // keys.provision grant), INDEPENDENT of the keys.write capability that every
-  // "*" wildcard key satisfies. Checked before any side effect (e.g. program
-  // auto-registration) so a non-provisioner cannot mutate state at all.
+  // SARK gate (task fesTTlPTC + #341 re-review): provisioning keys requires a
+  // LITERAL keys.provision grant, INDEPENDENT of the keys.write capability that
+  // every "*" wildcard key satisfies. (#341 NO-GO: the prior uid/owner branch
+  // was a prod no-op — auth.userId is the shared tenant uid, not the principal,
+  // so it passed the whole fleet. Dropped; the literal cap is now the sole gate.)
+  // Checked before any side effect (e.g. program auto-registration) so a
+  // non-provisioner cannot mutate state at all.
   if (!isKeyProvisioner(auth)) {
     return {
       content: [{ type: "text", text: JSON.stringify({
         success: false,
-        error: "Forbidden: creating API keys requires the platform owner or an explicit keys.provision grant",
+        error: "Forbidden: creating API keys requires an explicit keys.provision grant",
       }) }],
     };
   }
@@ -44,6 +47,35 @@ export async function createKeyHandler(auth: AuthContext, args: any) {
   if (!programId) {
     return {
       content: [{ type: "text", text: JSON.stringify({ success: false, error: "programId is required" }) }],
+    };
+  }
+
+  if (!label) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: false, error: "label is required" }) }],
+    };
+  }
+
+  // Phase 4: Accept scoped capabilities, default to program defaults.
+  const { getDefaultCapabilities } = await import("../middleware/capabilities.js");
+  const defaultCaps = getDefaultCapabilities(programId);
+  const requestedCapabilities: string[] = args.capabilities && Array.isArray(args.capabilities) && args.capabilities.length > 0
+    ? args.capabilities
+    : defaultCaps.length > 0 ? defaultCaps : ["*"];
+
+  // SARK #341 ceiling: a provisioner may only grant capabilities it itself
+  // holds — clamp minted caps ⊆ caller's. Enforced BEFORE any side effect
+  // (program auto-registration, key write) so a non-entitled request mutates
+  // nothing. An owner key holding "*" passes everything; a bounded
+  // keys.provision holder cannot mint "*" or caps beyond its own grant, so
+  // keys.provision can never launder a wildcard into a freshly minted key.
+  const disallowed = disallowedMintCapabilities(auth.capabilities, requestedCapabilities);
+  if (disallowed.length > 0) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({
+        success: false,
+        error: `Forbidden: cannot grant capabilities you do not hold: ${disallowed.join(", ")}`,
+      }) }],
     };
   }
 
@@ -62,22 +94,9 @@ export async function createKeyHandler(auth: AuthContext, args: any) {
     registered = true;
   }
 
-  if (!label) {
-    return {
-      content: [{ type: "text", text: JSON.stringify({ success: false, error: "label is required" }) }],
-    };
-  }
-
   const rawKey = generateApiKey();
   const keyHash = hashKey(rawKey);
   const db = getFirestore();
-
-  // Phase 4: Accept scoped capabilities, default to program defaults
-  const { getDefaultCapabilities } = await import("../middleware/capabilities.js");
-  const defaultCaps = getDefaultCapabilities(programId);
-  const requestedCapabilities: string[] = args.capabilities && Array.isArray(args.capabilities) && args.capabilities.length > 0
-    ? args.capabilities
-    : defaultCaps.length > 0 ? defaultCaps : ["*"];
 
   const keyDoc: Omit<ApiKeyDoc, "createdAt" | "lastUsedAt"> & { createdAt: any } = {
     userId: auth.userId,

--- a/services/mcp-server/src/modules/keys.ts
+++ b/services/mcp-server/src/modules/keys.ts
@@ -9,6 +9,7 @@ import * as crypto from "crypto";
 import { getFirestore } from "../firebase/client.js";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import type { AuthContext } from "../auth/authValidator.js";
+import { isKeyProvisioner } from "../auth/ownerAuthz.js";
 import { isProgramRegistered, registerProgram } from "./programRegistry.js";
 import type { ApiKeyDoc } from "../types/apiKey.js";
 
@@ -25,6 +26,19 @@ function hashKey(key: string): string {
  * Returns the raw key — only time it's visible.
  */
 export async function createKeyHandler(auth: AuthContext, args: any) {
+  // SARK gate (task fesTTlPTC): provisioning keys is owner-only (or an explicit
+  // keys.provision grant), INDEPENDENT of the keys.write capability that every
+  // "*" wildcard key satisfies. Checked before any side effect (e.g. program
+  // auto-registration) so a non-provisioner cannot mutate state at all.
+  if (!isKeyProvisioner(auth)) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({
+        success: false,
+        error: "Forbidden: creating API keys requires the platform owner or an explicit keys.provision grant",
+      }) }],
+    };
+  }
+
   const { programId, label } = args;
 
   if (!programId) {


### PR DESCRIPTION
## SARK task `fesTTlPTC` — keys.ts owner-authz

### The hole
`createKeyHandler` mints a **new** key under the caller's tenant with **caller-chosen capabilities**, gated only by the `keys.write` capability at the middleware layer. But:
- `hasCapability(["*"], "keys.write")` is `true` — every wildcard key passes.
- **Every Grid program defaults to `["*"]`** (`basher`, `iso`, `sark`, … per `DEFAULT_CAPABILITIES`).

So a leaked builder/wildcard key can mint fresh admin keys for any program under the tenant — **durable persistence from a transient leak**. The `keys.ts` header claimed "Only Flynn's userId can manage keys (Phase 2 hardcode)" but **no code enforced it** (verified on origin/main, exactly as SARK reported).

### The fix — a second, independent gate (`auth/ownerAuthz.ts`)
```
isKeyProvisioner(auth) =
   auth.userId ∈ getAllowedUids()          // platform owner (Flynn)
   OR auth.capabilities.includes("keys.provision")   // literal — NOT wildcard-expanded
```
- **Reuses** the Flynn-only allowlist that already gates OAuth (`getAllowedUids`, env-configurable via `OAUTH_ALLOWED_UIDS`) — single source of truth, the same principal from PR #339, **not duplicated**. (No change to the freshly-deployed OAuth callback; `ownerAuthz` just imports the exported getter.)
- The `keys.provision` grant is checked by **literal `.includes`**, deliberately **not** via the wildcard-expanding `hasCapability` matcher — so a `["*"]` key does **not** satisfy it. That independence from `*` is the entire point. Added to the `Capability` type; in **no** default role.
- Gate runs **before** any side effect (program auto-registration), so a denied caller mutates nothing.

### Scope: `createKey` only — and why
`rotateKey` copies the calling key's **existing** capabilities (self, no scope increase); `revokeKey` is a same-user **downgrade**. Neither is an escalation vector, and gating them would break legitimate self-service rotation. (This refines my task ACK, where I floated gating all three — the analysis says createKey-only is correct. Flag if you want it broader.)

### Tests (26/26 green)
- `__tests__/ownerAuthz.test.ts` (new) — the load-bearing proof: a non-owner `["*"]` key is **DENIED**; `keys.write` is denied; only an explicit `keys.provision` grant or an owner uid passes; env-driven allowlist change honored.
- `__tests__/keys.test.ts` — gate cases: deny precedes field validation, no side effects on deny, permitted provisioner mints.
- `__tests__/integration/keys.test.ts` — lifecycle test marks its user owner via `OAUTH_ALLOWED_UIDS`.

### Open question for SARK
Should a **non-owner `keys.provision` holder** be allowed to mint keys whose capabilities **exceed their own** (e.g. mint `["*"]`)? Today the gate authorizes *who* may provision but not a capability *ceiling*. Suggest a follow-up clamping minted caps ⊆ caller's caps for non-owners. Out of scope here; tracking your call.

### ⛔ Gate
SARK requested this — **review before merge/deploy**. Routing back on the relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)