### PR TITLE
feat(mcp-server): IS_LITE deploy profile flag (CACHEBASH_PROFILE=lite)

### DIFF
--- a/services/mcp-server/src/tools/index.ts
+++ b/services/mcp-server/src/tools/index.ts
@@ -1,6 +1,12 @@
 /**
  * Tool Registry — Merges all domain registries into unified TOOL_HANDLERS and TOOL_DEFINITIONS.
  * 73 handlers across 21 domain registries.
+ *
+ * Deploy profiles (CACHEBASH_PROFILE env var):
+ *   "full" (default) — all modules; Grid prod (cachebash-app)
+ *   "lite"           — core modules only; tenant deployments (cerebro-grid, future tenants)
+ *                      Excludes: dream, schedule, clu, patternConsolidation, usage
+ *                      Spec: cerebro/cachebash-lite.profile.js in rezzedai/grid
  */
 import { AuthContext } from "../auth/authValidator.js";
 
@@ -28,28 +34,31 @@ import * as webhook from "./webhook.js";
 
 type Handler = (auth: AuthContext, args: any) => Promise<any>;
 
+const IS_LITE = (process.env.CACHEBASH_PROFILE ?? "full") === "lite";
+
 export const TOOL_HANDLERS: Record<string, Handler> = {
   ...dispatch.handlers,
   ...relay.handlers,
   ...pulse.handlers,
   ...signal.handlers,
-  ...dream.handlers,
   ...sprint.handlers,
   ...keys.handlers,
   ...programs.handlers,
   ...audit.handlers,
   ...programState.handlers,
   ...metrics.handlers,
-  ...usage.handlers,
   ...trace.handlers,
   ...feedback.handlers,
-  ...clu.handlers,
   ...admin.handlers,
   ...gsp.handlers,
-  ...patternConsolidation.handlers,
-  ...schedule.handlers,
   ...policy.handlers,
   ...webhook.handlers,
+  // enrichment/analytics tier — omitted in lite profile
+  ...(!IS_LITE ? dream.handlers : {}),
+  ...(!IS_LITE ? usage.handlers : {}),
+  ...(!IS_LITE ? clu.handlers : {}),
+  ...(!IS_LITE ? patternConsolidation.handlers : {}),
+  ...(!IS_LITE ? schedule.handlers : {}),
 };
 
 export const TOOL_DEFINITIONS = [
@@ -57,21 +66,22 @@ export const TOOL_DEFINITIONS = [
   ...relay.definitions,
   ...pulse.definitions,
   ...signal.definitions,
-  ...dream.definitions,
   ...sprint.definitions,
   ...keys.definitions,
   ...programs.definitions,
   ...audit.definitions,
   ...programState.definitions,
   ...metrics.definitions,
-  ...usage.definitions,
   ...trace.definitions,
   ...feedback.definitions,
-  ...clu.definitions,
   ...admin.definitions,
   ...gsp.definitions,
-  ...patternConsolidation.definitions,
-  ...schedule.definitions,
   ...policy.definitions,
   ...webhook.definitions,
+  // enrichment/analytics tier — omitted in lite profile
+  ...(!IS_LITE ? dream.definitions : []),
+  ...(!IS_LITE ? usage.definitions : []),
+  ...(!IS_LITE ? clu.definitions : []),
+  ...(!IS_LITE ? patternConsolidation.definitions : []),
+  ...(!IS_LITE ? schedule.definitions : []),
 ];


### PR DESCRIPTION
## Summary

- Wires the CacheBash-lite deploy profile from [rezzedai/grid#817](https://github.com/rezzedai/grid/pull/817).
- Single `IS_LITE` constant read from `process.env.CACHEBASH_PROFILE` (defaults to `"full"`).
- `CACHEBASH_PROFILE=full`: all 21 modules — Grid prod (`cachebash-app`) unchanged.
- `CACHEBASH_PROFILE=lite`: 16 core modules — tenant deployments (`cerebro-grid`, future tenants).

## Excluded in lite profile

`dream`, `schedule`, `clu`, `patternConsolidation`, `usage`

## Verification

- TypeScript: `tsc --noEmit` exits 0.
- Same main SHA deploys both profiles — no fork, no divergence.
- CI should add: `build:full` (`CACHEBASH_PROFILE=full`) + `build:lite` (`CACHEBASH_PROFILE=lite`) both pass.

## Spec

`cerebro/cachebash-lite.profile.js` in rezzedai/grid (PR #817).

🤖 Generated with [Claude Code](https://claude.com/claude-code)