### PR TITLE
fix(dispatch): Fix-B/P0 — STATUS/RESULT task drain + boot query defaults + session ownership (#847)

### DIFF
--- a/services/mcp-server/src/modules/dispatch/tasks.ts
+++ b/services/mcp-server/src/modules/dispatch/tasks.ts
@@ -23,13 +23,19 @@ const GetTasksSchema = z.object({
   type: z.enum(["task", "question", "dream", "sprint", "sprint-story", "all"]).default("all"),
   target: z.string().max(100).optional(),
   limit: z.number().min(1).max(50).default(10),
-  requires_action: z.boolean().optional(),
+  // Default true: boot queries scope to actionable tasks only. Pass false for informational tasks,
+  // null to bypass the filter entirely (audit/export use cases).
+  requires_action: z.boolean().nullable().default(true),
   include_archived: z.boolean().default(false),
+  // Default false: omit instruction bodies to keep boot payloads small. Fetch full body via get_task_by_id.
+  include_instructions: z.boolean().default(false),
 });
 
 const CreateTaskSchema = z.object({
   title: z.string().max(200),
   instructions: z.string().max(32000).optional(),
+  // message_type drives requires_action classification and STATUS/RESULT drain semantics.
+  message_type: z.enum(["DIRECTIVE", "QUERY", "HANDSHAKE", "ACK", "STATUS", "PING", "PONG", "RESULT"]).optional(),
   type: z.enum(["task", "question", "dream", "sprint", "sprint-story"]).default("task"),
   priority: z.enum(["low", "normal", "high"]).default("normal"),
   action: z.enum(["interrupt", "sprint", "parallel", "queue", "backlog"]).default("queue"),
@@ -119,8 +125,8 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
   const tasks = snapshot.docs
     .filter((doc) => {
       const data = doc.data();
-      // Filter by requires_action if specified
-      if (args.requires_action !== undefined) {
+      // Filter by requires_action: null = no filter, true/false = exact match
+      if (args.requires_action !== null) {
         const reqAction = data.requires_action ?? true; // default true for legacy tasks
         if (reqAction !== args.requires_action) return false;
       }
@@ -137,7 +143,7 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
       const data = doc.data();
       const decrypted = decryptTaskFields(data, auth.encryptionKey);
 
-      // Auto-archive informational tasks on read
+      // Auto-archive informational tasks on read (fallback for tasks created pre-schema-fix)
       if (data.requires_action === false && !data.auto_archived) {
         autoArchiveRefs.push(doc.ref);
       }
@@ -146,7 +152,9 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
         id: doc.id,
         type: data.type || "task",
         title: decrypted.title,
-        instructions: decrypted.instructions,
+        // Omit instruction body by default — callers fetch full body via get_task_by_id on demand.
+        // This keeps boot payloads small regardless of pile size.
+        instructions: args.include_instructions ? decrypted.instructions : undefined,
         action: data.action || "queue",
         priority: data.priority || "normal",
         status: data.status,
@@ -226,6 +234,8 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
     createdAt: now,
     encrypted: false,
     archived: false,
+    // message_type drives classification and drain semantics (STATUS/RESULT).
+    message_type: args.message_type || null,
     // Envelope v2.1
     ttl: args.ttl || null,
     replyTo: args.replyTo || null,
@@ -238,13 +248,26 @@ export async function createTaskHandler(auth: AuthContext, rawArgs: unknown): Pr
     parentSpanId: args.parentSpanId || null,
   };
 
-    // Auto-classification: requires_action
-    taskData.requires_action = classifyRequiresAction(taskData);
-    taskData.auto_archived = false;
+  // Auto-classification: requires_action
+  taskData.requires_action = classifyRequiresAction(taskData);
+  taskData.auto_archived = false;
 
-    // Telemetry: classify task
-    taskData.task_class = classifyTask(args.type, args.action, args.title);
-    taskData.attempt_count = 0;
+  // Drain semantics for report-type tasks (council-ruled #847/#846):
+  // STATUS: informational, latest subsumes prior — never enter `created` pool.
+  if (args.message_type === "STATUS" && taskData.requires_action === false) {
+    taskData.auto_archived = true;
+  }
+  // RESULT (non-failed): auto-complete to `done` on create — preserves get_task_lineage/audit
+  // history while draining the boot query. Failed RESULTs remain actionable (requires_action:true).
+  if (args.message_type === "RESULT" && taskData.requires_action === false) {
+    taskData.status = "done";
+    taskData.completed_status = "SUCCESS";
+    taskData.completedAt = now;
+  }
+
+  // Telemetry: classify task
+  taskData.task_class = classifyTask(args.type, args.action, args.title);
+  taskData.attempt_count = 0;
 
   // Default 24h TTL for type=task; other types (dream, sprint, question) have no default TTL
   const effectiveTtl = args.ttl || (args.type === "task" ? CONSTANTS.ttl.defaultTaskSeconds : null);

--- a/services/mcp-server/src/modules/pulse.ts
+++ b/services/mcp-server/src/modules/pulse.ts
@@ -188,6 +188,26 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
     console.warn(`[W1.2.1] Legacy session ID format used: ${sessionId}. Consider using: {program}[-{env}].{task}`);
   }
 
+  // SARK C2 (#847): Bind update_session to the authenticating key's program.
+  // Reject cross-session writes to prevent a confused-deputy attack where any
+  // key with pulse.write could set handoffRequired on a sibling's session.
+  // Admin keys (legacy/mobile/dispatcher) retain full access for supervision.
+  const callerProgramId = auth.programId;
+  const isPrivileged = !callerProgramId || callerProgramId === "legacy"
+    || callerProgramId === "mobile" || callerProgramId === "dispatcher";
+  if (!isPrivileged) {
+    // Session ID prefix is the program name: "iso" in "iso.task123", "basher" in "basher-g2.task"
+    const sessionPrefix = sessionId.split(".")[0].split("-")[0];
+    if (sessionPrefix !== callerProgramId) {
+      console.warn(`[C2] Cross-session write rejected: caller="${callerProgramId}" session="${sessionId}"`);
+      return jsonResult({
+        success: false,
+        error: `Cannot update another program's session. Caller "${callerProgramId}" cannot write to session "${sessionId}".`,
+        sessionId,
+      });
+    }
+  }
+
   const now = serverTimestamp();
   const lifecycleStatus = stateToLifecycle(args.state || "working");
 
@@ -597,6 +617,10 @@ export async function listSessionsHandler(auth: AuthContext, rawArgs: unknown): 
       projectName: data.projectName,
       lastUpdate: data.lastUpdate?.toDate?.()?.toISOString() || null,
       archived: data.archived || false,
+      // Expose handoffRequired so the dispatcher's getSessions() can trigger managed recycle.
+      handoffRequired: data.handoffRequired || false,
+      lastHeartbeat: data.lastHeartbeat?.toDate?.()?.toISOString() || null,
+      contextBytes: data.contextBytes ?? null,
     };
   });
 

--- a/services/mcp-server/src/tools/dispatch.ts
+++ b/services/mcp-server/src/tools/dispatch.ts
@@ -34,7 +34,7 @@ export const handlers: Record<string, Handler> = {
 export const definitions = [
   {
     name: "dispatch_get_tasks",
-    description: "Get tasks created for programs to work on.",
+    description: "Get tasks created for programs to work on. Boot default: requires_action=true (actionable only), titles+IDs only (fetch body via get_task_by_id).",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -42,8 +42,9 @@ export const definitions = [
         type: { type: "string", enum: ["task", "question", "dream", "sprint", "sprint-story", "all"], default: "all" },
         target: { type: "string", description: "Filter by target program ID", maxLength: 100 },
         limit: { type: "number", minimum: 1, maximum: 50, default: 10 },
-        requires_action: { type: "boolean", description: "Filter by actionability (true = actionable, false = informational)" },
+        requires_action: { type: ["boolean", "null"], default: true, description: "true=actionable only (default), false=informational only, null=no filter" },
         include_archived: { type: "boolean", default: false, description: "Include auto-archived informational tasks" },
+        include_instructions: { type: "boolean", default: false, description: "Include full instruction bodies. Default false keeps boot payload small; fetch body on demand via get_task_by_id." },
       },
     },
   },
@@ -60,12 +61,13 @@ export const definitions = [
   },
   {
     name: "dispatch_create_task",
-    description: "Create a new task for a program to work on",
+    description: "Create a new task for a program to work on. STATUS tasks auto-archive on create. RESULT (non-failed) tasks auto-complete to done.",
     inputSchema: {
       type: "object" as const,
       properties: {
         title: { type: "string", maxLength: 200 },
         instructions: { type: "string", maxLength: 32000 },
+        message_type: { type: "string", enum: ["DIRECTIVE", "QUERY", "HANDSHAKE", "ACK", "STATUS", "PING", "PONG", "RESULT"], description: "Message type — drives requires_action classification and STATUS/RESULT drain semantics" },
         type: { type: "string", enum: ["task", "question", "dream", "sprint", "sprint-story"], default: "task" },
         priority: { type: "string", enum: ["low", "normal", "high"], default: "normal" },
         action: { type: "string", enum: ["interrupt", "sprint", "parallel", "queue", "backlog"], default: "queue" },


### PR DESCRIPTION
## Summary
Council-ruled Fix-B/P0 from recycle-spiral remediation (grid#847). Breaks the boot-reload spiral by preventing STATUS/RESULT report-tasks from accumulating in the `created` pool.

## Changes
- **STATUS tasks** (`message_type:STATUS`): `auto_archived:true` on create — never enter `created` pool (ALAN ruling: informational, latest subsumes prior)
- **RESULT tasks** (non-failed, `message_type:RESULT`): `status:done` + `completed_status:SUCCESS` auto-set on create — preserves `get_task_lineage`/audit history while draining boot query (ALAN gate condition: archive would destroy lineage)
- `message_type` added to `CreateTaskSchema` — previously stripped by Zod, so `classifyRequiresAction` could never detect STATUS/RESULT (root cause of the unbounded pile)
- `get_tasks` defaults: `requires_action` now defaults to `true`; new `include_instructions` field defaults to `false` (titles+IDs only on boot)
- `list_sessions` now returns `handoffRequired`, `lastHeartbeat`, `contextBytes` — previously stored but never returned, blocking the dispatcher API recycle trigger (Root Cause A #1 from #847)
- `updateSessionHandler` session ownership check (SARK C2): rejects cross-session writes from non-admin keys

## Proof
```
# created pile with requires_action:false = 0 (ISO already drained 33 tasks this session)
get_tasks(status=created, requires_action=false) → count: 0 ✓

# typecheck: clean
npx tsc --noEmit → 0 errors ✓

# tests: all pass
npm test -- --testPathPattern="tasks|pulse" → 12 passed ✓
```

## Gate
- ALAN STATUS/RESULT split ✓ (auto-archive vs auto-complete, not conflated)
- SARK C2 session ownership ✓
- `handoffRequired` now surfaced in list_sessions ✓ (unblocks Fix-A dispatcher trigger)

Authority: grid/decisions/vector-assessment-fleet-recycle-spiral.md (#847), grid/decisions/alan-assessment-recycle-spiral-fix.md (#846)

🤖 Generated with [Claude Code](https://claude.com/claude-code)