### PR TITLE
feat(relay): ADR-013 participant-scoped durable relay reads

### DIFF
--- a/infra/firestore.indexes.json
+++ b/infra/firestore.indexes.json
@@ -514,6 +514,24 @@
       ]
     },
     {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "source", "order": "ASCENDING" },
+        { "fieldPath": "threadId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "relay",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "target", "order": "ASCENDING" },
+        { "fieldPath": "threadId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "ledger",
       "queryScope": "COLLECTION",
       "fields": [

--- a/services/mcp-server/src/__tests__/capabilities.test.ts
+++ b/services/mcp-server/src/__tests__/capabilities.test.ts
@@ -55,6 +55,12 @@ describe('Capability System', () => {
   });
 
   describe('TOOL_CAPABILITIES coverage', () => {
+    it('ADR-013: relay read tools stay mapped to relay.read (no new capability)', () => {
+      expect(TOOL_CAPABILITIES['relay_query_message_history']).toBe('relay.read');
+      expect(TOOL_CAPABILITIES['relay_get_messages']).toBe('relay.read');
+      expect(TOOL_CAPABILITIES['relay_get_sent_messages']).toBe('relay.read');
+    });
+
     it('every tool in the map has a valid capability', () => {
       const validPrefixes = [
         'dispatch', 'relay', 'pulse', 'signal', 'dream',

--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -10,7 +10,7 @@
  */
 
 import * as admin from "firebase-admin";
-import { getTestFirestore, clearFirestoreData, seedTestUser } from "./setup";
+import { getTestFirestore, clearFirestoreData, seedTestUser, seedTestData } from "./setup";
 
 describe("Relay Delivery Integration", () => {
   let db: admin.firestore.Firestore;
@@ -343,6 +343,275 @@ describe("Relay Delivery Integration", () => {
       );
 
       expect(uniqueKeys.size).toBe(messages.length);
+    });
+  });
+});
+
+/**
+ * ADR-013: participant-scoped durable relay reads.
+ *
+ * SARK GO-WITH-CONTROLS (grid#716): C1 source/target coercion LOCK,
+ * C2 single enforcement point for MCP + REST, C3 threadId-only LOCK,
+ * C4 read-audit ledger detail. Tests call the real handlers against the
+ * Firestore emulator; the REST test runs the real router over HTTP.
+ */
+
+// github-sync (pulled in via transport/rest -> tools) imports ESM-only
+// @octokit/rest, which ts-jest does not transform — mock it out.
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+import * as http from "http";
+import * as crypto from "crypto";
+import { initializeFirebase } from "../../firebase/client";
+import {
+  getMessagesHandler,
+  getSentMessagesHandler,
+  queryMessageHistoryHandler,
+} from "../../modules/relay";
+import { createRestRouter } from "../../transport/rest";
+import type { AuthContext } from "../../auth/authValidator";
+
+function makeAuth(userId: string, programId: string): AuthContext {
+  return {
+    userId,
+    programId,
+    capabilities: ["relay.read", "relay.write"],
+    rateLimitTier: "free",
+    apiKeyHash: `test-hash-${programId}`,
+    encryptionKey: Buffer.alloc(32),
+  } as unknown as AuthContext;
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+function ts(isoDate: string) {
+  return admin.firestore.Timestamp.fromDate(new Date(isoDate));
+}
+
+describe("ADR-013 Participant-Scoped Durable Relay Reads", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+    initializeFirebase(); // point module-level handlers at the emulator
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    const testUser = await seedTestUser("test-user-adr013");
+    userId = testUser.userId;
+
+    // Conversation thread t-adr: scalar<->iso, plus a third party (basher)
+    // sharing the same thread, plus a broadcast.
+    await seedTestData(userId, "relay", [
+      { id: "m1", data: { source: "iso", target: "scalar", payload: "body-iso-to-scalar", message_type: "DIRECTIVE", status: "delivered", threadId: "t-adr", priority: "normal", action: "queue", createdAt: ts("2026-06-09T10:00:00Z") } },
+      { id: "m2", data: { source: "scalar", target: "iso", payload: "body-scalar-to-iso", message_type: "ACK", status: "delivered", threadId: "t-adr", priority: "normal", action: "queue", createdAt: ts("2026-06-09T10:01:00Z") } },
+      { id: "m3", data: { source: "iso", target: "basher", payload: "body-iso-to-basher", message_type: "DIRECTIVE", status: "delivered", threadId: "t-adr", priority: "normal", action: "queue", createdAt: ts("2026-06-09T10:02:00Z") } },
+      { id: "m4", data: { source: "iso", target: "all", payload: "broadcast-body", message_type: "STATUS", status: "pending", threadId: "t-adr", priority: "normal", action: "queue", createdAt: ts("2026-06-09T10:03:00Z") } },
+      { id: "m5", data: { source: "iso", target: "basher", payload: "body-other-thread", message_type: "QUERY", status: "pending", threadId: "t-other", priority: "normal", action: "queue", createdAt: ts("2026-06-09T10:04:00Z") } },
+    ]);
+  });
+
+  describe("query_message_history — participant scoping (Option A)", () => {
+    it("non-admin reads own received history with bodies", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { target: "scalar" }) as never);
+
+      expect(res.success).toBe(true);
+      expect(res.messages.map((m: any) => m.id)).toEqual(["m1"]);
+      expect(res.messages[0].message).toBe("body-iso-to-scalar");
+      expect(res.messages[0].status).toBe("delivered");
+    });
+
+    it("LOCK C1: non-admin source arg naming another program is rejected", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { source: "basher" }) as never);
+
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/participant scope/i);
+      expect(res.messages).toBeUndefined();
+    });
+
+    it("LOCK C1: non-admin target arg naming another program is rejected", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { target: "basher" }) as never);
+
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/participant scope/i);
+    });
+
+    it("LOCK C1: non-admin cannot read a counterparty's outbox even via source=iso", async () => {
+      // m3 (iso->basher) shares source iso with m1 (iso->scalar); a scalar key
+      // naming source=iso would read basher's inbound traffic.
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { source: "iso" }) as never);
+
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/participant scope/i);
+    });
+
+    it("LOCK C3: threadId-only non-admin query stays participant-constrained", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { threadId: "t-adr" }) as never);
+
+      expect(res.success).toBe(true);
+      // Both directions + broadcast, ascending; m3 (iso->basher) must NOT leak
+      expect(res.messages.map((m: any) => m.id)).toEqual(["m1", "m2", "m4"]);
+      expect(res.sort).toBe("asc");
+    });
+
+    it("non-admin target='all' broadcast read is allowed", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { target: "all" }) as never);
+
+      expect(res.success).toBe(true);
+      expect(res.messages.map((m: any) => m.id)).toEqual(["m4"]);
+    });
+
+    it("admin paths unchanged: unrestricted third-party query", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "orchestrator"), { source: "iso" }) as never);
+
+      expect(res.success).toBe(true);
+      expect(res.messages.map((m: any) => m.id).sort()).toEqual(["m1", "m3", "m4", "m5"]);
+    });
+
+    it("admin threadId query returns every party's messages", async () => {
+      const res = parse(await queryMessageHistoryHandler(makeAuth(userId, "orchestrator"), { threadId: "t-adr" }) as never);
+
+      expect(res.success).toBe(true);
+      expect(res.messages.map((m: any) => m.id)).toEqual(["m1", "m2", "m3", "m4"]);
+    });
+
+    it("C4: history read ledgers effective filters, count, and message IDs", async () => {
+      await queryMessageHistoryHandler(makeAuth(userId, "scalar"), { threadId: "t-adr" });
+
+      // logAudit persists fire-and-forget — poll the ledger briefly
+      let entry: any = null;
+      for (let i = 0; i < 20 && !entry; i++) {
+        // filter by programId too: fire-and-forget audit writes from prior
+        // tests can land after clearFirestoreData
+        const snap = await db.collection(`tenants/${userId}/ledger`)
+          .where("tool", "==", "relay_query_message_history.read")
+          .where("programId", "==", "scalar").get();
+        if (!snap.empty) entry = snap.docs[0].data();
+        else await new Promise((r) => setTimeout(r, 100));
+      }
+
+      expect(entry).not.toBeNull();
+      expect(entry.programId).toBe("scalar");
+      expect(entry.details.effectiveFilters.threadId).toBe("t-adr");
+      expect(entry.details.effectiveFilters.participantScope).toBe("scalar");
+      expect(entry.details.resultCount).toBe(3);
+      expect(entry.details.messageIds.sort()).toEqual(["m1", "m2", "m4"]);
+    });
+  });
+
+  describe("get_messages — includeDelivered (Option C)", () => {
+    it("delivered re-read returns bodies and does NOT re-claim", async () => {
+      const auth = makeAuth(userId, "scalar");
+
+      // First poll claims the pending broadcast + nothing else for scalar
+      const first = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true }) as never);
+      expect(first.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
+
+      const afterClaim = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
+      expect(afterClaim.status).toBe("delivered");
+      expect(afterClaim.deliveryAttempts).toBe(1);
+
+      // Default re-poll: empty inbox (pending window closed) — unchanged behavior
+      const second = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true }) as never);
+      expect(second.interrupts).toEqual([]);
+
+      // includeDelivered re-opens the body read without re-claiming
+      const reread = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true, includeDelivered: true }) as never);
+      expect(reread.interrupts.map((m: any) => m.id).sort()).toEqual(["m1", "m4"]);
+      const m4 = reread.interrupts.find((m: any) => m.id === "m4");
+      expect(m4.message).toBe("broadcast-body");
+
+      const afterReread = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
+      expect(afterReread.deliveryAttempts).toBe(1); // no re-claim
+    });
+
+    it("includeDelivered read-only poll returns pending + delivered bodies, own target only", async () => {
+      const res = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar", includeDelivered: true }) as never);
+
+      // m1 (delivered, target scalar) + m4 (pending broadcast); never m3/m5 (basher's)
+      expect(res.interrupts.map((m: any) => m.id).sort()).toEqual(["m1", "m4"]);
+      const m1 = res.interrupts.find((m: any) => m.id === "m1");
+      expect(m1.message).toBe("body-iso-to-scalar");
+      expect(m1.status).toBe("delivered");
+    });
+
+    it("default behavior unchanged: pending only", async () => {
+      const res = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar" }) as never);
+      expect(res.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
+    });
+  });
+
+  describe("get_sent_messages — body inclusion", () => {
+    it("sender re-reads own bodies", async () => {
+      const res = parse(await getSentMessagesHandler(makeAuth(userId, "scalar"), {}) as never);
+
+      expect(res.success).toBe(true);
+      expect(res.messages.length).toBe(1);
+      expect(res.messages[0].id).toBe("m2");
+      expect(res.messages[0].message).toBe("body-scalar-to-iso");
+    });
+
+    it("non-admin source arg is still forced to self", async () => {
+      const res = parse(await getSentMessagesHandler(makeAuth(userId, "scalar"), { source: "iso" }) as never);
+
+      expect(res.source).toBe("scalar");
+      expect(res.messages.map((m: any) => m.id)).toEqual(["m2"]);
+    });
+  });
+
+  describe("REST transport — single enforcement point (C2)", () => {
+    let server: http.Server;
+    let baseUrl: string;
+    let apiKey: string;
+
+    beforeEach(async () => {
+      // Seed a NON-admin participant key (programId scalar — in neither
+      // ADMIN_PROGRAMS nor ADMIN_READERS, no wildcard capability)
+      apiKey = `cb_test_${crypto.randomBytes(8).toString("hex")}`;
+      const keyHash = crypto.createHash("sha256").update(apiKey).digest("hex");
+      await db.doc(`keyIndex/${keyHash}`).set({
+        userId,
+        programId: "scalar",
+        capabilities: ["relay.read", "relay.write"],
+        active: true,
+      });
+
+      server = http.createServer(createRestRouter());
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+    });
+
+    afterEach(async () => {
+      await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+    });
+
+    it("GET /v1/messages/history with non-admin participant key returns own messages (no 403)", async () => {
+      const res = await fetch(`${baseUrl}/v1/messages/history?threadId=t-adr`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+
+      expect(res.status).not.toBe(403);
+      expect(res.status).toBe(200);
+      const body = await res.json() as any;
+      const data = body.data ?? body;
+      expect(data.success).toBe(true);
+      expect(data.messages.map((m: any) => m.id)).toEqual(["m1", "m2", "m4"]);
+    });
+
+    it("GET /v1/messages/history third-party read rejected for non-admin key", async () => {
+      const res = await fetch(`${baseUrl}/v1/messages/history?source=basher`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+
+      const body = await res.json() as any;
+      const data = body.data ?? body;
+      expect(data.success).toBe(false);
+      expect(String(data.error)).toMatch(/participant scope/i);
     });
   });
 });

