### PR TITLE
fix(dispatch): claimedBy on claim + owner self-recovery on unclaim + idempotent retries (Wave B · B1-server)

### DIFF
--- a/services/mcp-server/src/__tests__/claims-limbo.test.ts
+++ b/services/mcp-server/src/__tests__/claims-limbo.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Claims Limbo-Trap Tests — Wave B item B1-server
+ *
+ * The active-unclaimed limbo trap (vector-grid-improvement-review-2026-06-09):
+ * claim_task never wrote claimedBy, so unclaim authz (sessionId vs programId)
+ * locked owners out of self-recovery and sweepers had no owner field to key
+ * on; claim idempotency broke on null/undefined sessionId mismatch.
+ *
+ * Verifies:
+ *   1. claim writes claimedBy + claimedAt
+ *   2. claim retry without sessionId is idempotent (null/undefined normalized)
+ *   3. claim retry by the claiming program is idempotent (claimedBy match)
+ *   4. unclaim authorized for the claiming OWNER via claimedBy
+ *   5. unclaim reverts to created, clears claimedBy/claimedAt, bumps unclaimCount
+ *   6. unclaim still denied for unrelated programs
+ */
+
+// Mock external dependencies before imports
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+const mockTx = {
+  get: jest.fn(),
+  update: jest.fn(),
+};
+const mockDb = {
+  doc: jest.fn(() => ({ path: "tenants/u1/tasks/t1" })),
+  runTransaction: jest.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+  collection: jest.fn(() => ({ add: jest.fn(() => Promise.resolve()) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-server-timestamp"),
+}));
+
+jest.mock("../modules/events.js", () => ({
+  emitEvent: jest.fn(),
+}));
+
+jest.mock("../modules/analytics.js", () => ({
+  emitAnalyticsEvent: jest.fn(),
+}));
+
+jest.mock("../modules/github-sync.js", () => ({
+  syncTaskClaimed: jest.fn(),
+}));
+
+// Import AFTER mocks
+import { claimTaskHandler, unclaimTaskHandler } from "../modules/dispatch/claims.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+const AUTH = { userId: "u1", programId: "basher", encryptionKey: null } as unknown as AuthContext;
+const ISO_AUTH = { userId: "u1", programId: "iso", encryptionKey: null } as unknown as AuthContext;
+const OTHER_AUTH = { userId: "u1", programId: "quorra", encryptionKey: null } as unknown as AuthContext;
+
+function taskDoc(data: Record<string, unknown>) {
+  mockTx.get.mockResolvedValue({ exists: true, data: () => data });
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("B1-server: claim writes owner identity", () => {
+  it("claim writes claimedBy=programId and claimedAt", async () => {
+    taskDoc({ status: "created", title: "t", type: "task", priority: "normal", action: "queue" });
+
+    const res = parse((await claimTaskHandler(AUTH, { taskId: "t1", sessionId: "basher" })) as never);
+
+    expect(res.success).toBe(true);
+    expect(mockTx.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: "active", claimedBy: "basher", claimedAt: expect.anything() }),
+    );
+  });
+
+  it("claim retry WITHOUT sessionId is idempotent (null/undefined normalized)", async () => {
+    // First claim wrote sessionId: null (claim_task with no sessionId). The
+    // retry used to compare null === undefined → contention → stranded task.
+    taskDoc({ status: "active", sessionId: null, claimedBy: "basher", title: "t" });
+
+    const res = parse((await claimTaskHandler(AUTH, { taskId: "t1" })) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.alreadyClaimed).toBe(true);
+  });
+
+  it("claim retry by the claiming program is idempotent via claimedBy", async () => {
+    taskDoc({ status: "active", sessionId: "basher.task-9", claimedBy: "basher", title: "t" });
+
+    const res = parse((await claimTaskHandler(AUTH, { taskId: "t1", sessionId: "different-session" })) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.alreadyClaimed).toBe(true);
+  });
+
+  it("claim by another program on an active task is contention", async () => {
+    taskDoc({ status: "active", sessionId: "basher.task-9", claimedBy: "basher", title: "t" });
+
+    const res = parse((await claimTaskHandler(OTHER_AUTH, { taskId: "t1", sessionId: "quorra" })) as never);
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not claimable/);
+  });
+});
+
+describe("B1-server: unclaim self-recovery + cleanup", () => {
+  it("claiming OWNER can unclaim via claimedBy even when sessionId never matches programId", async () => {
+    taskDoc({ status: "active", sessionId: "basher.task-9", claimedBy: "basher", unclaimCount: 0 });
+
+    const res = parse((await unclaimTaskHandler(AUTH, { taskId: "t1", reason: "manual" })) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.unclaimCount).toBe(1);
+    expect(mockTx.update).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: "created",
+        sessionId: null,
+        claimedBy: null,
+        claimedAt: null,
+        unclaimCount: 1,
+      }),
+    );
+  });
+
+  it("unrelated program cannot unclaim", async () => {
+    taskDoc({ status: "active", sessionId: "basher.task-9", claimedBy: "basher", unclaimCount: 0 });
+
+    const res = parse((await unclaimTaskHandler(OTHER_AUTH, { taskId: "t1" })) as never);
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Unauthorized/);
+  });
+
+  it("iso can always unclaim; circuit breaker flags at 3", async () => {
+    taskDoc({ status: "active", sessionId: null, claimedBy: null, unclaimCount: 2 });
+
+    const res = parse((await unclaimTaskHandler(ISO_AUTH, { taskId: "t1", reason: "stale_recovery" })) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.unclaimCount).toBe(3);
+    expect(res.flagged).toBe(true);
+  });
+});

