### PR TITLE
fix(gsp): bootstrap context queries use existing indexes; surface load errors; include 'all' broadcasts (Wave A · A1)

### DIFF
--- a/services/mcp-server/src/modules/gsp.ts
+++ b/services/mcp-server/src/modules/gsp.ts
@@ -576,7 +576,15 @@ interface BootstrapPayload {
   context: {
     pendingTasks: Array<{ id: string; title: string; priority: string; action: string }>;
     unreadMessages: Array<{ id: string; source: string; message_type: string; message: string }>;
+    /** Set when the tasks/messages load throws — distinguishes "empty" from "failed". */
+    loadError?: string;
   };
+}
+
+/** Priority rank for in-memory sorting (orderBy('priority') was alphabetical: high<low<normal). */
+const PRIORITY_RANK: Record<string, number> = { high: 0, normal: 1, low: 2 };
+function priorityRank(p: unknown): number {
+  return PRIORITY_RANK[typeof p === "string" ? p : "normal"] ?? 1;
 }
 
 function buildReportingChain(role: string | null): string[] {
@@ -948,52 +956,76 @@ export async function gspBootstrapHandler(auth: AuthContext, rawArgs: unknown): 
       console.warn("[GSP Bootstrap] Failed to load memory state:", err);
     }
 
-    // 6. Context — Pending tasks and unread messages
+    // 6. Context — Pending tasks and unread messages.
+    //
+    // Query shapes are constrained to EXISTING composite indexes (the previous
+    // orderBy('priority') shapes required indexes that don't exist in prod, so
+    // every bootstrap threw FAILED_PRECONDITION and silently returned empty —
+    // and 'priority' ordering was alphabetical anyway). Priority is ranked in
+    // memory; failures surface as payload.context.loadError instead of being
+    // swallowed, so "no work" and "couldn't look" are distinguishable.
+    const contextLimit = depth === "essential" ? 10 : 20;
+
+    // Pending tasks — includes 'all' broadcasts to match get_tasks visibility.
+    // Index: tasks(target, status, createdAt DESC); `in` is equality-class.
     try {
-      // Determine limits based on depth
-      const contextLimit = depth === "essential" ? 10 : 20;
-      
-      // Pending tasks
       const tasksSnap = await db
         .collection(`tenants/${auth.userId}/tasks`)
-        .where("target", "==", args.agentId)
+        .where("target", "in", [args.agentId, "all"])
         .where("status", "==", "created")
-        .orderBy("priority")
         .orderBy("createdAt", "desc")
-        .limit(contextLimit)
+        .limit(contextLimit * 2)
         .get();
 
-      payload.context.pendingTasks = tasksSnap.docs.map((doc) => {
-        const data = doc.data();
-        return {
-          id: doc.id,
-          title: data.title || "",
-          priority: data.priority || "normal",
-          action: data.action || "queue",
-        };
-      });
+      payload.context.pendingTasks = tasksSnap.docs
+        .map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            title: data.title || "",
+            priority: data.priority || "normal",
+            action: data.action || "queue",
+          };
+        })
+        .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority))
+        .slice(0, contextLimit);
+    } catch (err) {
+      console.warn("[GSP Bootstrap] Failed to load pending tasks:", err);
+      payload.context.loadError = `pendingTasks: ${err instanceof Error ? err.message : String(err)}`;
+    }
 
