### PR TITLE
feat(C-1): OAuth fallback de-escalation — read-only capability set

### DIFF
--- a/services/mcp-server/src/__tests__/capabilities.test.ts
+++ b/services/mcp-server/src/__tests__/capabilities.test.ts
@@ -128,6 +128,18 @@ describe('Capability System', () => {
     it('auditor has audit.read (security role)', () => {
       expect(DEFAULT_CAPABILITIES['auditor']).toContain('audit.read');
     });
+
+    it('C-1: oauth fallback carries zero .write capabilities', () => {
+      const oauthCaps = DEFAULT_CAPABILITIES['oauth'];
+      expect(oauthCaps).toBeDefined();
+      const writeCaps = oauthCaps.filter(c => c.endsWith('.write') || c === '*');
+      expect(writeCaps).toHaveLength(0);
+      expect(oauthCaps).toContain('dispatch.read');
+      expect(oauthCaps).toContain('relay.read');
+      expect(oauthCaps).not.toContain('dispatch.write');
+      expect(oauthCaps).not.toContain('state.write');
+      expect(oauthCaps).not.toContain('gsp.write');
+    });
   });
 
   describe('getDefaultCapabilities', () => {

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -170,11 +170,10 @@ export const DEFAULT_CAPABILITIES: Record<string, Capability[]> = {
     "pulse.read", "pulse.write", "signal.read", "signal.write",
     "state.read", "state.write", "sprint.read", "programs.read", "programs.write",
     "gsp.read"],
-  // OAuth external clients — standard operational access, no admin
-  oauth: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
-    "pulse.read", "pulse.write", "signal.read", "signal.write",
-    "state.read", "state.write", "sprint.read", "programs.read", "programs.write",
-    "gsp.read", "gsp.write"],
+  // OAuth external clients — read-only fallback (C-1); fallback sites in callback.ts/token.ts still mint tokens, but these caps are powerless to mutate
+  oauth: ["dispatch.read", "relay.read", "pulse.read", "signal.read",
+    "sprint.read", "metrics.read", "fleet.read", "programs.read",
+    "gsp.read", "state.read"],
   // OAuth service accounts (client_credentials) — same as oauth
   "oauth-service": ["dispatch.read", "dispatch.write", "relay.read", "relay.write",
     "pulse.read", "pulse.write", "signal.read", "signal.write",


### PR DESCRIPTION
## Summary
- Replace `oauth` entry in `DEFAULT_CAPABILITIES` with a read-only list — removes all `.write` capabilities from the OAuth external client fallback path
- External OAuth clients can no longer mutate dispatch, relay, state, gsp, signal, or pulse via the fallback token path
- `oauth-service` and `scalar` are untouched; the three `|| 'oauth'` fallback sites in callback.ts/token.ts are untouched (they still mint tokens, but the tokens are now powerless to mutate)

## Test plan
- [x] New test: `C-1: oauth fallback carries zero .write capabilities` — asserts zero `.write` or `*` caps in the oauth set
- [x] All 20 existing capability tests pass
- [x] `oauth-service` and `scalar` entries unchanged (verified by existing test suite)

## Gate
SARK review required before merge — security-relevant capability change.

🤖 BASHER Grid Execution Engine