--- a/services/mcp-server/src/modules/dispatch/claims.ts
+++ b/services/mcp-server/src/modules/dispatch/claims.ts
@@ -70,8 +70,12 @@ export async function claimTaskHandler(auth: AuthContext, rawArgs: unknown): Pro
 
       const data = doc.data()!;
 
-      // Idempotent: already claimed by this session
-      if (data.status === "active" && data.sessionId === args.sessionId) {
+      // Idempotent: already claimed by this session (normalize null/undefined —
+      // a claim without sessionId wrote null, and a retry's undefined !== null
+      // read as contention, stranding the claimer) or by this program.
+      const sameSession = (data.sessionId ?? null) === (args.sessionId ?? null);
+      const sameProgram = data.claimedBy != null && data.claimedBy === auth.programId;
+      if (data.status === "active" && (sameSession || sameProgram)) {
         return { alreadyClaimed: true, data };
       }
 
@@ -90,6 +94,11 @@ export async function claimTaskHandler(auth: AuthContext, rawArgs: unknown): Pro
         status: "active",
         startedAt: admin.firestore.FieldValue.serverTimestamp(),
         sessionId: args.sessionId || null,
+        // Owner identity — sessionId is free-form ("iso.task-x"), so authz and
+        // sweepers key on claimedBy. Never written before this fix: every
+        // normally-claimed task read back claimedBy: null.
+        claimedBy: auth.programId,
+        claimedAt: admin.firestore.FieldValue.serverTimestamp(),
         lastHeartbeat: admin.firestore.FieldValue.serverTimestamp(),
         attempt_count: admin.firestore.FieldValue.increment(1),
         stateTransitions: updatedTransitions,
@@ -171,13 +180,17 @@ export async function unclaimTaskHandler(auth: AuthContext, rawArgs: unknown): P
         return { error: `Task not unclaimable (status: ${data.status}). Only active tasks can be unclaimed.` };
       }
 
-      // Authorization: callable by the claiming session, any program with 'iso' identity, or admin/legacy key
+      // Authorization: the claiming OWNER (claimedBy — written on claim),
+      // the claiming session (legacy back-compat: sessionId values like
+      // "iso.task-x" almost never equal a programId, which locked owners out
+      // of self-recovery), any program with 'iso' identity, or admin key.
       const claimingSession = data.sessionId as string | undefined;
       const isClaimingSession = claimingSession && claimingSession === auth.programId;
+      const isClaimingOwner = data.claimedBy != null && data.claimedBy === auth.programId;
       const isIso = auth.programId === "iso" || auth.programId === "orchestrator";
       const isAdmin = auth.programId === "legacy" || auth.programId === "dispatcher";
