### PR TITLE
fix(relay): informational task mirrors — stop creating claimable phantom work

### DIFF
--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -346,3 +346,107 @@ describe("Relay Delivery Integration", () => {
     });
   });
 });
+
+/**
+ * Relay-mirror structural fix (Wave B tail): relay messages must not create
+ * claimable task records. The tasks-collection mirror is informational only —
+ * auto_archived + requires_action:false + TTL — so dispatchers never claim
+ * phantom work (replaces SARK's sweeper-skip regex stopgap).
+ */
+
+// dispatch/tasks pulls in github-sync -> ESM-only @octokit/rest; mock it out.
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+import { initializeFirebase } from "../../firebase/client";
+import { sendMessageHandler } from "../../modules/relay";
+import { getTasksHandler } from "../../modules/dispatch/tasks";
+import type { AuthContext } from "../../auth/authValidator";
+
+function mirrorAuth(userId: string, programId: string): AuthContext {
+  return {
+    userId,
+    programId,
+    capabilities: ["relay.read", "relay.write", "dispatch.read", "dispatch.write"],
+    rateLimitTier: "free",
+    apiKeyHash: `test-hash-${programId}`,
+    encryptionKey: Buffer.alloc(32),
+  } as unknown as AuthContext;
+}
+
+function parseResult(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("Relay-Mirror Structural Fix (informational mirrors)", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+    initializeFirebase();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    const testUser = await seedTestUser("test-user-mirror");
+    userId = testUser.userId;
+  });
+
+  it("unicast mirror is informational: auto_archived, requires_action false, TTL set", async () => {
+    const res = parseResult(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "structural fix proof",
+      source: "basher",
+      target: "iso",
+      message_type: "QUERY",
+      idempotency_key: "mirror-test-unicast-1",
+    }) as never);
+    expect(res.success).toBe(true);
+
+    const mirror = (await db.doc(`tenants/${userId}/tasks/${res.messageId}`).get()).data()!;
+    expect(mirror.requires_action).toBe(false);
+    expect(mirror.auto_archived).toBe(true);
+    expect(mirror.relay_mirror).toBe(true);
+    expect(mirror.message_type).toBe("QUERY");
+    expect(mirror.expiresAt).toBeDefined();
+    expect(mirror.ttl).toBeGreaterThan(0);
+  });
+
+  it("mirror is invisible to default task polls but recoverable via include_archived", async () => {
+    const send = parseResult(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "phantom work check",
+      source: "basher",
+      target: "iso",
+      message_type: "DIRECTIVE",
+      idempotency_key: "mirror-test-poll-1",
+    }) as never);
+    expect(send.success).toBe(true);
+
+    // Default poll (what dispatcher task-poll sees): no mirror
+    const poll = parseResult(await getTasksHandler(mirrorAuth(userId, "iso"), { target: "iso", status: "created" }) as never);
+    expect(poll.tasks.map((t: any) => t.id)).not.toContain(send.messageId);
+
+    // Forensic/mobile read with include_archived: mirror visible
+    const archived = parseResult(await getTasksHandler(mirrorAuth(userId, "iso"), { target: "iso", status: "created", include_archived: true }) as never);
+    expect(archived.tasks.map((t: any) => t.id)).toContain(send.messageId);
+  });
+
+  it("multicast mirror is informational too", async () => {
+    const res = parseResult(await sendMessageHandler(mirrorAuth(userId, "iso"), {
+      message: "multicast mirror check",
+      source: "iso",
+      target: "council",
+      message_type: "STATUS",
+      idempotency_key: "mirror-test-multi-1",
+    }) as never);
+    expect(res.success).toBe(true);
+    expect(res.recipients).toBeGreaterThan(1);
+
+    const snap = await db.collection(`tenants/${userId}/tasks`).where("target", "==", "council").get();
+    expect(snap.size).toBe(1);
+    const mirror = snap.docs[0].data();
+    expect(mirror.requires_action).toBe(false);
+    expect(mirror.auto_archived).toBe(true);
+    expect(mirror.relay_mirror).toBe(true);
+    expect(mirror.expiresAt).toBeDefined();
+  });
+});

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -189,7 +189,10 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
       refs.push(ref.id);
     }
 
