### PR TITLE
fix(pulse): derive fleet/session state from heartbeat age at read (Wave B · B3)

### DIFF
--- a/services/mcp-server/src/__tests__/pulse-state-expiry.test.ts
+++ b/services/mcp-server/src/__tests__/pulse-state-expiry.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Pulse State Expiry Tests — Wave B item B3
+ *
+ * Fleet state was sticky forever: list_sessions returned whatever a session
+ * last self-declared ("working" observed at 364414s stale) and fleet-health
+ * let programs with NO heartbeat at all keep their self-declared state.
+ *
+ * Verifies state is derived from heartbeat/lastUpdate age at read time:
+ *   1. list_sessions: active session with old lastUpdate → effectiveState "stale"
+ *   2. list_sessions: fresh active session → effectiveState "active"
+ *   3. list_sessions: completed session never reads stale
+ *   4. fleet-health: program with NO lastHeartbeat → "stale", lastReportedState kept
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+type Doc = { id: string; data: () => Record<string, unknown> };
+let sessionDocs: Doc[] = [];
+let programDocs: Doc[] = [];
+
+function chainable(docs: () => Doc[]) {
+  const q: Record<string, unknown> = {};
+  q.where = jest.fn(() => q);
+  q.orderBy = jest.fn(() => q);
+  q.limit = jest.fn(() => q);
+  q.get = jest.fn(async () => ({ docs: docs(), size: docs().length }));
+  return q;
+}
+
+const mockDb = {
+  collection: jest.fn((path: string) => {
+    if (path.includes("/sessions/_meta/programs")) return chainable(() => programDocs);
+    if (path.endsWith("/sessions")) return chainable(() => sessionDocs);
+    return chainable(() => []);
+  }),
+  doc: jest.fn(() => ({ get: jest.fn(async () => ({ exists: false })) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-server-timestamp"),
+}));
+
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn() }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+
+import { listSessionsHandler, getFleetHealthHandler } from "../modules/pulse.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+const AUTH = { userId: "u1", programId: "basher", capabilities: ["*"] } as unknown as AuthContext;
+
+const ts = (ageSeconds: number) => {
+  const d = new Date(Date.now() - ageSeconds * 1000);
+  return { toDate: () => d };
+};
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  sessionDocs = [];
+  programDocs = [];
+});
+
+describe("B3: list_sessions effective state", () => {
+  it("active session with 4-day-old lastUpdate reads stale, raw state preserved", async () => {
+    sessionDocs = [
+      { id: "vector", data: () => ({ programId: "vector", status: "active", lastUpdate: ts(364414), archived: false }) },
+    ];
+    const res = parse((await listSessionsHandler(AUTH, {})) as never);
+    expect(res.success).toBe(true);
+    expect(res.sessions[0].state).toBe("active");
+    expect(res.sessions[0].effectiveState).toBe("stale");
+    expect(res.sessions[0].lastUpdateAgeSeconds).toBeGreaterThan(364000);
+  });
+
+  it("fresh active session reads active", async () => {
+    sessionDocs = [
+      { id: "basher", data: () => ({ programId: "basher", status: "active", lastUpdate: ts(60), archived: false }) },
+    ];
+    const res = parse((await listSessionsHandler(AUTH, {})) as never);
+    expect(res.sessions[0].effectiveState).toBe("active");
+  });
+
+  it("completed session never reads stale regardless of age", async () => {
+    sessionDocs = [
+      { id: "old", data: () => ({ programId: "old", status: "done", lastUpdate: ts(900000), archived: false }) },
+    ];
+    const res = parse((await listSessionsHandler(AUTH, {})) as never);
+    expect(res.sessions[0].effectiveState).toBe("done");
+  });
+
+  it("active session with NO lastUpdate reads stale (no data is not liveness)", async () => {
+    sessionDocs = [
+      { id: "ghost", data: () => ({ programId: "ghost", status: "active", archived: false }) },
+    ];
+    const res = parse((await listSessionsHandler(AUTH, {})) as never);
+    expect(res.sessions[0].effectiveState).toBe("stale");
+    expect(res.sessions[0].lastUpdateAgeSeconds).toBeNull();
+  });
+});
+
+describe("B3: fleet-health program state", () => {
+  it("program with NO heartbeat reads stale with lastReportedState preserved", async () => {
+    programDocs = [
+      { id: "vector", data: () => ({ currentState: "working" }) },
+    ];
+    const res = parse((await getFleetHealthHandler(AUTH, {})) as never);
+    const prog = res.programs.find((p: { programId: string }) => p.programId === "vector");
+    expect(prog.state).toBe("stale");
+    expect(prog.lastReportedState).toBe("working");
+    expect(res.summary.stale).toBe(1);
+    expect(res.summary.working).toBe(0);
+  });
+
+  it("program with fresh heartbeat keeps its reported state", async () => {
+    programDocs = [
+      { id: "basher", data: () => ({ currentState: "working", lastHeartbeat: ts(120) }) },
+    ];
+    const res = parse((await getFleetHealthHandler(AUTH, {})) as never);
+    const prog = res.programs.find((p: { programId: string }) => p.programId === "basher");
+    expect(prog.state).toBe("working");
+    expect(prog.heartbeatAgeSeconds).toBeGreaterThanOrEqual(115);
+  });
+});