-      if (!isClaimingSession && !isIso && !isAdmin) {
-        return { error: `Unauthorized: only the claiming session, ISO, or admin can unclaim this task.` };
+      if (!isClaimingOwner && !isClaimingSession && !isIso && !isAdmin) {
+        return { error: `Unauthorized: only the claiming owner, ISO, or admin can unclaim this task.` };
       }
 
       // Validate lifecycle transition: active -> created
@@ -194,6 +207,8 @@ export async function unclaimTaskHandler(auth: AuthContext, rawArgs: unknown): P
       const updateFields: Record<string, unknown> = {
         status: "created",
         sessionId: null,
+        claimedBy: null,
+        claimedAt: null,
         startedAt: null,
         lastHeartbeat: null,
         unclaimCount: newUnclaimCount,
@@ -272,8 +287,11 @@ export async function batchClaimTasksHandler(auth: AuthContext, rawArgs: unknown
 
         const data = doc.data()!;
 
-        // Idempotent: already claimed by this session
-        if (data.status === "active" && data.sessionId === args.sessionId) {
+        // Idempotent: already claimed by this session (null/undefined
+        // normalized) or by this program — same rule as single claim
+        const sameSession = (data.sessionId ?? null) === (args.sessionId ?? null);
+        const sameProgram = data.claimedBy != null && data.claimedBy === auth.programId;
+        if (data.status === "active" && (sameSession || sameProgram)) {
           return { alreadyClaimed: true, data };
         }
 
@@ -291,6 +309,8 @@ export async function batchClaimTasksHandler(auth: AuthContext, rawArgs: unknown
           status: "active",
           startedAt: admin.firestore.FieldValue.serverTimestamp(),
           sessionId: args.sessionId || null,
+          claimedBy: auth.programId,
+          claimedAt: admin.firestore.FieldValue.serverTimestamp(),
           lastHeartbeat: admin.firestore.FieldValue.serverTimestamp(),
           attempt_count: admin.firestore.FieldValue.increment(1),
           stateTransitions: updatedTransitions,


### PR DESCRIPTION
## Wave B item B1-server — the active-unclaimed limbo trap

Evidence: `grid/decisions/vector-grid-improvement-review-2026-06-09.md` (contested P1, **confirmed live** during the A1 proof — abort → `created→done invalid`, claim → `status: active`, complete → `created→done` again, no self-recovery path).

### Scope note vs the dispatch brief
`unclaim_task` at HEAD **already** reverts status→`created` and persists `unclaimCount` (post-#315); reassign/escalate revert correctly too — brief items (a)/(b) describe pre-#315 behavior. The REAL gaps were owner identity and idempotency:

### Changes (`services/mcp-server/src/modules/dispatch/claims.ts`)
1. **claim + batch_claim write `claimedBy: auth.programId` + `claimedAt`** — never written by any claim path before, so every normally-claimed task read back `claimedBy: null`: sweepers had no owner field, unclaim authz had nothing to match. This is the keying field for B1-dispatcher's limbo sweeper.
2. **unclaim authz accepts the claiming OWNER** via `claimedBy === programId` (sessionId match kept for back-compat — sessionIds like `iso.task-x` almost never equal a programId, which locked owners out of self-recovery).
3. **claim idempotency**: null/undefined sessionId normalized (a claim without sessionId wrote `null`; a retry's `undefined !== null` read as contention — the exact stranding observed live), plus same-program retry accepted via `claimedBy`.
4. **unclaim clears `claimedBy`/`claimedAt`** alongside sessionId.

### Executed proof
- `claims-limbo.test.ts` — 7 cases: claimedBy written; no-sessionId retry idempotent; same-program retry idempotent; cross-program contention preserved; owner unclaim via claimedBy; unrelated program denied; iso override + circuit-breaker flag at 3. **7/7 green**, full suite 543 green.
- **Live proof post-deploy** (this is the API change the live limbo task needs): claim → verify `claimedBy` in doc → unclaim as owner → task returns to `created` → re-claim normally. Will be executed against prod and pasted here after deploy (deploy coordinated with iso — A1 deploy was in flight).

**SARK gate**: API behavior change (claim/unclaim authz + idempotency semantics). Batched gate request with B3 + B1-dispatcher, cc iso. Thread `grid-fleet-restore`, task LiRO0f0wM3gmH3A2CHLn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)