### PR TITLE
fix(scheduler): wire execute-schedules job + fix getActiveUserIds collection

### DIFF
--- a/services/mcp-server/scripts/setup-schedulers.sh
+++ b/services/mcp-server/scripts/setup-schedulers.sh
@@ -2,39 +2,38 @@
 # Cloud Scheduler setup for CacheBash internal jobs
 # Run once per environment. Requires gcloud CLI authenticated to cachebash-app project.
 #
-# IMPORTANT: Set INTERNAL_API_KEY environment variable before running:
-#   export INTERNAL_API_KEY="your-api-key-here"
+# All jobs authenticate via OIDC using the cachebash-scheduler service account.
+# The scheduler SA must have Cloud Run Invoker on the Cloud Run service.
 #
-# This API key is used by Cloud Scheduler to authenticate to internal endpoints.
-# The key must be a valid CacheBash API key (cb_* prefix).
+# Usage:
+#   export CLOUD_RUN_URL="https://cachebash-mcp-922749444863.us-central1.run.app"
+#   export SCHEDULER_SA="cachebash-scheduler@cachebash-app.iam.gserviceaccount.com"
+#   bash setup-schedulers.sh
 
 set -euo pipefail
 
-if [ -z "${INTERNAL_API_KEY:-}" ]; then
-  echo "Error: INTERNAL_API_KEY environment variable is not set"
-  echo "Please set it with: export INTERNAL_API_KEY=\"your-api-key-here\""
-  exit 1
-fi
-
 PROJECT="cachebash-app"
 REGION="us-central1"
-SERVICE_URL="https://api.cachebash.dev"
+CLOUD_RUN_URL="${CLOUD_RUN_URL:-https://cachebash-mcp-922749444863.us-central1.run.app}"
+SCHEDULER_SA="${SCHEDULER_SA:-cachebash-scheduler@cachebash-app.iam.gserviceaccount.com}"
 
 echo "=== Creating/updating wake daemon scheduler (every 60s) ==="
 gcloud scheduler jobs create http cachebash-wake-daemon \
   --schedule="* * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/wake" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/wake" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Wake daemon: polls for orphaned tasks and spawns idle programs" \
   --attempt-deadline="30s" 2>/dev/null || \
 gcloud scheduler jobs update http cachebash-wake-daemon \
   --schedule="* * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/wake" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/wake" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Wake daemon: polls for orphaned tasks and spawns idle programs" \
@@ -44,18 +43,20 @@ echo ""
 echo "=== Creating/updating TTL reaper scheduler (every 5min) ==="
 gcloud scheduler jobs create http cachebash-ttl-reaper \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/cleanup" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/cleanup" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="TTL Reaper: cleans expired sessions, relay messages, idempotency keys" \
   --attempt-deadline="60s" 2>/dev/null || \
 gcloud scheduler jobs update http cachebash-ttl-reaper \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/cleanup" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/cleanup" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="TTL Reaper: cleans expired sessions, relay messages, idempotency keys" \
@@ -65,18 +66,20 @@ echo ""
 echo "=== Creating/updating GitHub reconciliation scheduler (every 15min) ==="
 gcloud scheduler jobs create http cachebash-github-reconcile \
   --schedule="*/15 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/reconcile-github" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/reconcile-github" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="GitHub Reconciliation: retries failed GitHub sync operations" \
   --attempt-deadline="120s" 2>/dev/null || \
 gcloud scheduler jobs update http cachebash-github-reconcile \
   --schedule="*/15 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/reconcile-github" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/reconcile-github" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="GitHub Reconciliation: retries failed GitHub sync operations" \
@@ -86,18 +89,20 @@ echo ""
 echo "=== Creating/updating health check scheduler (every 5min) ==="
 gcloud scheduler jobs create http cachebash-health-check \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/health-check" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/health-check" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Health Check: monitors health indicators, routes alerts" \
   --attempt-deadline="60s" 2>/dev/null || \
 gcloud scheduler jobs update http cachebash-health-check \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/health-check" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/health-check" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Health Check: monitors health indicators, routes alerts" \
@@ -107,22 +112,47 @@ echo ""
 echo "=== Creating/updating stale sessions detector scheduler (every 5min) ==="
 gcloud scheduler jobs create http cachebash-stale-sessions \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/stale-sessions" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/stale-sessions" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Stale Session Detector: identifies and archives sessions with no recent heartbeat" \
   --attempt-deadline="60s" 2>/dev/null || \
 gcloud scheduler jobs update http cachebash-stale-sessions \
   --schedule="*/5 * * * *" \
-  --uri="${SERVICE_URL}/v1/internal/stale-sessions" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/stale-sessions" \
   --http-method=POST \
