### PR TITLE
feat(registry): E-2 dynamic PROGRAM_GROUPS — Firestore-backed group resolution (60s cache)

### DIFF
--- a/services/mcp-server/src/__tests__/program-registry.test.ts
+++ b/services/mcp-server/src/__tests__/program-registry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * E-2: Dynamic PROGRAM_GROUPS — resolveGroupAsync unit tests
+ */
+
+import type { AuthContext } from "../auth/authValidator";
+
+// ---- Firestore mock --------------------------------------------------------
+
+type MockDoc = { id: string; data: () => Record<string, unknown> };
+
+let mockGroupDocs: MockDoc[] = [];
+let mockGroupQueryError: Error | null = null;
+let mockQueryCalls = 0;
+
+const mockFirestoreInstance = {
+  collection: jest.fn(() => ({
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => {
+      mockQueryCalls++;
+      if (mockGroupQueryError) throw mockGroupQueryError;
+      return { docs: mockGroupDocs };
+    }),
+  })),
+  doc: jest.fn(() => ({
+    get: jest.fn(async () => ({ exists: false })),
+    set: jest.fn(async () => {}),
+    update: jest.fn(async () => {}),
+  })),
+  batch: jest.fn(() => ({ set: jest.fn(), commit: jest.fn(async () => {}) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockFirestoreInstance),
+  serverTimestamp: jest.fn(() => "MOCK_TS"),
+}));
+
+// ---- programs config mock --------------------------------------------------
+
+const MOCK_PROGRAM_GROUPS: Record<string, string[]> = {
+  council: ["orchestrator", "architect", "reviewer"],
+  builders: ["builder", "basher"],
+  all: ["orchestrator", "architect", "builder", "basher"],
+};
+
+jest.mock("../config/programs.js", () => ({
+  REGISTERED_PROGRAMS: ["orchestrator", "architect", "builder", "basher"],
+  SPECIAL_PROGRAMS: ["iso", "legacy"],
+  PROGRAM_GROUPS: {
+    council: ["orchestrator", "architect", "reviewer"],
+    builders: ["builder", "basher"],
+    all: ["orchestrator", "architect", "builder", "basher"],
+  },
+  PROGRAM_REGISTRY: {},
+  isGroupTarget: jest.fn((t: string) => t in MOCK_PROGRAM_GROUPS),
+  isRegisteredProgram: jest.fn(() => false),
+  isValidProgram: jest.fn(() => false),
+}));
+
+// ---- gate mock -------------------------------------------------------------
+
+jest.mock("../middleware/gate.js", () => ({
+  verifySource: jest.fn((s: string) => s),
+  isAdmin: jest.fn(() => false),
+  logAudit: jest.fn(),
+  generateCorrelationId: jest.fn(() => "corr-id"),
+}));
+
+// ---- Import after mocks ----------------------------------------------------
+
+// Dynamic import lets jest replace the module cache between describe blocks
+// by isolating the module. We re-import in beforeAll so cache state resets.
+let resolveGroupAsync: (userId: string, groupName: string) => Promise<string[]>;
+let resolveTargetsAsync: (userId: string, target: string) => Promise<string[]>;
+let listGroupsAsync: (userId: string) => Promise<Record<string, string[]>>;
+
+beforeAll(async () => {
+  // Isolate module so each test suite starts with a fresh cache
+  jest.resetModules();
+  // Re-apply mocks after reset
+  jest.mock("../firebase/client.js", () => ({
+    getFirestore: jest.fn(() => mockFirestoreInstance),
+    serverTimestamp: jest.fn(() => "MOCK_TS"),
+  }));
+  jest.mock("../config/programs.js", () => ({
+    REGISTERED_PROGRAMS: ["orchestrator", "architect", "builder", "basher"],
+    SPECIAL_PROGRAMS: ["iso", "legacy"],
+    PROGRAM_GROUPS: {
+      council: ["orchestrator", "architect", "reviewer"],
+      builders: ["builder", "basher"],
+      all: ["orchestrator", "architect", "builder", "basher"],
+    },
+    PROGRAM_REGISTRY: {},
+    isGroupTarget: jest.fn((t: string) => t in MOCK_PROGRAM_GROUPS),
+    isRegisteredProgram: jest.fn(() => false),
+    isValidProgram: jest.fn(() => false),
+  }));
+  jest.mock("../middleware/gate.js", () => ({
+    verifySource: jest.fn((s: string) => s),
+    isAdmin: jest.fn(() => false),
+    logAudit: jest.fn(),
+    generateCorrelationId: jest.fn(() => "corr-id"),
+  }));
+
+  const mod = await import("../modules/programRegistry.js");
+  resolveGroupAsync = mod.resolveGroupAsync;
+  resolveTargetsAsync = mod.resolveTargetsAsync;
+  listGroupsAsync = mod.listGroupsAsync;
+});
+
+beforeEach(() => {
+  mockGroupDocs = [];
+  mockGroupQueryError = null;
+  mockQueryCalls = 0;
+  jest.clearAllMocks();
+  // Reset mock implementations after clearAllMocks
+  (mockFirestoreInstance.collection as jest.Mock).mockReturnValue({
+    where: jest.fn().mockReturnThis(),
+    get: jest.fn(async () => {
+      mockQueryCalls++;
+      if (mockGroupQueryError) throw mockGroupQueryError;
+      return { docs: mockGroupDocs };
+    }),
+  });
+});
+
+describe("E-2: resolveGroupAsync", () => {
+  it("returns Firestore results when programs exist for the group", async () => {
+    mockGroupDocs = [
+      { id: "orchestrator", data: () => ({ active: true, groups: ["council"] }) },
+      { id: "architect", data: () => ({ active: true, groups: ["council"] }) },
+      { id: "new-reviewer", data: () => ({ active: true, groups: ["council"] }) },
+    ];
+
+    const members = await resolveGroupAsync("uid-1", "council");
+
+    expect(members.sort()).toEqual(["architect", "new-reviewer", "orchestrator"]);
+    expect(mockQueryCalls).toBe(1);
+  });
+
+  it("falls back to PROGRAM_GROUPS when Firestore returns empty", async () => {
+    mockGroupDocs = []; // Firestore empty = unseeded tenant
+
+    const members = await resolveGroupAsync("uid-empty", "builders");
+
+    // Should fall back to hardcoded PROGRAM_GROUPS["builders"]
+    expect(members.sort()).toEqual(["basher", "builder"]);
+  });
+
+  it("falls back to PROGRAM_GROUPS when Firestore throws", async () => {
+    mockGroupQueryError = new Error("Firestore unavailable");
+
+    const members = await resolveGroupAsync("uid-error", "council");
+
+    // Falls back gracefully
+    expect(members.sort()).toEqual(["architect", "orchestrator", "reviewer"]);
+    expect(mockQueryCalls).toBe(1);
+  });
+
+  it("returns empty array for unknown group with no Firestore results", async () => {
+    mockGroupDocs = [];
+
+    const members = await resolveGroupAsync("uid-unknown", "nonexistent-group");
+
+    expect(members).toEqual([]);
+  });
+
+  it("E-2: 60s cache — second call skips Firestore", async () => {
+    const userId = "uid-cache-test";
+    mockGroupDocs = [
+      { id: "basher", data: () => ({ active: true, groups: ["builders"] }) },
+    ];
+
+    const first = await resolveGroupAsync(userId, "builders");
+    expect(mockQueryCalls).toBe(1);
+
+    // Second call within 60s — should hit cache
+    const callsBefore = mockQueryCalls;
+    const second = await resolveGroupAsync(userId, "builders");
+    expect(mockQueryCalls).toBe(callsBefore); // no extra Firestore call
+    expect(second).toEqual(first);
+  });
+});
+
+describe("E-2: resolveTargetsAsync — group dispatch", () => {
+  it("resolves named group via Firestore (not hardcoded)", async () => {
+    mockGroupDocs = [
+      { id: "orchestrator", data: () => ({ active: true, groups: ["council"] }) },
+      { id: "newprogram", data: () => ({ active: true, groups: ["council"] }) },
+    ];
+
+    const targets = await resolveTargetsAsync("uid-2", "council");
+
+    // newprogram is NOT in hardcoded PROGRAM_GROUPS["council"] — proves Firestore path
+    expect(targets).toContain("newprogram");
+    expect(targets).toContain("orchestrator");
+  });
+
+  it("resolves single program as-is (not a group)", async () => {
+    const targets = await resolveTargetsAsync("uid-3", "basher");
+
+    expect(targets).toEqual(["basher"]);
+    expect(mockQueryCalls).toBe(0); // No Firestore call for non-group targets
+  });
+});
+
+describe("E-2: listGroupsAsync", () => {
+  it("returns all group names with their Firestore-resolved members", async () => {
+    mockGroupDocs = [
+      { id: "orchestrator", data: () => ({}) },
+      { id: "architect", data: () => ({}) },
+    ];
+
+    const groups = await listGroupsAsync("uid-4");
+
+    // All PROGRAM_GROUPS keys should be present
+    expect(Object.keys(groups).sort()).toEqual(["all", "builders", "council"]);
+  });
+});

