### PR TITLE
security(identity): BUG-005 server-side identity gate — keyProgramId enforcement (inv.6)

### DIFF
--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -158,6 +158,7 @@ beforeEach(() => {
 const mockAuth: AuthContext = {
   userId: "test-user",
   programId: "iso",
+  keyProgramId: "iso",
   apiKeyHash: "test-hash",
   capabilities: ["dispatch.write"],
   encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),

--- a/services/mcp-server/src/__tests__/helpers.ts
+++ b/services/mcp-server/src/__tests__/helpers.ts
@@ -4,6 +4,7 @@ export function mockAuth(overrides?: Partial<AuthContext>): AuthContext {
   return {
     userId: "test-user-123",
     programId: "orchestrator",
+    keyProgramId: "orchestrator",
     apiKeyHash: "test-hash",
     encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
     capabilities: ["*"],

--- a/services/mcp-server/src/__tests__/policy-engine.test.ts
+++ b/services/mcp-server/src/__tests__/policy-engine.test.ts
@@ -115,6 +115,7 @@ const mockAuth: AuthContext = {
   apiKeyHash: "test-hash-123",
   encryptionKey: Buffer.from("test-key"),
   programId: "iso" as any,
+  keyProgramId: "iso" as any,
   capabilities: ["policy.read", "policy.write"],
   rateLimitTier: "standard",
 };

--- a/services/mcp-server/src/__tests__/programState.test.ts
+++ b/services/mcp-server/src/__tests__/programState.test.ts
@@ -126,6 +126,7 @@ const mockAuth: AuthContext = {
   userId: "test-user-123",
   apiKeyHash: "test-key-hash",
   programId: "basher" as ValidProgramId,
+  keyProgramId: "basher" as ValidProgramId,
   encryptionKey: Buffer.from("test-key-32-bytes-long-padding!!", "utf-8"),
   capabilities: ["*"],
   rateLimitTier: "internal",

--- a/services/mcp-server/src/__tests__/send-directive.test.ts
+++ b/services/mcp-server/src/__tests__/send-directive.test.ts
@@ -77,6 +77,7 @@ function auth(): AuthContext {
     apiKeyHash: "k1",
     encryptionKey: Buffer.from("abc"),
     programId: "vector" as any,
+    keyProgramId: "vector" as any,
     capabilities: ["*"],
     rateLimitTier: "internal",
   };

--- a/services/mcp-server/src/__tests__/sessionCompliance.test.ts
+++ b/services/mcp-server/src/__tests__/sessionCompliance.test.ts
@@ -40,6 +40,7 @@ function auth(programId: string): AuthContext {
     apiKeyHash: "k1",
     encryptionKey: Buffer.from("abc"),
     programId: programId as any,
+    keyProgramId: programId as any,
     capabilities: ["*"],
     rateLimitTier: "internal",
   };

--- a/services/mcp-server/src/__tests__/telemetry-suite.test.ts
+++ b/services/mcp-server/src/__tests__/telemetry-suite.test.ts
@@ -35,6 +35,7 @@ describe("Telemetry Suite", () => {
   const adminAuth: AuthContext = {
     userId: "test-user",
     programId: "orchestrator",
+    keyProgramId: "orchestrator",
     apiKeyHash: "test-hash",
     encryptionKey: mockEncryptionKey,
     capabilities: ["*"],

--- a/services/mcp-server/src/auth/authValidator.ts
+++ b/services/mcp-server/src/auth/authValidator.ts
@@ -9,6 +9,11 @@ export interface AuthContext {
   apiKeyHash: string;
   encryptionKey: Buffer;
   programId: ValidProgramId;
+  /** The programId bound to the AUTHENTICATING credential (cb_ key, Firebase token, OAuth token).
+   * Never overridable by X-Program-Id. Used by verifySource to enforce Identity Sovereignty inv.6:
+   * claimed source must match the credential's own identity.
+   * Always set by production auth validators. Optional only for test backward compat. */
+  keyProgramId?: ValidProgramId;
   capabilities: string[];
   /** OAuth granted scopes — only present for OAuth tokens */
   oauthScopes?: string[];
@@ -47,6 +52,9 @@ export async function validateApiKey(
     }
 
     const userId = data.userId;
+
+    // The key's canonical identity — never overridable. Used for source enforcement (BUG-005).
+    const keyProgramId: ValidProgramId = (data.programId || "legacy") as ValidProgramId;
 
     // Phase 0: Auth Mode logic
     const AUTH_MODE = process.env.AUTH_MODE || 'hybrid';
@@ -108,6 +116,7 @@ export async function validateApiKey(
       apiKeyHash: keyHash,
       encryptionKey: deriveEncryptionKey(apiKey),
       programId,
+      keyProgramId,
       capabilities,
       rateLimitTier: data.rateLimitTier || "free",
     };

--- a/services/mcp-server/src/auth/firebaseAuthValidator.ts
+++ b/services/mcp-server/src/auth/firebaseAuthValidator.ts
@@ -38,11 +38,13 @@ export async function validateFirebaseToken(
     const principal = email ? PORTAL_PRINCIPALS[email] : undefined;
 
     if (principal && decoded.email_verified === true && decoded.uid === principal.userId) {
+      const pid = principal.programId as any;
       return {
         userId: principal.userId,
         apiKeyHash: `firebase:${decoded.uid}`,
         encryptionKey,
-        programId: principal.programId as any,
+        programId: pid,
+        keyProgramId: pid,
         capabilities: getDefaultCapabilities("reviewer"),
         rateLimitTier: principal.rateLimitTier,
       };
@@ -53,6 +55,7 @@ export async function validateFirebaseToken(
       apiKeyHash: `firebase:${decoded.uid}`,
       encryptionKey,
       programId: "mobile",
+      keyProgramId: "mobile",
       capabilities: getDefaultCapabilities("mobile"),
       rateLimitTier: "free",
     };

--- a/services/mcp-server/src/auth/oauthTokenValidator.ts
+++ b/services/mcp-server/src/auth/oauthTokenValidator.ts
@@ -58,11 +58,13 @@ export async function validateOAuthToken(token: string): Promise<AuthContext | n
     // Pass granted scopes through capabilities for scope enforcement
     const grantedScopes = data.grantedScopes || (data.scope ? data.scope.split(" ") : ["mcp:full"]);
 
+    const resolvedProgramId = programId as import("../config/programs.js").ValidProgramId;
     return {
       userId: data.userId,
       apiKeyHash: `oauth:${tokenHash}`,
       encryptionKey,
-      programId: programId as import("../config/programs.js").ValidProgramId,
+      programId: resolvedProgramId,
+      keyProgramId: resolvedProgramId,
       capabilities: getDefaultCapabilities(programId),
       oauthScopes: grantedScopes,
       rateLimitTier: "free",

--- a/services/mcp-server/src/middleware/gate.ts
+++ b/services/mcp-server/src/middleware/gate.ts
@@ -144,24 +144,41 @@ export function hasCapability(auth: AuthContext, capability: string): boolean {
 
 /**
  * Verify source claim against key identity.
- * Phase 2: ENFORCED. Key's programId must match claimed source.
+ * BUG-005 / Identity Sovereignty inv.6: enforces against keyProgramId — the identity
+ * bound to the AUTHENTICATING credential — not the X-Program-Id override (programId).
+ * This closes the impersonation path on all surfaces (HTTP, Desktop, mobile, OAuth).
+ *
+ * legacy/mobile are admin-tier actors exempted from source pinning.
  */
 export function verifySource(
   claimedSource: string | undefined,
   auth: AuthContext,
   endpoint: "mcp" | "admin" | "rest"
 ): string {
-  if (auth.programId === "legacy" || auth.programId === "mobile") {
-    return claimedSource || auth.programId;
+  // BUG-005: use the AUTHENTICATING credential's identity (keyProgramId), falling back
+  // to programId only when keyProgramId is absent (test mocks / legacy callers).
+  const credentialIdentity = auth.keyProgramId ?? auth.programId;
+
+  // Admin-tier actors (legacy/mobile keys) may send on behalf of any source.
+  if (credentialIdentity === "legacy" || credentialIdentity === "mobile") {
+    return claimedSource || credentialIdentity;
   }
 
   if (!claimedSource) {
-    return auth.programId;
+    // No source claimed — attribute to the key's own identity.
+    return credentialIdentity;
   }
 
-  if (claimedSource !== auth.programId) {
+  // Enforce: claimed source must match the AUTHENTICATING credential's identity.
+  // auth.programId may differ (X-Program-Id override for capability routing) — that
+  // does NOT expand the source identity. A basher key cannot claim source "iso".
+  if (claimedSource !== credentialIdentity) {
+    console.error(
+      `[SECURITY] BUG-005 identity mismatch: credential="${credentialIdentity}" ` +
+      `claimed_source="${claimedSource}" endpoint="${endpoint}". Rejecting.`
+    );
     throw new Error(
-      `Source mismatch: key belongs to "${auth.programId}", claimed "${claimedSource}". ` +
+      `Source mismatch: key belongs to "${credentialIdentity}", claimed "${claimedSource}". ` +
       `Each program must use its own API key.`
     );
   }


### PR DESCRIPTION
## Summary

- **BUG-005 structural resolution gate**: Add `keyProgramId` to `AuthContext` — the programId bound to the authenticating credential (`cb_` key, Firebase token, OAuth token). This field is never overridable by `X-Program-Id`.
- **`verifySource` hardened**: Now enforces claimed `source` against `credentialIdentity` (`keyProgramId ?? programId`) rather than `auth.programId`. Closes the `hybrid` mode impersonation path: a client with any `cb_` key could previously set `X-Program-Id: basher` header + `source: "basher"` in tool args and bypass source enforcement.
- **Identity Sovereignty inv.6**: Every principal-bearing write (relay, dispatch, tasks) is now validated against its authenticating credential at the server choke point shared by all surfaces — CLI, HTTP, Desktop, mobile, OAuth.

## Files changed

- `auth/authValidator.ts` — `AuthContext.keyProgramId?` added; set in `validateApiKey` from `keyIndex.programId` before any override
- `auth/firebaseAuthValidator.ts` / `oauthTokenValidator.ts` — set `keyProgramId` = `programId` (fixed identity for these token types)
- `middleware/gate.ts` — `verifySource` uses `credentialIdentity = auth.keyProgramId ?? auth.programId`
- `__tests__/*.ts` — backfill `keyProgramId` in mock auth objects for 7 test files

## Security verification

**Before**: `cb_iso_key` (bound to `iso`) + `X-Program-Id: basher` → `auth.programId = "basher"` → `verifySource("basher", auth)` passes → impersonation succeeds.

**After**: `auth.keyProgramId = "iso"` (from keyIndex, not overridable) → `verifySource("basher", auth)` → `"basher" !== "iso"` → rejected with `[SECURITY] BUG-005 identity mismatch` log.

## Test plan

- [ ] `tsc --noEmit` passes (no `keyProgramId` errors in source or test files)
- [ ] `relay_send_message` with mismatched source throws `Source mismatch`
- [ ] `relay_send_message` with correct source passes
- [ ] `legacy`/`mobile` keys exempt from source pinning (existing behavior preserved)
- [ ] SARK security review before merge

🔒 SARK-gate: security review required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)