### PR TITLE
feat(dispatch): B4 — record_task_telemetry, post-completion measured token/cost stamps

### DIFF
--- a/services/mcp-server/src/__tests__/integration/task-telemetry.test.ts
+++ b/services/mcp-server/src/__tests__/integration/task-telemetry.test.ts
@@ -1,0 +1,116 @@
+/**
+ * B4 (Wave B tail): post-completion telemetry stamp.
+ *
+ * Completers rarely pass tokens/cost to complete_task — the host hook
+ * measures real deltas from stats-cache.json and records them after the
+ * fact via record_task_telemetry. Proof: a synthetic task completed
+ * WITHOUT telemetry gets tokens_in/out + cost_usd populated through the
+ * real REST route, without the completer passing them; self-reported
+ * values are never overwritten; third-party programs are rejected.
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+import * as http from "http";
+import * as crypto from "crypto";
+import * as admin from "firebase-admin";
+import { getTestFirestore, clearFirestoreData, seedTestUser, seedTestData } from "./setup";
+import { initializeFirebase } from "../../firebase/client";
+import { claimTaskHandler } from "../../modules/dispatch/claims";
+import { completeTaskHandler, recordTaskTelemetryHandler } from "../../modules/dispatch/completion";
+import { createRestRouter } from "../../transport/rest";
+import type { AuthContext } from "../../auth/authValidator";
+
+function makeAuth(userId: string, programId: string): AuthContext {
+  return {
+    userId,
+    programId,
+    capabilities: ["dispatch.read", "dispatch.write", "relay.read", "relay.write"],
+    rateLimitTier: "free",
+    apiKeyHash: `test-hash-${programId}`,
+    encryptionKey: Buffer.alloc(32),
+  } as unknown as AuthContext;
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("B4 Task Telemetry Capture", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+    initializeFirebase();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    const u = await seedTestUser("test-user-b4");
+    userId = u.userId;
+    await seedTestData(userId, "tasks", [
+      { id: "t-b4", data: { type: "task", title: "synthetic B4 proof task", status: "created", source: "iso", target: "basher", priority: "normal", action: "queue", createdAt: admin.firestore.FieldValue.serverTimestamp() } },
+    ]);
+    const basher = makeAuth(userId, "basher");
+    parse(await claimTaskHandler(basher, { taskId: "t-b4", sessionId: "basher" }) as never);
+    // Complete WITHOUT tokens/cost — the 87%-null case
+    const done = parse(await completeTaskHandler(basher, { taskId: "t-b4", model: "claude-fable-5", provider: "anthropic", result: "done" }) as never);
+    expect(done.success).toBe(true);
+  });
+
+  it("REST POST /v1/tasks/:id/telemetry populates measured tokens without completer self-report", async () => {
+    const apiKey = `cb_test_${crypto.randomBytes(8).toString("hex")}`;
+    const keyHash = crypto.createHash("sha256").update(apiKey).digest("hex");
+    await db.doc(`keyIndex/${keyHash}`).set({
+      userId, programId: "basher",
+      capabilities: ["dispatch.read", "dispatch.write"],
+      active: true,
+    });
+
+    const server = http.createServer(createRestRouter());
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/tasks/t-b4/telemetry`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ tokens_in: 123456, tokens_out: 7890, cost_usd: 1.23, telemetry_source: "host-hook" }),
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      await new Promise<void>((r, j) => server.close((e) => (e ? j(e) : r())));
+    }
+
+    const doc = (await db.doc(`tenants/${userId}/tasks/t-b4`).get()).data()!;
+    expect(doc.tokens_in).toBe(123456);
+    expect(doc.tokens_out).toBe(7890);
+    expect(doc.cost_usd).toBe(1.23);
+    expect(doc.telemetry_source).toBe("host-hook");
+  });
+
+  it("never overwrites self-reported values (fill-if-null only)", async () => {
+    await db.doc(`tenants/${userId}/tasks/t-b4`).update({ tokens_out: 555 });
+
+    const res = parse(await recordTaskTelemetryHandler(makeAuth(userId, "basher"), { taskId: "t-b4", tokens_in: 100, tokens_out: 999 }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.updated).toEqual(["tokens_in"]);
+    expect(res.skipped).toContain("tokens_out");
+    const doc = (await db.doc(`tenants/${userId}/tasks/t-b4`).get()).data()!;
+    expect(doc.tokens_out).toBe(555);
+    expect(doc.tokens_in).toBe(100);
+  });
+
+  it("rejects third-party programs and non-completed tasks", async () => {
+    const other = parse(await recordTaskTelemetryHandler(makeAuth(userId, "quorra"), { taskId: "t-b4", tokens_in: 1 }) as never);
+    expect(other.success).toBe(false);
+
+    await seedTestData(userId, "tasks", [
+      { id: "t-open", data: { type: "task", title: "open", status: "created", source: "iso", target: "basher", createdAt: admin.firestore.FieldValue.serverTimestamp() } },
+    ]);
+    const open = parse(await recordTaskTelemetryHandler(makeAuth(userId, "basher"), { taskId: "t-open", tokens_in: 1 }) as never);
+    expect(open.success).toBe(false);
+    expect(open.error).toMatch(/completed tasks/i);
+  });
+});

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -39,6 +39,7 @@ export const TOOL_CAPABILITIES: Record<string, Capability> = {
   dispatch_claim_task: "dispatch.write",
   dispatch_unclaim_task: "dispatch.write",
   dispatch_complete_task: "dispatch.write",
+  dispatch_record_task_telemetry: "dispatch.write",
   dispatch_batch_claim_tasks: "dispatch.write",
   dispatch_batch_complete_tasks: "dispatch.write",
   dispatch_get_contention_metrics: "dispatch.read",

--- a/services/mcp-server/src/modules/dispatch/completion.ts
+++ b/services/mcp-server/src/modules/dispatch/completion.ts
@@ -879,3 +879,89 @@ export async function batchCompleteTasksHandler(auth: AuthContext, rawArgs: unkn
 
   return jsonResult({ success: true, results, completed, failed });
 }
+
+const RecordTaskTelemetrySchema = z.object({
+  taskId: z.string(),
+  tokens_in: z.number().nonnegative().optional(),
+  tokens_out: z.number().nonnegative().optional(),
+  cost_usd: z.number().nonnegative().optional(),
+  model: z.string().optional(),
+  provider: z.string().optional(),
+  telemetry_source: z.string().max(100).default("host-hook"),
+});
+
+/**
+ * B4 (Wave B tail): post-completion telemetry stamp. Completers rarely pass
+ * tokens/cost to complete_task (87% of done tasks had null cost), so the
+ * host-side PostToolUse hook measures real token deltas from
+ * ~/.claude/stats-cache.json and records them here AFTER completion.
+ *
+ * Fill-if-null only: self-reported numbers from complete_task are never
+ * overwritten. Caller must be the completing program (claimedBy) or admin.
+ * Only telemetry fields are writable — this is not a task-update backdoor.
+ */
+export async function recordTaskTelemetryHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
+  const args = RecordTaskTelemetrySchema.parse(rawArgs);
+  const db = getFirestore();
+  const ref = db.doc(`tenants/${auth.userId}/tasks/${args.taskId}`);
+
+  try {
+    const result = await db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) {
+        return { success: false as const, error: "Task not found" };
+      }
+      const data = snap.data()!;
+
+      if (data.status !== "done" && data.status !== "failed") {
+        return { success: false as const, error: `Telemetry can only be recorded on completed tasks (status: ${data.status})` };
+      }
+
+      const { isAdmin } = await import("../../middleware/gate.js");
+      if (!isAdmin(auth) && data.claimedBy !== auth.programId) {
+        return { success: false as const, error: "Only the completing program or admin can record telemetry" };
+      }
+
+      const updates: Record<string, unknown> = {};
+      const skipped: string[] = [];
+      const fields: Array<["tokens_in" | "tokens_out" | "cost_usd" | "model" | "provider", unknown]> = [
+        ["tokens_in", args.tokens_in],
+        ["tokens_out", args.tokens_out],
+        ["cost_usd", args.cost_usd],
+        ["model", args.model],
+        ["provider", args.provider],
+      ];
+      for (const [field, value] of fields) {
+        if (value === undefined) continue;
+        const existing = data[field];
+        if (existing === null || existing === undefined) {
+          updates[field] = value;
+        } else {
+          skipped.push(field); // self-reported value wins — never overwrite
+        }
+      }
+
+      if (Object.keys(updates).length === 0) {
+        return { success: true as const, taskId: args.taskId, updated: [], skipped, message: "Nothing to record (all fields already set or none provided)" };
+      }
+
+      updates.telemetry_source = args.telemetry_source;
+      updates.telemetryRecordedAt = admin.firestore.FieldValue.serverTimestamp();
+      tx.update(ref, updates);
+
+      return {
+        success: true as const,
+        taskId: args.taskId,
+        updated: Object.keys(updates).filter((k) => !k.startsWith("telemetry")),
+        skipped,
+        message: "Telemetry recorded",
+      };
+    });
+    return jsonResult(result);
+  } catch (error) {
+    return jsonResult({
+      success: false,
+      error: `Failed to record telemetry: ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+}

--- a/services/mcp-server/src/modules/dispatch/index.ts
+++ b/services/mcp-server/src/modules/dispatch/index.ts
@@ -5,7 +5,7 @@
 
 export { getTasksHandler, getTaskByIdHandler, createTaskHandler } from "./tasks.js";
 export { claimTaskHandler, unclaimTaskHandler, batchClaimTasksHandler } from "./claims.js";
-export { completeTaskHandler, batchCompleteTasksHandler } from "./completion.js";
+export { completeTaskHandler, batchCompleteTasksHandler, recordTaskTelemetryHandler } from "./completion.js";
 export { getContentionMetricsHandler } from "./contention.js";
 export { dispatchHandler } from "./dispatchHandler.js";
 export { checkGovernanceRules, CONSTITUTIONAL_RULES, getConstitutionalSeedEntries } from "./governance.js";

--- a/services/mcp-server/src/tools/dispatch.ts
+++ b/services/mcp-server/src/tools/dispatch.ts
@@ -2,7 +2,7 @@
  * Dispatch Domain Registry — Task lifecycle tools.
  */
 import { AuthContext } from "../auth/authValidator.js";
-import { getTasksHandler, getTaskByIdHandler, createTaskHandler, claimTaskHandler, unclaimTaskHandler, completeTaskHandler, batchClaimTasksHandler, batchCompleteTasksHandler, getContentionMetricsHandler, dispatchHandler, retryTaskHandler, abortTaskHandler, reassignTaskHandler, escalateTaskHandler, quarantineProgramHandler, unquarantineProgramHandler, replayTaskHandler, approveTaskHandler, getTaskLineageHandler, exportTasksHandler, suggestTargetHandler } from "../modules/dispatch/index.js";
+import { getTasksHandler, getTaskByIdHandler, createTaskHandler, claimTaskHandler, unclaimTaskHandler, completeTaskHandler, batchClaimTasksHandler, batchCompleteTasksHandler, getContentionMetricsHandler, dispatchHandler, retryTaskHandler, abortTaskHandler, reassignTaskHandler, escalateTaskHandler, quarantineProgramHandler, unquarantineProgramHandler, replayTaskHandler, approveTaskHandler, getTaskLineageHandler, exportTasksHandler, suggestTargetHandler, recordTaskTelemetryHandler } from "../modules/dispatch/index.js";
 
 type Handler = (auth: AuthContext, args: any) => Promise<any>;
 
@@ -13,6 +13,7 @@ export const handlers: Record<string, Handler> = {
   dispatch_claim_task: claimTaskHandler,
   dispatch_unclaim_task: unclaimTaskHandler,
   dispatch_complete_task: completeTaskHandler,
+  dispatch_record_task_telemetry: recordTaskTelemetryHandler,
   dispatch_batch_claim_tasks: batchClaimTasksHandler,
   dispatch_batch_complete_tasks: batchCompleteTasksHandler,
   dispatch_get_contention_metrics: getContentionMetricsHandler,
@@ -141,6 +142,23 @@ export const definitions = [
         parentSpanId: { type: "string", description: "Parent span ID" },
       },
       required: ["taskIds"],
+    },
+  },
+  {
+    name: "dispatch_record_task_telemetry",
+    description: "Record measured token/cost telemetry on a completed task (fill-if-null; never overwrites self-reported values). For host-side telemetry hooks. Completing program or admin only.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        taskId: { type: "string" },
+        tokens_in: { type: "number", minimum: 0 },
+        tokens_out: { type: "number", minimum: 0 },
+        cost_usd: { type: "number", minimum: 0 },
+        model: { type: "string" },
+        provider: { type: "string" },
+        telemetry_source: { type: "string", maxLength: 100, default: "host-hook" },
+      },
+      required: ["taskId"],
     },
   },
   {

--- a/services/mcp-server/src/tools/tool-aliases.ts
+++ b/services/mcp-server/src/tools/tool-aliases.ts
@@ -25,6 +25,7 @@ export const TOOL_ALIASES: Record<string, string> = {
   claim_task: "dispatch_claim_task",
   unclaim_task: "dispatch_unclaim_task",
   complete_task: "dispatch_complete_task",
+  record_task_telemetry: "dispatch_record_task_telemetry",
   batch_claim_tasks: "dispatch_batch_claim_tasks",
   batch_complete_tasks: "dispatch_batch_complete_tasks",
   get_contention_metrics: "dispatch_get_contention_metrics",

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -334,6 +334,11 @@ const routes: Route[] = [
     const data = await callTool(auth, req, "complete_task", { taskId: p.id, ...body });
     restResponse(res, true, data);
   }),
+  route("POST", "/v1/tasks/:id/telemetry", async (auth, req, res, p) => {
+    const body = await readBody(req);
+    const data = await callTool(auth, req, "record_task_telemetry", { taskId: p.id, ...body });
+    restResponse(res, true, data);
+  }),
   route("POST", "/v1/tasks/:id/unclaim", async (auth, req, res, p) => {
     const body = await readBody(req);
     const data = await callTool(auth, req, "unclaim_task", { taskId: p.id, ...body });


### PR DESCRIPTION
87% of done tasks had null cost: completers rarely pass tokens/cost to
complete_task, and the host-side telemetry hook could only inject
additionalContext and hope the model relayed it. New tool
dispatch_record_task_telemetry (+ REST POST /v1/tasks/:id/telemetry,
alias record_task_telemetry, capability dispatch.write):

- fill-if-null ONLY — self-reported values from complete_task are never
  overwritten
- status gate: done/failed tasks only (not a task-update backdoor)
- authz: completing program (claimedBy) or admin
- stamps telemetry_source + telemetryRecordedAt for provenance

Proof (emulator integration): synthetic task claimed + completed WITHOUT
tokens, then populated via the real REST route with a non-admin completer
key; overwrite-skip and third-party/non-completed rejection covered.

Companion: grid-side telemetry-capture.sh rewrite (broken tool-name
match: hook still matched mcp__cachebash__complete_task, renamed to
dispatch_complete_task in the monorepo restructure) posts measured
stats-cache.json deltas here. Wave B tail, task kwhisjuc, thread
grid-fleet-restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)