### PR TITLE
fix(portal): CORS + Firebase→Flynn mapping + GSP proposal REST endpoints

### DIFF
--- a/services/mcp-server/src/__tests__/firebaseAuthValidator.test.ts
+++ b/services/mcp-server/src/__tests__/firebaseAuthValidator.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for firebaseAuthValidator.ts
+ * Covers the PORTAL_PRINCIPALS UID-gating security fix.
+ */
+
+import { validateFirebaseToken } from '../auth/firebaseAuthValidator';
+
+const FLYNN_UID = '7viFKVtl5lgzguhFoZlnYYrqeDG2';
+
+const mockVerifyIdToken = jest.fn();
+
+jest.mock('firebase-admin', () => ({
+  auth: () => ({ verifyIdToken: mockVerifyIdToken }),
+}));
+
+jest.mock('../middleware/capabilities', () => ({
+  getDefaultCapabilities: (role: string) => [`${role}.read`],
+}));
+
+function makeToken(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: FLYNN_UID,
+    email: 'christian@rezzed.ai',
+    email_verified: true,
+    ...overrides,
+  };
+}
+
+describe('validateFirebaseToken', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('elevates to flynn when email + UID + email_verified all match', async () => {
+    mockVerifyIdToken.mockResolvedValue(makeToken());
+    const ctx = await validateFirebaseToken('eyJ.fake.token');
+    expect(ctx?.programId).toBe('flynn');
+    expect(ctx?.userId).toBe(FLYNN_UID);
+  });
+
+  it('falls through to mobile when email matches but UID is different', async () => {
+    mockVerifyIdToken.mockResolvedValue(makeToken({ uid: 'attacker-uid-not-flynn' }));
+    const ctx = await validateFirebaseToken('eyJ.fake.token');
+    expect(ctx?.programId).toBe('mobile');
+  });
+
+  it('falls through to mobile when email matches but email_verified is false', async () => {
+    mockVerifyIdToken.mockResolvedValue(makeToken({ email_verified: false }));
+    const ctx = await validateFirebaseToken('eyJ.fake.token');
+    expect(ctx?.programId).toBe('mobile');
+  });
+
+  it('falls through to mobile for an unknown email', async () => {
+    mockVerifyIdToken.mockResolvedValue(makeToken({ email: 'unknown@example.com', uid: 'some-uid' }));
+    const ctx = await validateFirebaseToken('eyJ.fake.token');
+    expect(ctx?.programId).toBe('mobile');
+  });
+
+  it('returns null when verifyIdToken throws', async () => {
+    mockVerifyIdToken.mockRejectedValue(new Error('token expired'));
+    const ctx = await validateFirebaseToken('eyJ.fake.token');
+    expect(ctx).toBeNull();
+  });
+});

