### PR TITLE
fix(indexes): add Firestore composite indexes for gsp_proposals and schedules

### DIFF
--- a/infra/firestore.indexes.json
+++ b/infra/firestore.indexes.json
@@ -571,6 +571,22 @@
         { "fieldPath": "enabled", "order": "ASCENDING" },
         { "fieldPath": "nextRunAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "schedules",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "enabled", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "gsp_proposals",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary

- Add `gsp_proposals` index: `status ASC + createdAt DESC` — fixes `FAILED_PRECONDITION` on `GET /v1/gsp/proposals?status=pending`
- Add `schedules` index: `enabled ASC + createdAt DESC` — fixes `FAILED_PRECONDITION` on `schedule_list` with enabled filter

## Test plan

- [ ] Deploy: `firebase deploy --only firestore:indexes` (indexes take ~5-10 min to build)
- [ ] `GET /v1/gsp/proposals?status=pending` returns results without FAILED_PRECONDITION
- [ ] `schedule_list` with `enabled` filter no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)