--- a/services/mcp-server/src/modules/programRegistry.ts
+++ b/services/mcp-server/src/modules/programRegistry.ts
@@ -58,6 +58,78 @@ function invalidateListCache(userId: string): void {
   listCache.delete(userId);
 }
 
+// Cache for group membership — 60s TTL (E-2: dynamic group resolution)
+// Key: `${userId}:${groupName}`
+const GROUP_CACHE_TTL_MS = 60 * 1000;
+const groupCache = new Map<string, { members: string[]; cachedAt: number }>();
+
+function invalidateGroupCache(userId: string, groupName?: string): void {
+  if (groupName) {
+    groupCache.delete(`${userId}:${groupName}`);
+  } else {
+    for (const key of groupCache.keys()) {
+      if (key.startsWith(`${userId}:`)) groupCache.delete(key);
+    }
+  }
+}
+
+/**
+ * Resolve a named group to its member program IDs.
+ * Reads group membership from Firestore (programs where groups array-contains groupName),
+ * caches for 60s, falls back to hardcoded PROGRAM_GROUPS on Firestore error or empty result.
+ */
+export async function resolveGroupAsync(userId: string, groupName: string): Promise<string[]> {
+  const cacheKey = `${userId}:${groupName}`;
+  const entry = groupCache.get(cacheKey);
+  if (entry && Date.now() - entry.cachedAt < GROUP_CACHE_TTL_MS) {
+    return entry.members;
+  }
+
+  try {
+    const db = getFirestore();
+    let members: string[];
+
+    if (groupName === "all") {
+      const snapshot = await db
+        .collection(`tenants/${userId}/programs`)
+        .where("active", "==", true)
+        .get();
+      members = snapshot.docs.map((d) => d.id);
+    } else {
+      const snapshot = await db
+        .collection(`tenants/${userId}/programs`)
+        .where("groups", "array-contains", groupName)
+        .where("active", "==", true)
+        .get();
+      members = snapshot.docs.map((d) => d.id);
+    }
+
+    // Fallback to hardcoded list if Firestore returned nothing (unseeded tenant)
+    if (members.length === 0 && groupName in PROGRAM_GROUPS) {
+      members = [...PROGRAM_GROUPS[groupName]];
+    }
+
+    groupCache.set(cacheKey, { members, cachedAt: Date.now() });
+    return members;
+  } catch {
+    // Firestore unavailable — return hardcoded fallback
+    if (groupName in PROGRAM_GROUPS) return [...PROGRAM_GROUPS[groupName]];
+    return [];
+  }
+}
+
+/**
+ * Resolve all known groups for a tenant. Uses resolveGroupAsync (60s cache) per group.
+ * Returns a map of groupName → memberIds.
+ */
+export async function listGroupsAsync(userId: string): Promise<Record<string, string[]>> {
+  const groupNames = Object.keys(PROGRAM_GROUPS);
+  const entries = await Promise.all(
+    groupNames.map(async (name) => [name, await resolveGroupAsync(userId, name)] as const)
+  );
+  return Object.fromEntries(entries);
+}
+
 // === Core Functions ===
 
 /**
@@ -149,22 +221,20 @@ export async function getProgramsByRole(userId: string, role: string): Promise<s
  * Replaces the sync resolveTargets from programs.ts.
  */
 export async function resolveTargetsAsync(userId: string, target: string): Promise<string[]> {
-  // 1. Named group (backward compat from hardcoded PROGRAM_GROUPS)
+  // 1. Named group — Firestore-backed with 60s cache + static fallback (E-2)
   if (target in PROGRAM_GROUPS) {
-    return [...PROGRAM_GROUPS[target]];
+    return resolveGroupAsync(userId, target);
   }
 
-
-  // 3. Role-based: @builder, @orchestrator, etc.
+  // 2. Role-based: @builder, @orchestrator, etc.
   if (target.startsWith("@")) {
     const role = target.slice(1);
     const programs = await getProgramsByRole(userId, role);
     if (programs.length > 0) return programs;
-    // Fallback: treat as unknown target
     return [target];
   }
 
-  // 4. Exact program match or unknown — deliver anyway (it'll queue)
+  // 3. Exact program match or unknown — deliver anyway (it'll queue)
   return [target];
 }
 