-  --headers="Authorization=Bearer ${INTERNAL_API_KEY}" \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
   --location="$REGION" \
   --project="$PROJECT" \
   --description="Stale Session Detector: identifies and archives sessions with no recent heartbeat" \
   --attempt-deadline="60s"
+
+echo ""
+echo "=== Creating/updating schedule executor (every 60s) ==="
+gcloud scheduler jobs create http cachebash-execute-schedules \
+  --schedule="* * * * *" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/execute-schedules" \
+  --http-method=POST \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="Schedule Executor: evaluates cron expressions and creates tasks for due user schedules" \
+  --attempt-deadline="30s" 2>/dev/null || \
+gcloud scheduler jobs update http cachebash-execute-schedules \
+  --schedule="* * * * *" \
+  --uri="${CLOUD_RUN_URL}/v1/internal/execute-schedules" \
+  --http-method=POST \
+  --oidc-service-account-email="${SCHEDULER_SA}" \
+  --oidc-token-audience="${CLOUD_RUN_URL}" \
+  --location="$REGION" \
+  --project="$PROJECT" \
+  --description="Schedule Executor: evaluates cron expressions and creates tasks for due user schedules" \
+  --attempt-deadline="30s"
 
 echo ""
 echo "=== Done. Verify with: ==="

--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -85,7 +85,7 @@ async function getActiveUserIds(): Promise<string[]> {
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
     const keysSnapshot = await db
-      .collection("apiKeys")
+      .collection("keyIndex")
       .where("lastUsedAt", ">=", sevenDaysAgo)
       .get();
 


### PR DESCRIPTION
## Root Cause

Three compounding bugs prevented all user-defined schedules from ever firing — all schedules had `lastRunAt:null` since creation (some months old, including the YB safety gate).

### Bug 1: Missing Cloud Scheduler job (primary)

The `/v1/internal/execute-schedules` endpoint and `executeSchedulesForUser()` code were complete and correct, but **no Cloud Scheduler job ever called the endpoint**. The `setup-schedulers.sh` script only created: wake-daemon, ttl-reaper, github-reconcile, health-check, stale-sessions — `cachebash-execute-schedules` was never in it.

**Fix:** Created `cachebash-execute-schedules` (every minute, OIDC auth) and added it to `setup-schedulers.sh`.

### Bug 2: Wrong Firestore collection in `getActiveUserIds()` (silent empty return)

`getActiveUserIds()` queried `db.collection("apiKeys")` — a **top-level collection that doesn't exist**. API keys are stored at `keyIndex/{keyHash}`. Result: executor always found 0 active users → fired nothing → returned HTTP 200 with `totalFired: 0`.

**Fix:** `"apiKeys"` → `"keyIndex"` in `index.ts`.

### Bug 3: OIDC audience mismatch (all `/v1/internal/*` endpoints 403'd)

`INTERNAL_OIDC_AUDIENCE` env var was missing on Cloud Run. Server defaulted to `"https://api.cachebash.dev"` but scheduler jobs send OIDC tokens with `"https://cachebash-mcp-922749444863.us-central1.run.app"` as the audience → every `/v1/internal/*` call was rejected with 403. **This means wake-daemon, ttl-reaper, health-check were also broken.**

**Fix:** Added `INTERNAL_OIDC_AUDIENCE=https://cachebash-mcp-922749444863.us-central1.run.app` as Cloud Run env var (done via `gcloud run services update`).

## Also in this PR

- `setup-schedulers.sh` updated to use OIDC auth (matching actual deployed pattern; old static Bearer key approach was pre-OIDC and never reflected live config)

## Proof

After deploy, manual trigger of `cachebash-execute-schedules`:

```
All 4 schedules: lastRunAt: "2026-06-11T16:13:14.003Z"

BASHER-TEST (*/1):     nextRunAt: 2026-06-11T16:14:00.000Z ✓
YB pre-open gate:      nextRunAt: 2026-06-12T12:45:00.000Z ✓ (fires tomorrow 05:45 PT)
Fleet full-throttle:   nextRunAt: 2026-06-11T18:00:00.000Z ✓
Weekly consolidation:  nextRunAt: 2026-06-15T15:00:00.000Z ✓
```

YB pre-open gate (`s6jXVto1g3GVNZCQUUqB`) **confirmed to fire tomorrow 2026-06-12 at 12:45 UTC / 05:45 PT**.

## Schedule Sweep

- Deleted `TtdZH86VSZSkbYRZfS9T` (Oracle 50-Trade Decision Gate) — annual one-shot, stuck April 2026, Oracle program months stale; would have caused spurious fire
- Test schedule (`39oA3JRvO6MIefKaC3Np`) created for proof, deleted after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)