### PR TITLE
feat(C-2): API key TTL — optional expiresAt with 90-day default

### DIFF
--- a/services/mcp-server/src/__tests__/auth-phase0.test.ts
+++ b/services/mcp-server/src/__tests__/auth-phase0.test.ts
@@ -335,4 +335,63 @@ describe('Auth Phase 0: Dual-mode auth middleware', () => {
       expect(result?.programId).toBe('iso');
     });
   });
+
+  describe('C-2: key TTL expiry rejection', () => {
+    it('rejects a key whose expiresAt is in the past', async () => {
+      const pastTimestamp = new Date(Date.now() - 60_000); // 1 minute ago
+      const keyDocRef = {
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => ({
+            userId: testUserId,
+            programId: 'basher',
+            active: true,
+            capabilities: ['dispatch.read'],
+            expiresAt: { toDate: () => pastTimestamp },
+            createdAt: { toDate: () => new Date(Date.now() - 86400_000) },
+          }),
+        }),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockDb.doc.mockImplementation((path: string) => {
+        if (path === `keyIndex/${keyHash}`) return keyDocRef;
+        throw new Error(`Unexpected doc path: ${path}`);
+      });
+
+      const result = await validateApiKey(testApiKey);
+      expect(result).toBeNull();
+    });
+
+    it('accepts a key whose expiresAt is in the future', async () => {
+      const futureTimestamp = new Date(Date.now() + 86400_000); // 1 day ahead
+      const keyDocRef = {
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => ({
+            userId: testUserId,
+            programId: 'basher',
+            active: true,
+            capabilities: ['dispatch.read'],
+            expiresAt: { toDate: () => futureTimestamp },
+            createdAt: { toDate: () => new Date(Date.now() - 3600_000) },
+          }),
+        }),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const programDocRef = {
+        get: jest.fn().mockResolvedValue({ exists: false }),
+      };
+
+      mockDb.doc.mockImplementation((path: string) => {
+        if (path === `keyIndex/${keyHash}`) return keyDocRef;
+        return programDocRef;
+      });
+
+      mockGetDefaultCapabilities.mockReturnValue(['dispatch.read']);
+      const result = await validateApiKey(testApiKey);
+      expect(result).not.toBeNull();
+    });
+  });
 });

--- a/services/mcp-server/src/__tests__/keys.test.ts
+++ b/services/mcp-server/src/__tests__/keys.test.ts
@@ -237,6 +237,40 @@ describe("Keys Module Unit Tests", () => {
       expect(data.success).toBe(false);
       expect(data.error).toContain("label is required");
     });
+
+    it("C-2: default TTL sets expiresAt ~90 days from now", async () => {
+      const before = Date.now();
+      const result = await createKeyHandler(mockAuth, {
+        programId: "basher",
+        label: "Default TTL Key",
+      });
+      const after = Date.now();
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(true);
+
+      const storedDoc = mockKeyDocs[data.keyHash];
+      expect(storedDoc.expiresAt).toBeDefined();
+      const expiresMs = storedDoc.expiresAt.toMillis();
+      const expectedLow = before + 90 * 24 * 60 * 60 * 1000;
+      const expectedHigh = after + 90 * 24 * 60 * 60 * 1000;
+      expect(expiresMs).toBeGreaterThanOrEqual(expectedLow - 1000);
+      expect(expiresMs).toBeLessThanOrEqual(expectedHigh + 1000);
+    });
+
+    it("C-2: ttlDays:0 creates non-expiring key (no expiresAt)", async () => {
+      const result = await createKeyHandler(mockAuth, {
+        programId: "basher",
+        label: "Non-expiring Key",
+        ttlDays: 0,
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.success).toBe(true);
+
+      const storedDoc = mockKeyDocs[data.keyHash];
+      expect(storedDoc.expiresAt).toBeUndefined();
+    });
   });
 
   describe("createKeyHandler owner gate (SARK fesTTlPTC + #341 ceiling)", () => {

--- a/services/mcp-server/src/modules/keys.ts
+++ b/services/mcp-server/src/modules/keys.ts
@@ -98,6 +98,11 @@ export async function createKeyHandler(auth: AuthContext, args: any) {
   const keyHash = hashKey(rawKey);
   const db = getFirestore();
 
+  const ttlDays: number = typeof args.ttlDays === "number" ? args.ttlDays : 90;
+  const expiresAt: Timestamp | undefined = ttlDays > 0
+    ? Timestamp.fromMillis(Date.now() + ttlDays * 24 * 60 * 60 * 1000)
+    : undefined;
+
   const keyDoc: Omit<ApiKeyDoc, "createdAt" | "lastUsedAt"> & { createdAt: any } = {
     userId: auth.userId,
     programId,
@@ -105,6 +110,7 @@ export async function createKeyHandler(auth: AuthContext, args: any) {
     capabilities: requestedCapabilities,
     createdAt: FieldValue.serverTimestamp(),
     active: true,
+    ...(expiresAt !== undefined && { expiresAt }),
   };
 
   await db.doc(`keyIndex/${keyHash}`).set(keyDoc);

--- a/services/mcp-server/src/tools/keys.ts
+++ b/services/mcp-server/src/tools/keys.ts
@@ -27,6 +27,10 @@ export const definitions = [
           items: { type: "string" },
           description: 'Optional capability scopes. Defaults to program defaults or ["*"] if unknown.',
         },
+        ttlDays: {
+          type: "number",
+          description: "Days until key expires. Default 90. Pass 0 for non-expiring.",
+        },
       },
       required: ["programId", "label"],
     },

--- a/services/mcp-server/src/types/apiKey.ts
+++ b/services/mcp-server/src/types/apiKey.ts
@@ -14,5 +14,6 @@ export interface ApiKeyDoc {
   createdAt: Timestamp;
   lastUsedAt?: Timestamp;
   revokedAt?: Timestamp;
+  expiresAt?: Timestamp;
   active: boolean;
 }


### PR DESCRIPTION
## Summary
- New optional `ttlDays` param on `keys_create_key` — keys expire after 90 days by default
- `ttlDays: 0` creates a non-expiring key (no `expiresAt` field written)
- `expiresAt` is a Firestore `Timestamp` set to `now + ttlDays * 86400s` at creation time
- `authValidator.ts` already checks `expiresAt` and returns null for expired keys — no change to that path

## Changes
| File | Change |
|------|--------|
| `types/apiKey.ts` | `expiresAt?: Timestamp` added to `ApiKeyDoc` |
| `modules/keys.ts` | TTL computation in `createKeyHandler`; spread into keyDoc if `ttlDays > 0` |
| `tools/keys.ts` | `ttlDays` optional number field in `keys_create_key` inputSchema |
| `keys.test.ts` | C-2: default 90d TTL, ttlDays:0 non-expiring |
| `auth-phase0.test.ts` | C-2: expired key rejected, future key accepted |

## Test plan
- [x] 33 tests pass across `keys.test.ts` + `auth-phase0.test.ts`
- [x] Default TTL test verifies expiresAt is within ±1s of expected 90-day window
- [x] ttlDays:0 test confirms no expiresAt field written to doc
- [x] Expiry rejection test: past expiresAt → validateApiKey returns null
- [x] Future expiry test: future expiresAt → validateApiKey passes through

## Gate
SARK review required before merge.

🤖 BASHER Grid Execution Engine