@@ -346,6 +416,11 @@ export async function updateProgramHandler(auth: AuthContext, rawArgs: unknown):
   // Invalidate caches
   invalidateCache(auth.userId, args.programId);
   invalidateListCache(auth.userId);
+  // Group membership changed — flush all group entries for this tenant so
+  // resolveGroupAsync returns fresh results on next call.
+  if (args.groups !== undefined) {
+    invalidateGroupCache(auth.userId);
+  }
 
   return jsonResult({
     success: true,

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -8,8 +8,8 @@ import { verifySource, isAdmin, logAudit, generateCorrelationId } from "../middl
 import * as admin from "firebase-admin";
 import { AuthContext } from "../auth/authValidator.js";
 import { RELAY_DEFAULT_TTL_SECONDS } from "../types/relay.js";
-import { isGroupTarget, PROGRAM_GROUPS } from "../config/programs.js";
-import { resolveTargetsAsync } from "./programRegistry.js";
+import { isGroupTarget } from "../config/programs.js";
+import { resolveTargetsAsync, listGroupsAsync } from "./programRegistry.js";
 import { validatePayload } from "../types/relay-schemas.js";
 import { emitEvent } from "./events.js";
 import { emitAnalyticsEvent } from "./analytics.js";
@@ -846,11 +846,8 @@ export async function sendDirectiveHandler(auth: AuthContext, args: unknown): Pr
   }
 }
 