--- a/services/mcp-server/src/middleware/gate.ts
+++ b/services/mcp-server/src/middleware/gate.ts
@@ -24,6 +24,8 @@ export interface AuditEntry {
   allowed: boolean;
   reason?: string;
   durationMs?: number;
+  /** Structured read-audit detail (e.g. ADR-013 history reads: effective filters, result count, message IDs) */
+  details?: Record<string, unknown>;
 }
 
 /**

--- a/services/mcp-server/src/modules/feedback.ts
+++ b/services/mcp-server/src/modules/feedback.ts
@@ -7,7 +7,7 @@ import { getFirestore, serverTimestamp } from "../firebase/client.js";
 import * as admin from "firebase-admin";
 import { AuthContext } from "../auth/authValidator.js";
 import { z } from "zod";
-// @ts-expect-error — @octokit/rest v22 is ESM-only; Node 20.19+ handles require() of ESM at runtime
+// @ts-ignore — @octokit/rest v22 is ESM-only; TS1479 in Node 18 CI, resolves fine in Node 24+ (and ts-jest, where @ts-expect-error is unused)
 import { Octokit } from "@octokit/rest";
 import * as crypto from "crypto";
 

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -4,7 +4,7 @@
  */
 
 import { getFirestore, serverTimestamp } from "../firebase/client.js";