-      // Unread messages
+    // Unread messages — relay has NO (target, status, ...) composite index;
+    // query on the existing relay(target, createdAt DESC) index and filter
+    // status in memory (over-fetch to compensate).
+    try {
       const messagesSnap = await db
         .collection(`tenants/${auth.userId}/relay`)
         .where("target", "==", args.agentId)
-        .where("status", "==", "pending")
-        .orderBy("priority")
         .orderBy("createdAt", "desc")
-        .limit(contextLimit)
+        .limit(contextLimit * 3)
         .get();
 
-      payload.context.unreadMessages = messagesSnap.docs.map((doc) => {
-        const data = doc.data();
-        return {
-          id: doc.id,
-          source: data.source || "",
-          message_type: data.message_type || "",
-          message: data.message || "",
-        };
-      });
+      payload.context.unreadMessages = messagesSnap.docs
+        .filter((doc) => doc.data().status === "pending")
+        .map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            source: data.source || "",
+            message_type: data.message_type || "",
+            message: data.message || "",
+            priority: data.priority || "normal",
+          };
+        })
+        .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority))
+        .slice(0, contextLimit)
+        .map(({ id, source, message_type, message }) => ({ id, source, message_type, message }));
     } catch (err) {
-      console.warn("[GSP Bootstrap] Failed to load context:", err);
+      console.warn("[GSP Bootstrap] Failed to load unread messages:", err);
+      const msg = `unreadMessages: ${err instanceof Error ? err.message : String(err)}`;
+      payload.context.loadError = payload.context.loadError
+        ? `${payload.context.loadError}; ${msg}`
+        : msg;
     }
 
     // 7. Fleet Health — lightweight program heartbeat summary (standard + full only)


### PR DESCRIPTION
## Wave A item A1 — gsp_bootstrap pendingTasks/unreadMessages always empty (P0 · confidence 0.97)

Evidence: `grid/decisions/vector-grid-improvement-review-2026-06-09.md` §CacheBash MCP Server. Both bootstrap context queries `orderBy('priority')` in shapes requiring composite indexes that don't exist in prod; Firestore throws `FAILED_PRECONDITION`; the shared catch swallowed it into `success:true` + empty arrays — every program booted blind, forever.

### Changes (`services/mcp-server/src/modules/gsp.ts`)
1. **tasks**: `(target IN [agentId,'all'], status=='created', createdAt DESC)` — served by the **existing** `tasks(target,status,createdAt DESC)` index; priority ranked in memory (`high>normal>low`; the old `orderBy('priority')` was alphabetical, so `high<low<normal` — wrong even with an index). `'all'` broadcasts now visible, matching `get_tasks` scoping.
2. **relay**: relay has **no** `(target,status,…)` composite index at all (checked `infra/firestore.indexes.json` + live) — so the review's "reuse (target,status,createdAt)" doesn't apply there; instead query the existing `relay(target, createdAt DESC)` index, over-fetch 3×, filter `status=='pending'` in memory.
3. **stop swallowing**: split try/catch per block; failures set `payload.context.loadError` — "no work" and "couldn't look" are now distinguishable, and a tasks failure can't zero out messages.

### Executed proof (live prod Firestore, REST `runQuery`, tenant `7viFKVtl…`, agent `basher`)

**OLD shape** — throws, exactly as the review root-caused:
```
=== OLD shape (target==basher + status==created + orderBy priority, createdAt desc) ===
{
 "code": 400,
 "message": "The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/cachebash-app/firestore/indexes?create_composite=Ckt...",
 "status": "FAILED_PRECONDITION"
}
```

**NEW shape** — returns the queued task (synthetic, created via `dispatch_create_task` for this proof):
```
=== NEW shape (target IN [basher,'all'] + status==created + orderBy createdAt desc) ===
1 pending task(s):
  [high] (basher) 6GllL9GfyUeBnPrW4j2T [SYNTHETIC — A1 proof] gsp_bootstrap pendingTasks visibility t
```

**Relay NEW shape** — no FAILED_PRECONDITION:
```
=== Relay NEW shape (target==basher + orderBy createdAt desc; status filtered in memory) ===
scanned 4 recent for target=basher, 2 pending — no FAILED_PRECONDITION
```

`tsc --noEmit` clean.

### Bonus live confirmation of the contested limbo finding
Cleaning up the synthetic task hit the exact trap: `dispatch_abort_task` → `Invalid transition for task: created → done`; then `claim_task` → `not claimable (status: active)`; then `complete_task` → `created → done` again. Inconsistent state reads, no self-recovery path — the contested P1 "active-unclaimed limbo" finding reproduces on demand. (Task has ttl 3600 and will TTL-hide; left as evidence for Wave B.)

**SARK gate**: API behavior change — gate request sent, cc iso. Thread `grid-fleet-restore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)