--- a/services/mcp-server/src/modules/pulse.ts
+++ b/services/mcp-server/src/modules/pulse.ts
@@ -363,9 +363,13 @@ export async function getFleetHealthHandler(auth: AuthContext, rawArgs: unknown)
     const data = doc.data();
     const heartbeatTime = data.lastHeartbeat?.toDate?.() ? data.lastHeartbeat.toDate().getTime() : 0;
     const heartbeatAgeMinutes = heartbeatTime ? Math.round((now - heartbeatTime) / 60000) : null;
-    const isStale = heartbeatAgeMinutes !== null && heartbeatAgeMinutes > 10;
+    // State is self-declared and sticky; only a fresh heartbeat earns it.
+    // No heartbeat at all is NOT alive — it's unknown, bucketed with stale
+    // (a program that never wrote lastHeartbeat must not read as "working").
+    const isStale = heartbeatAgeMinutes === null || heartbeatAgeMinutes > 10;
 
-    const state = isStale ? "stale" : (data.currentState || "idle");
+    const lastReportedState = data.currentState || "idle";
+    const state = isStale ? "stale" : lastReportedState;
     if (isStale) summary.stale++;
     else if (state === "working") summary.working++;
     else if (state === "blocked") summary.blocked++;
@@ -374,9 +378,13 @@ export async function getFleetHealthHandler(auth: AuthContext, rawArgs: unknown)
     return {
       programId: doc.id,
       state,
+      // Preserved so "stale" stays diagnosable: stale (last self-reported:
+      // working, N min ago) — per the fleet-review recommendation.
+      lastReportedState,
       sessionId: data.currentSessionId || null,
       lastHeartbeat: data.lastHeartbeat?.toDate?.()?.toISOString() || null,
       heartbeatAgeMinutes,
+      heartbeatAgeSeconds: heartbeatTime ? Math.round((now - heartbeatTime) / 1000) : null,
       pendingMessages: pendingMsgsByTarget.get(doc.id) || 0,
       pendingTasks: pendingTasksByTarget.get(doc.id) || 0,
       contextBytes: data.contextBytes || null,
@@ -566,14 +574,25 @@ export async function listSessionsHandler(auth: AuthContext, rawArgs: unknown): 
   query = query.orderBy("lastUpdate", "desc").limit(args.limit);
   const snapshot = await query.get();
 
+  // Session state is whatever the program last self-declared — sticky
+  // forever ("working" observed at 364414s stale). Derive an effective
+  // state from lastUpdate age at read time; raw state is preserved.
+  const STALE_AFTER_SECONDS = 30 * 60;
+  const nowMs = Date.now();
   const sessions = snapshot.docs.map((doc) => {
     const data = doc.data();
+    const lastUpdateMs = data.lastUpdate?.toDate?.()?.getTime() ?? null;
+    const lastUpdateAgeSeconds = lastUpdateMs !== null ? Math.round((nowMs - lastUpdateMs) / 1000) : null;
+    const isLive = data.status === "active" || data.status === "blocked";
+    const isStale = isLive && (lastUpdateAgeSeconds === null || lastUpdateAgeSeconds > STALE_AFTER_SECONDS);
     return {
       sessionId: doc.id,
       name: data.name,
       programId: data.programId,
       status: data.currentAction || data.name,
-      state: data.status, // lifecycle status
+      state: data.status, // lifecycle status, as last self-reported
+      effectiveState: isStale ? "stale" : data.status,
+      lastUpdateAgeSeconds,
       progress: data.progress,
       projectName: data.projectName,
       lastUpdate: data.lastUpdate?.toDate?.()?.toISOString() || null,


### PR DESCRIPTION
## Wave B item B3 — sticky pulse state never expires (P1 · confidence 0.9)

Evidence: `grid/decisions/vector-grid-improvement-review-2026-06-09.md` §Pulse — "working" observed at 364414s stale; heartbeatScore a uniform no-data 50. Read-side fix per the review recommendation (writers untouched; B2 heartbeat writer is a separate item):

### Changes (`services/mcp-server/src/modules/pulse.ts`)
- **list_sessions**: adds `effectiveState` + `lastUpdateAgeSeconds`. An active/blocked session whose `lastUpdate` is >30min old — or absent — reads `stale`; the raw self-reported `state` is preserved; terminal states never read stale.
- **fleet-health**: a program with **no `lastHeartbeat` at all** now buckets as `stale` (previously kept its self-declared "working" forever — no data is not liveness). Adds `lastReportedState` + `heartbeatAgeSeconds` so consumers can render *"stale (last self-reported: working, 4.2d ago)"*.

### Executed proof — `pulse-state-expiry.test.ts`, 6/6 green (full suite green)
```
B3: list_sessions effective state
  ✓ active session with 4-day-old lastUpdate reads stale, raw state preserved   (the literal 364414s repro)
  ✓ fresh active session reads active
  ✓ completed session never reads stale regardless of age
  ✓ active session with NO lastUpdate reads stale (no data is not liveness)
B3: fleet-health program state
  ✓ program with NO heartbeat reads stale with lastReportedState preserved
  ✓ program with fresh heartbeat keeps its reported state
```
Post-deploy live check: `pulse_list_sessions` must show vector-class sessions as `effectiveState: stale` instead of `working` — will paste output after deploy.

**SARK quick check**: read-path semantics change (no auth surface). Batched with B1, cc iso. Thread `grid-fleet-restore`, task LiRO0f0wM3gmH3A2CHLn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)