-import { verifySource, isAdmin } from "../middleware/gate.js";
+import { verifySource, isAdmin, logAudit, generateCorrelationId } from "../middleware/gate.js";
 import * as admin from "firebase-admin";
 import { AuthContext } from "../auth/authValidator.js";
 import { RELAY_DEFAULT_TTL_SECONDS } from "../types/relay.js";
@@ -46,6 +46,7 @@ const GetMessagesSchema = z.object({
   sessionId: z.string(),
   target: z.string().max(100).optional(),
   markAsRead: z.boolean().default(false),
+  includeDelivered: z.boolean().default(false),
   message_type: z.enum(["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"]).optional(),
   priority: z.enum(["low", "normal", "high"]).optional(),
 });
@@ -346,9 +347,13 @@ export async function getMessagesHandler(auth: AuthContext, rawArgs: unknown): P
   const args = GetMessagesSchema.parse(rawArgs);
   const db = getFirestore();
 
-  let query: admin.firestore.Query = db
-    .collection(`tenants/${auth.userId}/relay`)
-    .where("status", "==", "pending");
+  // ADR-013: includeDelivered re-opens the body-read window after a claim.
+  // Target enforcement below scopes it; the claim transaction skips
+  // non-pending docs, so delivered re-reads can never re-claim.
+  let query: admin.firestore.Query = db.collection(`tenants/${auth.userId}/relay`);
+  query = args.includeDelivered
+    ? query.where("status", "in", ["pending", "delivered"])
+    : query.where("status", "==", "pending");
 
   if (args.message_type) {
     query = query.where("message_type", "==", args.message_type);
@@ -390,6 +395,7 @@ export async function getMessagesHandler(auth: AuthContext, rawArgs: unknown): P
         message: data.payload,
         source: data.source,
         message_type: data.message_type,
+        status: data.status,
         action: data.action,
         priority: data.priority,
         context: data.context || null,
@@ -422,20 +428,27 @@ export async function getMessagesHandler(auth: AuthContext, rawArgs: unknown): P
       })));
 
       for (const { ref, id, fresh } of freshDocs) {
-        if (!fresh.exists || fresh.data()!.status !== "pending") continue;
+        if (!fresh.exists) continue;
         const data = fresh.data()!;
 
-        tx.update(ref, {
-          status: "delivered",
-          deliveredAt: admin.firestore.FieldValue.serverTimestamp(),
-          deliveryAttempts: admin.firestore.FieldValue.increment(1),
-        });
+        if (data.status === "pending") {
+          tx.update(ref, {
+            status: "delivered",
+            deliveredAt: admin.firestore.FieldValue.serverTimestamp(),
+            deliveryAttempts: admin.firestore.FieldValue.increment(1),
+          });
+        } else if (!(args.includeDelivered && data.status === "delivered")) {
+          // Only pending docs are claimable; delivered docs are returned
+          // read-only when includeDelivered is set, all others skipped.
+          continue;
+        }
 
         claimed.push({
           id,
           message: data.payload,
           source: data.source,
           message_type: data.message_type,
+          status: data.status === "pending" ? "delivered" : data.status,
           action: data.action,
           priority: data.priority,
           context: data.context || null,
@@ -508,6 +521,8 @@ export async function getSentMessagesHandler(auth: AuthContext, rawArgs: unknown
       id: doc.id,
       target: data.target,
       message_type: data.message_type,
+      // ADR-013: a sender re-reading their own body is zero new exposure
+      message: data.payload,
       status: data.status,
       deliveryAttempts: data.deliveryAttempts || 0,
       createdAt: data.createdAt?.toDate?.()?.toISOString() || null,
@@ -596,50 +611,93 @@ export async function queryMessageHistoryHandler(auth: AuthContext, rawArgs: unk
     });
   }
 
-  // Admin only gate
-  if (!isAdmin(auth)) {
-    return jsonResult({
-      success: false,
-      error: "query_message_history is only accessible by admin.",
-    });
+  // ADR-013: participant scoping for non-admins. The read path has no
+  // verifiedSource equivalent — this coercion IS the entire gate (SARK C1).
+  // Caller-supplied identity args naming another program are rejected,
+  // never passed through to the query.
+  const privileged = isAdmin(auth);
+  if (!privileged) {
+    const self = auth.programId;
+    if (args.source && args.source !== self) {
+      return jsonResult({
+        success: false,
+        error: `Participant scope: non-admin callers may only query source "${self}".`,
+      });
+    }
+    if (args.target && args.target !== self && args.target !== "all") {
+      return jsonResult({
+        success: false,
+        error: `Participant scope: non-admin callers may only query target "${self}" or "all".`,
+      });
+    }
   }
 
   const db = getFirestore();
-  let query: admin.firestore.Query = db.collection(`tenants/${auth.userId}/relay`);
-
-  if (args.threadId) {
-    query = query.where("threadId", "==", args.threadId);
-  }
-  if (args.source) {
-    query = query.where("source", "==", args.source);
-  }
-  if (args.target) {
-    query = query.where("target", "==", args.target);
-  }
-  if (args.message_type) {
-    query = query.where("message_type", "==", args.message_type);
-  }
-  if (args.status) {
-    query = query.where("status", "==", args.status);
-  }
+  const collection = db.collection(`tenants/${auth.userId}/relay`);
 
   // Sort: ASC when threadId filter set (conversation thread), DESC otherwise
-  const sortDirection = args.threadId ? "asc" : "desc";
-  query = query.orderBy("createdAt", sortDirection);
+  const sortDirection: "asc" | "desc" = args.threadId ? "asc" : "desc";
 
-  if (args.since) {
-    const sinceDate = new Date(args.since);
-    query = query.where("createdAt", ">=", admin.firestore.Timestamp.fromDate(sinceDate));
+  const applyCommonFilters = (q: admin.firestore.Query): admin.firestore.Query => {
+    if (args.threadId) {
+      q = q.where("threadId", "==", args.threadId);
+    }
+    if (args.message_type) {
+      q = q.where("message_type", "==", args.message_type);
+    }
+    if (args.status) {
+      q = q.where("status", "==", args.status);
+    }
+    q = q.orderBy("createdAt", sortDirection);
+    if (args.since) {
+      q = q.where("createdAt", ">=", admin.firestore.Timestamp.fromDate(new Date(args.since)));
+    }
+    if (args.until) {
+      q = q.where("createdAt", "<=", admin.firestore.Timestamp.fromDate(new Date(args.until)));
+    }
+    return q.limit(args.limit);
+  };
+
+  let queries: admin.firestore.Query[];
+  if (privileged || args.source || args.target) {
+    // Admin: filters as given. Non-admin: source/target already coerced to
+    // self/"all" above, so a single filtered query is participant-scoped.
+    let q: admin.firestore.Query = collection;
+    if (args.source) {
+      q = q.where("source", "==", args.source);
+    }
+    if (args.target) {
+      q = q.where("target", "==", args.target);
+    }
+    queries = [applyCommonFilters(q)];
+  } else {
+    // Non-admin threadId-only query: the participant constraint is forcibly
+    // added (SARK C3 LOCK) — both directions plus broadcast, merged in-handler.
+    const self = auth.programId;
+    queries = [
+      applyCommonFilters(collection.where("source", "==", self)),
+      applyCommonFilters(collection.where("target", "==", self)),
+      applyCommonFilters(collection.where("target", "==", "all")),
+    ];
   }
-  if (args.until) {
-    const untilDate = new Date(args.until);
-    query = query.where("createdAt", "<=", admin.firestore.Timestamp.fromDate(untilDate));
+
+  const snapshots = await Promise.all(queries.map((q) => q.get()));
+  const byId = new Map<string, admin.firestore.QueryDocumentSnapshot>();
+  for (const snapshot of snapshots) {
+    for (const doc of snapshot.docs) {
+      byId.set(doc.id, doc);
+    }
   }
 
-  query = query.limit(args.limit);
+  const docs = [...byId.values()]
+    .sort((a, b) => {
+      const ta = a.data().createdAt?.toMillis?.() ?? 0;
+      const tb = b.data().createdAt?.toMillis?.() ?? 0;
+      return sortDirection === "asc" ? ta - tb : tb - ta;
+    })
+    .slice(0, args.limit);
 
-  const snapshot = await query.get();
-  const messages = snapshot.docs.map((doc) => {
+  const messages = docs.map((doc) => {
     const data = doc.data();
     return {
       id: doc.id,
@@ -658,6 +716,34 @@ export async function queryMessageHistoryHandler(auth: AuthContext, rawArgs: unk
       deliveredAt: data.deliveredAt?.toDate?.()?.toISOString() || null,
       expiresAt: data.expiresAt?.toDate?.()?.toISOString() || null,
     };
+  });
+
+  // ADR-013 read-audit (SARK C4, GO condition): ledger the effective filters,
+  // result count, and returned message IDs so "who read what" is answerable.
+  logAudit({
+    timestamp: new Date().toISOString(),
+    correlationId: generateCorrelationId(),
+    tool: "relay_query_message_history.read",
+    source: auth.programId,
+    programId: auth.programId,
+    userId: auth.userId,
+    endpoint: "handler",
+    allowed: true,
+    details: {
+      effectiveFilters: {
+        threadId: args.threadId ?? null,
+        source: args.source ?? null,
+        target: args.target ?? null,
+        message_type: args.message_type ?? null,
+        status: args.status ?? null,
+        since: args.since ?? null,
+        until: args.until ?? null,
+        limit: args.limit,
+        participantScope: privileged ? null : auth.programId,
+      },
+      resultCount: messages.length,
+      messageIds: messages.map((m) => m.id),
+    },
   });
 
   return jsonResult({

--- a/services/mcp-server/src/tools/relay.ts
+++ b/services/mcp-server/src/tools/relay.ts
@@ -42,13 +42,14 @@ export const definitions = [
   },
   {
     name: "relay_get_messages",
-    description: "Check for pending messages from programs. Replaces get_interrupts.",
+    description: "Check for pending messages from programs. Set includeDelivered to re-read already-claimed message bodies. Replaces get_interrupts.",
     inputSchema: {
       type: "object" as const,
       properties: {
         sessionId: { type: "string" },
         target: { type: "string", description: "Filter by target program ID" },
         markAsRead: { type: "boolean", default: false },
+        includeDelivered: { type: "boolean", default: false, description: "Also return already-delivered messages (bodies re-readable; never re-claims). Default false." },
         message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"], description: "Filter by message type" },
         priority: { type: "string", enum: ["low", "normal", "high"], description: "Filter by priority level" },
       },
@@ -75,7 +76,7 @@ export const definitions = [
   },
   {
     name: "relay_get_sent_messages",
-    description: "Query sent messages from a program's outbox. Programs see own sent only; admin can query any source.",
+    description: "Query sent messages from a program's outbox, including message bodies. Programs see own sent only; admin can query any source.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -89,7 +90,7 @@ export const definitions = [
   },
   {
     name: "relay_query_message_history",
-    description: "Query full message history with bodies. Admin only. Requires at least one of: threadId, source, target.",
+    description: "Query full message history with bodies. Non-admin callers are participant-scoped: results are limited to messages they sent, received, or broadcasts (target 'all'); source/target args naming another program are rejected. Admin callers are unrestricted. Requires at least one of: threadId, source, target.",
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -94,7 +94,7 @@ function parseQuery(url: string): Record<string, string> {
 
 /** Numeric and boolean fields that arrive as strings from query params */
 const NUMERIC_FIELDS = new Set(['limit', 'progress', 'ttl', 'budget_cap_usd', 'timeout_hours', 'wave', 'maxConcurrent', 'completed', 'failed', 'skipped', 'duration', 'cost_tokens', 'confidence']);
-const BOOLEAN_FIELDS = new Set(['markAsRead', 'includeArchived', 'includeRevoked', 'allowed', 'encrypt', 'lastHeartbeat']);
+const BOOLEAN_FIELDS = new Set(['markAsRead', 'includeDelivered', 'includeArchived', 'includeRevoked', 'allowed', 'encrypt', 'lastHeartbeat']);
 
 /** Coerce string query params to proper types before Zod validation */
 function coerceQueryParams(params: Record<string, string>): Record<string, unknown> {
@@ -410,7 +410,9 @@ const routes: Route[] = [
     restResponse(res, true, data);
   }),
   route("GET", "/v1/messages/history", async (auth, req, res) => {
-    if (!requireAdmin(auth, res)) return;
+    // ADR-013: no requireAdmin pre-gate — participant scoping in
+    // queryMessageHistoryHandler is the single source of truth for both
+    // transports (SARK C2). Non-admin callers get their own messages only.
     const query = coerceQueryParams(parseQuery(req.url || ""));
     const data = await callTool(auth, req, "query_message_history", query);
     restResponse(res, true, data);


### PR DESCRIPTION
## ADR-013: participant-scoped durable relay reads

Implements `grid/decisions/alan-assessment-relay-body-read.md` (Accepted; SARK GO-WITH-CONTROLS grid#716; ALAN revision grid#717). Unblocks SCALAR as a two-way relay participant and fixes TENSOR's envelope-only reads.

**The gap:** the relay had no recipient-scoped durable read. `get_messages` is pending-only (bodies vanish on claim), `get_sent_messages` stripped bodies, and the only body-bearing read across statuses (`query_message_history`) was gated on the `ADMIN_PROGRAMS` programId roster — unfixable by any mintable capability.

### Changes (all `services/mcp-server/src/`)

| # | Change | Where |
|---|--------|-------|
| 1 | Participant scoping replaces blanket `isAdmin()` rejection in `queryMessageHistoryHandler`; non-admin = party only (`source==self`, `target==self`, `target=="all"`); three-query merge for threadId-only, bounded by `limit`. Admin unchanged. | `modules/relay.ts` |
| 2 | `includeDelivered: boolean` (default `false`) on `get_messages` → status `in ["pending","delivered"]`; claim txn already skips non-pending so re-reads never re-claim | `modules/relay.ts` |
| 3 | `get_sent_messages` includes `message: data.payload` | `modules/relay.ts` |
| 4 | `requireAdmin` pre-gate dropped from `GET /v1/messages/history`; handler scoping is the single source of truth for both transports; `includeDelivered` added to REST boolean query-param coercion | `transport/rest.ts` |
| 5 | Read-audit: history reads ledger effective filters, result count, returned message IDs via existing gate ledger (`AuditEntry.details`, no new collection) | `modules/relay.ts`, `middleware/gate.ts` |
| 6 | Tool schemas: `includeDelivered`; history description documents participant scoping. `capabilities.ts` untouched — mapping stays `relay.read` | `tools/relay.ts` |
| 7 | Composite indexes for the participant merge: `(source, threadId, createdAt)`, `(target, threadId, createdAt)`. All other needed indexes already exist | `infra/firestore.indexes.json` |

### SARK controls C1–C5 (grid/decisions/sark-assessment-relay-body-read.md, grid#716)

- **C1 (F-2, LOCK)** — non-admin `source`/`target` naming another program is **rejected** server-side; never passed to the query. Handler coercion is the entire gate (read path has no `verifiedSource`). Negative tests: `source=basher`, `target=basher`, and `source=iso` (counterparty-outbox attempt) all rejected for a `scalar` key.
- **C2 (F-1)** — enforcement moved into the handler; REST pre-gate dropped. Integration test runs the **real REST router over HTTP** with a seeded non-admin `scalar` key: `GET /v1/messages/history` returns 200 + own messages (no 403); third-party read rejected.
- **C3 (F-3, LOCK)** — threadId-only non-admin query forcibly carries the participant constraint. Test: thread shared with a third party (`iso→basher`) does NOT leak; caller gets only own-direction + broadcast messages.
- **C4 (F-4, GO condition)** — every history read ledgers `{effectiveFilters, resultCount, messageIds}` to `tenants/{userId}/ledger`. Test asserts the ledger entry contents.
- **C5 (F-5)** — exposure window documented as **48h** (delivered retention = 2×DEFAULT_TTL, `cleanupExpiredRelay.ts:42`), not 24h: a compromised participant key leaks up to 48h of that one identity's conversations, bounded by `limit`, tenant isolation, and send-time source verification.

**Constraints honored:** `ADMIN_PROGRAMS` / `ADMIN_READERS` rosters untouched (roster→capability migration is the separate SARK-led follow-up). Backward compatible — no existing caller changes behavior; new response fields are additive.

**Out-of-scope fix (1 line):** `modules/feedback.ts` `@ts-expect-error` → `@ts-ignore` on the `@octokit/rest` import (same pattern as `github-sync.ts:7`) — ts-jest flags the directive as unused, which blocked the integration suite from compiling.

### Executed proof

- Unit: **550 passed** (incl. new `capabilities.test.ts` assertion that relay read tools stay `relay.read`)
- Integration (Firestore emulator): **27 passed** — 15 new ADR-013 tests covering both LOCKs, C4 audit detail, delivered-re-read-doesn't-re-claim (deliveryAttempts stays 1), sent-body, admin parity, and both REST participant-read cases
- `tsc --noEmit` + `npm run build` clean

**Merge gate:** SARK sign-off required (LOCKs + audit GO condition). ISO + SARK notified via relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