--- a/services/mcp-server/src/auth/firebaseAuthValidator.ts
+++ b/services/mcp-server/src/auth/firebaseAuthValidator.ts
@@ -37,7 +37,7 @@ export async function validateFirebaseToken(
     const email = decoded.email?.toLowerCase();
     const principal = email ? PORTAL_PRINCIPALS[email] : undefined;
 
-    if (principal) {
+    if (principal && decoded.email_verified === true && decoded.uid === principal.userId) {
       return {
         userId: principal.userId,
         apiKeyHash: `firebase:${decoded.uid}`,

--- a/services/mcp-server/src/auth/firebaseAuthValidator.ts
+++ b/services/mcp-server/src/auth/firebaseAuthValidator.ts
@@ -2,9 +2,21 @@ import admin from "firebase-admin";
 import * as crypto from "crypto";
 import type { AuthContext } from "./authValidator.js";
 
+// Grid Portal principal map: Firebase email → { programId, userId, rateLimitTier }
+// These principals have named identities in the Grid and need elevated capabilities
+// (gsp.read + gsp.write) so they can ratify constitutional proposals.
+const PORTAL_PRINCIPALS: Record<string, { programId: string; userId: string; rateLimitTier: string }> = {
+  "christian@rezzed.ai": {
+    programId: "flynn",
+    userId: "7viFKVtl5lgzguhFoZlnYYrqeDG2",
+    rateLimitTier: "paid",
+  },
+};
+
 /**
  * Validate a Firebase ID token and return an AuthContext.
- * Used for mobile app authentication (OAuth 2.0 + PKCE flow).
+ * Known portal principals (e.g. christian@rezzed.ai) are mapped to their
+ * Grid programId so gsp_resolve reviewer checks pass correctly.
  */
 export async function validateFirebaseToken(
   idToken: string
@@ -12,8 +24,6 @@ export async function validateFirebaseToken(
   try {
     const decoded = await admin.auth().verifyIdToken(idToken);
 
-    // Create a deterministic encryption key from the Firebase UID
-    // (needed for AuthContext compatibility)
     const encryptionKey = crypto.pbkdf2Sync(
       decoded.uid,
       "cachebash_firebase_v1",
@@ -22,8 +32,21 @@ export async function validateFirebaseToken(
       "sha256"
     );
 
-    // Phase 4: Mobile gets scoped capabilities via defaults
     const { getDefaultCapabilities } = await import("../middleware/capabilities.js");
+
+    const email = decoded.email?.toLowerCase();
+    const principal = email ? PORTAL_PRINCIPALS[email] : undefined;
+
+    if (principal) {
+      return {
+        userId: principal.userId,
+        apiKeyHash: `firebase:${decoded.uid}`,
+        encryptionKey,
+        programId: principal.programId as any,
+        capabilities: getDefaultCapabilities("reviewer"),
+        rateLimitTier: principal.rateLimitTier,
+      };
+    }
 
     return {
       userId: decoded.uid,
@@ -34,7 +57,6 @@ export async function validateFirebaseToken(
       rateLimitTier: "free",
     };
   } catch (error) {
-    // Token expired, invalid, or revoked
     console.error("[Auth] Firebase token validation failed:", error instanceof Error ? error.message : String(error));
     return null;
   }

--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -302,9 +302,40 @@ async function main() {
   // Create REST router
   const restRouter = createRestRouter();
 
+  const ALLOWED_ORIGINS = [
+    "https://grid-portal.web.app",
+    "https://grid-portal.firebaseapp.com",
+    "http://localhost:5173",
+    "http://localhost:5174",
+  ];
+
+  function setCorsHeaders(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const origin = req.headers.origin;
+    if (origin && ALLOWED_ORIGINS.includes(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+    } else {
+      res.setHeader("Access-Control-Allow-Origin", "https://grid-portal.web.app");
+    }
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, Mcp-Session-Id, X-Program-Id");
+    res.setHeader("Access-Control-Max-Age", "86400");
+    res.setHeader("Vary", "Origin");
+  }
+
   // HTTP server
   const httpServer = http.createServer(async (req, res) => {
     const url = req.url?.split("?")[0];
+
+    // CORS preflight — must be before all auth/routing
+    if (req.method === "OPTIONS") {
+      setCorsHeaders(req, res);
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    // Attach CORS headers to all responses
+    setCorsHeaders(req, res);
 
     // Health check
     if (url === "/v1/health" && req.method === "GET") {

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -133,6 +133,7 @@ export const DEFAULT_CAPABILITIES: Record<string, Capability[]> = {
     "signal.read", "signal.write",
     "fleet.read", "metrics.read", "sprint.read",
     "programs.read",
+    "gsp.read",
   ],
   // Builder programs — standard operational set
   builder: ["dispatch.read", "dispatch.write", "relay.read", "relay.write",

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -13,7 +13,7 @@ import { getFirestore } from "../firebase/client.js";
 import * as admin from "firebase-admin";
 import { generateCorrelationId, createAuditLogger } from "../middleware/gate.js";
 import { dreamPeekHandler, dreamActivateHandler } from "../modules/dream.js";
-import { gspListNamespacesHandler } from "../modules/gsp.js";
+import { gspListNamespacesHandler, gspResolveHandler } from "../modules/gsp.js";
 import { enforceRateLimit, checkAuthRateLimit } from "../middleware/rateLimiter.js";
 import { checkSessionCompliance, resetTransportCompliance } from "../middleware/sessionCompliance.js";
 import { checkPricing } from "../middleware/pricingEnforce.js";
@@ -658,6 +658,45 @@ const routes: Route[] = [
     const body = await readBody(req);
     const data = await callTool(auth, req, "gsp_search", body);
     restResponse(res, true, data);
+  }),
+  // GSP Proposals — list pending proposals for the authenticated tenant
+  route("GET", "/v1/gsp/proposals", async (auth, req, res) => {
+    const query = coerceQueryParams(parseQuery(req.url || ""));
+    const db = getFirestore();
+    const colRef = db.collection(`tenants/${auth.userId}/gsp_proposals`);
+    const status = query.status as string | undefined;
+    let q: admin.firestore.Query = colRef;
+    if (status) {
+      q = q.where("status", "==", status);
+    }
+    q = q.orderBy("createdAt", "desc").limit(50);
+    const snap = await q.get();
+    const proposals = snap.docs.map(doc => {
+      const d = doc.data();
+      return {
+        id: doc.id,
+        namespace: d.namespace,
+        key: d.key,
+        proposedValue: d.proposedValue,
+        proposedBy: d.proposedBy,
+        status: d.status,
+        rationale: d.rationale,
+        reviewers: d.reviewers,
+        approvalChain: d.approvalChain,
+        createdAt: d.createdAt?.toDate?.()?.toISOString() || d.createdAt,
+        resolvedAt: d.resolvedAt?.toDate?.()?.toISOString() || d.resolvedAt || null,
+        expiresAt: d.expiresAt,
+      };
+    });
+    restResponse(res, true, { proposals, count: proposals.length });
+  }),
+  // GSP Resolve — approve, reject, or withdraw a proposal
+  route("POST", "/v1/gsp/proposals/:id/resolve", async (auth, req, res, p) => {
+    const body = await readBody(req);
+    const result = await gspResolveHandler(auth, { proposalId: p.id, ...body });
+    const text = result?.content?.[0]?.text;
+    const parsed = text ? JSON.parse(text) : result;
+    restResponse(res, parsed.success !== false, parsed, parsed.success !== false ? 200 : 400);
   }),
 
   // Program State


### PR DESCRIPTION
## Summary
- Add CORS headers + OPTIONS preflight to REST router — without this, all cross-origin calls from grid-portal.web.app were blocked with \"Failed to fetch\"
- Map christian@rezzed.ai Firebase tokens → programId=flynn (canonical UID) so gsp_resolve reviewer checks pass; previously all Firebase tokens got programId=mobile, blocked from approving proposals
- Add gsp.read to mobile capability set for read-only portal access
- Add REST endpoints: GET /v1/gsp/proposals and POST /v1/gsp/proposals/:id/resolve (both were missing, blocking proposal UI)

## Root cause
GSP Explorer showed \"Failed to fetch\" because browser CORS preflight (OPTIONS) hit no handler → 404 → browser blocked all /v1/* requests. Even after CORS fix, proposal approve would fail because Firebase tokens authenticated as programId=mobile which is not in proposal.reviewers=[\"flynn\"].

## Test plan
- [ ] Deploy cachebash to Cloud Run (gcloud run deploy cachebash-mcp --source . --project=cachebash-app --region=us-central1)
- [ ] Verify OPTIONS /v1/gsp/namespaces returns 204 with Access-Control-Allow-Origin
- [ ] Log in to grid-portal.web.app as christian@rezzed.ai — GSP Explorer should list namespaces
- [ ] GOVERNANCE > Proposals — proposal lUSPViO84ShWWDVUyYkO should appear; Approve button resolves it as flynn

🤖 Generated with [Claude Code](https://claude.com/claude-code)