### PR TITLE
fix(dispatch): complete_task owner/ISO/admin auth gate (SARK C3/CRITICAL)

### DIFF
--- a/services/mcp-server/src/__tests__/completion-authz.test.ts
+++ b/services/mcp-server/src/__tests__/completion-authz.test.ts
@@ -1,0 +1,108 @@
+/**
+ * complete_task ownership gate (SARK C3/CRITICAL, 2026-03-18).
+ *
+ * completeTaskHandler had no authorization check — any program key could mark
+ * any task done/failed. This suite proves the gate added in this PR is correct.
+ *
+ * Authorized callers: task claimedBy owner, matching session, "iso",
+ * "orchestrator", "legacy", "dispatcher".
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+const mockTx = { get: jest.fn(), update: jest.fn() };
+const mockCollection = { add: jest.fn(() => Promise.resolve()) };
+
+// Flexible doc mock: compliance + billing docs return { exists: false } (defaults to lenient/no-budget);
+// the task ref is handled via mockTx.get inside the transaction.
+const mockDoc = jest.fn(() => ({
+  path: "tenants/u1/tasks/t1",
+  get: jest.fn(() => Promise.resolve({ exists: false })),
+}));
+
+const mockDb = {
+  doc: mockDoc,
+  runTransaction: jest.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+  collection: jest.fn(() => mockCollection),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-ts"),
+}));
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn() }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+jest.mock("../modules/github-sync.js", () => ({ syncTaskCompleted: jest.fn() }));
+
+import { completeTaskHandler } from "../modules/dispatch/completion.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+const ENC = Buffer.from("test-encryption-key-32-bytes-long!!!");
+
+function auth(programId: string): AuthContext {
+  return { userId: "u1", programId, apiKeyHash: "h", encryptionKey: ENC, capabilities: ["*"], rateLimitTier: "internal" } as AuthContext;
+}
+
+function taskDoc(claimedBy: string | null) {
+  const data = () => ({
+    status: "active",
+    claimedBy,
+    sessionId: claimedBy ?? null,
+    policy_mode: null,
+    stateTransitions: [],
+    title: "test",
+    type: "task",
+    priority: "normal",
+  });
+  mockTx.get.mockResolvedValue({ exists: true, data });
+  mockDoc.mockReturnValue({ path: "tenants/u1/tasks/t1", get: jest.fn(() => Promise.resolve({ exists: false })) });
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const ARGS = { taskId: "t1", completed_status: "SUCCESS" as const, result: "done", model: "sonnet", provider: "anthropic" };
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe("complete_task authorization gate (SARK C3)", () => {
+  it("REJECTS a non-owner non-admin key completing another program's task", async () => {
+    taskDoc("quorra"); // quorra claimed it
+    const res = parse(await completeTaskHandler(auth("basher"), ARGS) as never);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Unauthorized/);
+    expect(mockTx.update).not.toHaveBeenCalled();
+  });
+
+  it("ALLOWS the claiming owner to complete its own task", async () => {
+    taskDoc("basher");
+    const res = parse(await completeTaskHandler(auth("basher"), ARGS) as never);
+    expect(res.success).toBe(true);
+  });
+
+  it("ALLOWS iso to complete any task", async () => {
+    taskDoc("basher");
+    const res = parse(await completeTaskHandler(auth("iso"), ARGS) as never);
+    expect(res.success).toBe(true);
+  });
+
+  it("ALLOWS orchestrator (iso alias) to complete any task", async () => {
+    taskDoc("basher");
+    const res = parse(await completeTaskHandler(auth("orchestrator"), ARGS) as never);
+    expect(res.success).toBe(true);
+  });
+
+  it("ALLOWS dispatcher (admin) to complete any task", async () => {
+    taskDoc("basher");
+    const res = parse(await completeTaskHandler(auth("dispatcher"), ARGS) as never);
+    expect(res.success).toBe(true);
+  });
+
+  it("REJECTS an unrelated program even if task is unclaimed", async () => {
+    taskDoc(null); // nobody claimed it
+    const res = parse(await completeTaskHandler(auth("basher"), ARGS) as never);
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Unauthorized/);
+  });
+});

--- a/services/mcp-server/src/__tests__/completion-authz.test.ts
+++ b/services/mcp-server/src/__tests__/completion-authz.test.ts
@@ -34,7 +34,7 @@ jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn() }));
 jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
 jest.mock("../modules/github-sync.js", () => ({ syncTaskCompleted: jest.fn() }));
 
-import { completeTaskHandler } from "../modules/dispatch/completion.js";
+import { completeTaskHandler, batchCompleteTasksHandler } from "../modules/dispatch/completion.js";
 import type { AuthContext } from "../auth/authValidator.js";
 
 const ENC = Buffer.from("test-encryption-key-32-bytes-long!!!");
@@ -104,5 +104,31 @@ describe("complete_task authorization gate (SARK C3)", () => {
     const res = parse(await completeTaskHandler(auth("basher"), ARGS) as never);
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/Unauthorized/);
+  });
+});
+
+describe("batch_complete_tasks authorization gate (SARK C3 bypass fix)", () => {
+  const BATCH_ARGS = { taskIds: ["t1"], completed_status: "SUCCESS" as const, result: "done", model: "sonnet", provider: "anthropic" };
+
+  it("REJECTS a non-owner completing another program's task via batch", async () => {
+    taskDoc("quorra");
+    const res = parse(await batchCompleteTasksHandler(auth("basher"), BATCH_ARGS) as never);
+    // batch handler returns per-task results array; the quorra-owned task should fail
+    expect(res.success).toBe(true); // outer success (batch processed)
+    expect(res.results[0].success).toBe(false);
+    expect(res.results[0].error).toMatch(/Unauthorized/);
+    expect(mockTx.update).not.toHaveBeenCalled();
+  });
+
+  it("ALLOWS the claiming owner to complete via batch", async () => {
+    taskDoc("basher");
+    const res = parse(await batchCompleteTasksHandler(auth("basher"), BATCH_ARGS) as never);
+    expect(res.results[0].success).toBe(true);
+  });
+
+  it("ALLOWS iso to complete any task via batch", async () => {
+    taskDoc("basher");
+    const res = parse(await batchCompleteTasksHandler(auth("iso"), BATCH_ARGS) as never);
+    expect(res.results[0].success).toBe(true);
   });
 });

--- a/services/mcp-server/src/modules/dispatch/completion.ts
+++ b/services/mcp-server/src/modules/dispatch/completion.ts
@@ -491,6 +491,16 @@ export async function completeTaskHandler(auth: AuthContext, rawArgs: unknown): 
       const data = doc.data()!;
       const current = data.status as LifecycleStatus;
 
+      // Authorization: only the claiming owner, the claiming session, ISO/orchestrator, or admin.
+      const isClaimingOwner = data.claimedBy != null && data.claimedBy === auth.programId;
+      const isClaimingSession = (data.sessionId as string | undefined) != null && data.sessionId === auth.programId;
+      const isIso = auth.programId === "iso" || auth.programId === "orchestrator";
+      const isAdminProgram = auth.programId === "legacy" || auth.programId === "dispatcher";
+      if (!isClaimingOwner && !isClaimingSession && !isIso && !isAdminProgram) {
+        console.warn(`[complete_task] AUTHZ_DENY programId=${auth.programId} taskId=${args.taskId} claimedBy=${data.claimedBy}`);
+        throw new Error("Unauthorized: only the claiming owner, ISO, or admin can complete this task.");
+      }
+
       // Capture task data for provenance hashing and budget tracking (before transaction completes)
       taskData = {
         instructions: data.instructions as string | undefined,

--- a/services/mcp-server/src/modules/dispatch/completion.ts
+++ b/services/mcp-server/src/modules/dispatch/completion.ts
@@ -798,6 +798,16 @@ export async function batchCompleteTasksHandler(auth: AuthContext, rawArgs: unkn
         const current = data.status as LifecycleStatus;
         taskData = { instructions: data.instructions, source: data.source, target: data.target, dreamId: data.dreamId };
 
+        // Authorization: mirrors completeTaskHandler gate.
+        const isClaimingOwner = data.claimedBy != null && data.claimedBy === auth.programId;
+        const isClaimingSession = (data.sessionId as string | undefined) != null && data.sessionId === auth.programId;
+        const isIso = auth.programId === "iso" || auth.programId === "orchestrator";
+        const isAdminProgram = auth.programId === "legacy" || auth.programId === "dispatcher";
+        if (!isClaimingOwner && !isClaimingSession && !isIso && !isAdminProgram) {
+          console.warn(`[batch_complete_tasks] AUTHZ_DENY programId=${auth.programId} taskId=${taskId} claimedBy=${data.claimedBy}`);
+          throw new Error("Unauthorized: only the claiming owner, ISO, or admin can complete this task.");
+        }
+
         const lifecycleTarget = args.completed_status === "FAILED" ? "failed" : "done";
         transition("task", current, lifecycleTarget as LifecycleStatus);
 


### PR DESCRIPTION
## Summary

- `completeTaskHandler` had no authorization check — any program key could mark any task SUCCESS/FAILED regardless of ownership (open since 2026-03-18, SARK C3/CRITICAL)
- Added owner/ISO/admin gate **inside the Firestore transaction** on the authoritative DB-read `claimedBy`/`sessionId`, mirroring `unclaimTaskHandler` exactly
- SARK round-1 KILL found `batchCompleteTasksHandler` was an unguarded bypass — fixed in the same PR with identical gate logic
- 9 unit tests covering reject (non-owner, unclaimed task) and allow (owner, iso, orchestrator, dispatcher) paths for both handlers

## SARK Gate — PASS (Voter 1)

```json
{
  "voter_id": 1,
  "branch": "grid/basher/p0-complete-task-auth",
  "verdict": "PASS",
  "findings": [],
  "summary": "Both handlers gate inside their Firestore transactions on authoritative DB-read claimedBy/sessionId. Gate logic is identical. Batch rejection is per-task and non-aborting. recordTaskTelemetryHandler has independent auth. No bypass paths found."
}
```

## Test plan

- [x] `npm run build` — tsc clean
- [x] `jest completion-authz` — 9/9 pass
- [x] Reject path: non-owner → `{ success: false, error: "Unauthorized..." }`, `tx.update` not called
- [x] Allow path: claimingOwner, iso, orchestrator, dispatcher → `{ success: true }`
- [x] Unclaimed task (`claimedBy: null`) with non-admin caller → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)