-export async function listGroupsHandler(_auth: AuthContext, _rawArgs: unknown): Promise<ToolResult> {
-  const groups: Record<string, string[]> = {};
-  for (const [name, members] of Object.entries(PROGRAM_GROUPS)) {
-    groups[name] = [...members];
-  }
+export async function listGroupsHandler(auth: AuthContext, _rawArgs: unknown): Promise<ToolResult> {
+  const groups = await listGroupsAsync(auth.userId);
   return {
     content: [{ type: "text", text: JSON.stringify({
       success: true,


### PR DESCRIPTION
## Summary

- **`resolveGroupAsync(userId, groupName)`**: queries `tenants/{uid}/programs` where `groups` array-contains `groupName` and `active==true`. Results cached for 60s per tenant+group. Falls back to hardcoded `PROGRAM_GROUPS` on empty result (unseeded tenant) or Firestore error.
- **`listGroupsAsync(userId)`**: resolves all known group names via `resolveGroupAsync` — `listGroupsHandler` now returns live membership.
- **`resolveTargetsAsync`**: named groups now route through `resolveGroupAsync` instead of reading hardcoded members directly. Static group *names* in `PROGRAM_GROUPS` remain the authoritative registry of known group names; only *members* are now dynamic.
- **Cache invalidation**: `updateProgramHandler` flushes all group entries for the tenant when a program's `groups` field is updated.
- **Static fallback preserved**: unseeded tenants and Firestore unavailability degrade gracefully to the hardcoded lists — no behavioral regression.

## Test plan

- [x] `npx jest program-registry` — 8 tests pass (Firestore path, empty fallback, error fallback, 60s cache, group dispatch via resolveTargetsAsync, listGroupsAsync shape)
- [x] Full unit suite — 558 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)