-    // Single task doc for mobile visibility (summary, not fan-out)
+    // Single task doc for mobile visibility (summary, not fan-out).
+    // Informational mirror only — the relay doc is the delivery mechanism.
+    // auto_archived + requires_action:false keep it out of task polls so
+    // dispatchers never claim phantom work; expiresAt mirrors the relay TTL.
     const preview = args.message.length > 50 ? args.message.substring(0, 47) + "..." : args.message;
     const taskRef = db.collection(`tenants/${auth.userId}/tasks`).doc();
     batch.set(taskRef, {
@@ -200,9 +203,15 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
       preview,
       source: verifiedSource,
       target: args.target,
+      message_type: args.message_type,
       priority: args.priority,
       action: args.action,
       status: "created",
+      requires_action: false,
+      auto_archived: true,
+      relay_mirror: true,
+      ttl,
+      expiresAt,
       createdAt: serverTimestamp(),
       encrypted: false,
       archived: false,
@@ -294,7 +303,10 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
     is_multicast: false,
   });
 
-  // Also write to tasks collection for mobile app visibility
+  // Also write to tasks collection for mobile app visibility.
+  // Informational mirror only — the relay doc is the delivery mechanism.
+  // auto_archived + requires_action:false keep it out of task polls so
+  // dispatchers never claim phantom work; expiresAt mirrors the relay TTL.
   const preview = args.message.length > 50 ? args.message.substring(0, 47) + "..." : args.message;
   await db.collection(`tenants/${auth.userId}/tasks`).doc(relayRef.id).set({
     schemaVersion: '2.2' as const,
@@ -304,9 +316,15 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
     preview,
     source: verifiedSource,
     target: args.target,
+    message_type: args.message_type,
     priority: args.priority,
     action: args.action,
     status: "created",
+    requires_action: false,
+    auto_archived: true,
+    relay_mirror: true,
+    ttl,
+    expiresAt,
     createdAt: serverTimestamp(),
     encrypted: false,
     archived: false,


### PR DESCRIPTION
## Relay-mirror structural fix — Wave B tail (task kwhisjuc, thread grid-fleet-restore)

Replaces SARK's sweeper-skip regex stopgap. Relay messages mirrored to the tasks collection were claimable phantom work: status `created`, no `requires_action`/`auto_archived`/`message_type`/TTL. Dispatcher task-polls claimed them into the active-unclaimed limbo trap (126 mirror records sit in the current created backlog; the JXaB965a live-repro task was one of these).

### Change
Both mirror writes in `sendMessageHandler` (unicast + multicast) now write:

| Field | Value | Effect |
|-------|-------|--------|
| `requires_action` | `false` | informational — the relay doc is the delivery mechanism |
| `auto_archived` | `true` | invisible to default `get_tasks` polls (existing filter, `dispatch/tasks.ts:126`); recoverable via `include_archived` for mobile/forensics |
| `message_type` | from the message | classifiable/sweepable |
| `ttl` + `expiresAt` | mirrors the relay message | TTL'd on read (existing filter) |
| `relay_mirror` | `true` | explicit marker for triage/analytics |

No new server filtering logic — this rides the informational-task machinery that already exists in `getTasksHandler`. Additive fields only; relay delivery semantics unchanged.

### Trade-off for SARK
Mobile surfaces that read mirrors via default `get_tasks` will no longer see them unless they pass `include_archived: true` (or read the relay inbox directly — which ADR-013 / PR #345 makes durable). This is the intended behavior change: mirrors stop masquerading as work.

### Executed proof
- 3 new emulator integration tests: mirror doc fields asserted (unicast + multicast); default created-status poll does NOT return the mirror; `include_archived` read does.
- 549 unit tests pass; `tsc --noEmit` clean.

**Merge gate:** SARK (API behavior change per task constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
