### PR TITLE
test(security): BUG-005 fast-follow — real verifySource regression + GSP write attribution (F-360-1, F-360-2)

### DIFF
--- a/services/mcp-server/src/__tests__/gate.test.ts
+++ b/services/mcp-server/src/__tests__/gate.test.ts
@@ -1,0 +1,127 @@
+/**
+ * gate.ts — verifySource unit tests (F-360-1)
+ *
+ * These tests exercise the REAL verifySource function — no mocks.
+ * Purpose: regression guard against any future change that re-opens the
+ * BUG-005 impersonation path (hybrid-mode X-Program-Id override bypass).
+ *
+ * BUG-005 attack vector:
+ *   cb_ key bound to "basher" + X-Program-Id: iso → auth.programId = "iso"
+ *   caller passes source: "iso" → old code: "iso" === auth.programId → passes
+ *   new code: "iso" !== auth.keyProgramId ("basher") → rejected
+ */
+
+import type { AuthContext } from "../auth/authValidator";
+import { verifySource } from "../middleware/gate";
+import type { ValidProgramId } from "../config/programs";
+
+// Minimal stub — no Firestore, no network.
+function makeAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    userId: "test-user",
+    apiKeyHash: "hash",
+    encryptionKey: Buffer.from("test-key-32-bytes-long-padding!!", "utf-8"),
+    programId: "basher" as ValidProgramId,
+    keyProgramId: "basher" as ValidProgramId,
+    capabilities: ["*"],
+    rateLimitTier: "internal",
+    ...overrides,
+  };
+}
+
+jest.mock("../firebase/client", () => ({
+  getFirestore: jest.fn(),
+  serverTimestamp: jest.fn(),
+}));
+
+jest.mock("../modules/events", () => ({
+  emitEvent: jest.fn(),
+}));
+
+describe("verifySource — BUG-005 regression (F-360-1)", () => {
+  describe("BUG-005 attack: keyProgramId !== programId (X-Program-Id override)", () => {
+    it("rejects claimed source matching programId override but not keyProgramId", () => {
+      // Exact BUG-005 scenario:
+      //   cb_basher_key sets X-Program-Id: iso → auth.programId = "iso"
+      //   caller passes source: "iso"
+      //   MUST throw — keyProgramId "basher" does not own source "iso"
+      const auth = makeAuth({
+        keyProgramId: "basher" as ValidProgramId,
+        programId: "iso" as ValidProgramId,
+      });
+
+      expect(() => verifySource("iso", auth, "mcp")).toThrow(
+        /Source mismatch.*basher.*iso/
+      );
+    });
+
+    it("allows claimed source matching keyProgramId even when programId differs", () => {
+      // Same auth context (X-Program-Id override active) but caller claims own identity.
+      const auth = makeAuth({
+        keyProgramId: "basher" as ValidProgramId,
+        programId: "iso" as ValidProgramId,
+      });
+
+      expect(verifySource("basher", auth, "mcp")).toBe("basher");
+    });
+  });
+
+  describe("normal operation (no X-Program-Id override)", () => {
+    it("returns keyProgramId when source is undefined", () => {
+      const auth = makeAuth({ keyProgramId: "basher" as ValidProgramId });
+      expect(verifySource(undefined, auth, "mcp")).toBe("basher");
+    });
+
+    it("returns claimed source when it matches keyProgramId", () => {
+      const auth = makeAuth({ keyProgramId: "basher" as ValidProgramId, programId: "basher" as ValidProgramId });
+      expect(verifySource("basher", auth, "mcp")).toBe("basher");
+    });
+
+    it("throws when claimed source mismatches keyProgramId", () => {
+      const auth = makeAuth({ keyProgramId: "sark" as ValidProgramId, programId: "sark" as ValidProgramId });
+      expect(() => verifySource("basher", auth, "mcp")).toThrow(/Source mismatch/);
+    });
+  });
+
+  describe("legacy/mobile exemption (admin-tier actors)", () => {
+    it("allows legacy key to claim any source", () => {
+      const auth = makeAuth({ keyProgramId: "legacy" as ValidProgramId, programId: "legacy" as ValidProgramId });
+      expect(verifySource("iso", auth, "mcp")).toBe("iso");
+    });
+
+    it("allows mobile key to claim any source", () => {
+      const auth = makeAuth({ keyProgramId: "mobile" as ValidProgramId, programId: "mobile" as ValidProgramId });
+      expect(verifySource("basher", auth, "mcp")).toBe("basher");
+    });
+
+    it("legacy with undefined source returns 'legacy'", () => {
+      const auth = makeAuth({ keyProgramId: "legacy" as ValidProgramId, programId: "legacy" as ValidProgramId });
+      expect(verifySource(undefined, auth, "mcp")).toBe("legacy");
+    });
+  });
+
+  describe("backward compat — keyProgramId absent (test mocks / legacy callers)", () => {
+    it("falls back to programId when keyProgramId is absent", () => {
+      // Simulates pre-BUG-005 mocks that never set keyProgramId.
+      const auth = makeAuth({ keyProgramId: undefined, programId: "vector" as ValidProgramId });
+      expect(verifySource("vector", auth, "mcp")).toBe("vector");
+    });
+
+    it("throws when programId fallback mismatches claimed source", () => {
+      const auth = makeAuth({ keyProgramId: undefined, programId: "vector" as ValidProgramId });
+      expect(() => verifySource("iso", auth, "mcp")).toThrow(/Source mismatch/);
+    });
+  });
+
+  describe("endpoint parameter is passed through to error message context", () => {
+    it("throws on admin endpoint with same mismatch", () => {
+      const auth = makeAuth({ keyProgramId: "basher" as ValidProgramId, programId: "basher" as ValidProgramId });
+      expect(() => verifySource("iso", auth, "admin")).toThrow(/Source mismatch/);
+    });
+
+    it("throws on rest endpoint with same mismatch", () => {
+      const auth = makeAuth({ keyProgramId: "basher" as ValidProgramId, programId: "basher" as ValidProgramId });
+      expect(() => verifySource("iso", auth, "rest")).toThrow(/Source mismatch/);
+    });
+  });
+});

--- a/services/mcp-server/src/__tests__/gsp.test.ts
+++ b/services/mcp-server/src/__tests__/gsp.test.ts
@@ -238,6 +238,10 @@ jest.mock("../middleware/capabilities", () => ({
   getDefaultCapabilities: jest.fn(() => ["*"]),
 }));
 
+jest.mock("../modules/events", () => ({
+  emitEvent: jest.fn(),
+}));
+
 // ── Shared auth context ─────────────────────────────────────────────────────
 
 const mockAuth: AuthContext = {
@@ -423,20 +427,31 @@ describe("gspWriteHandler", () => {
     ).rejects.toThrow("GOVERNANCE_VIOLATION");
   });
 
-  // #10
-  it("uses custom source when provided", async () => {
+  // #10 — source must match credential identity (inv.6, F-360-2)
+  it("uses own-identity source for updatedBy when source matches auth", async () => {
     const result = await gspWriteHandler(mockAuth, {
       namespace: "runtime",
       key: "src-test",
       value: "val",
-      source: "custom-agent",
+      source: "vector",  // matches mockAuth.programId — valid
     });
     const data = parse(result);
     expect(data.success).toBe(true);
 
-    // Verify the stored entry has updatedBy = custom-agent
     const stored = mockDocs["tenants/test-user-123/gsp/runtime/entries/src-test"];
-    expect(stored.updatedBy).toBe("custom-agent");
+    expect(stored.updatedBy).toBe("vector");
+  });
+
+  it("rejects cross-identity source attribution (F-360-2 / inv.6)", async () => {
+    // A "vector" key cannot claim source "iso" — verifySource must throw.
+    await expect(
+      gspWriteHandler(mockAuth, {
+        namespace: "runtime",
+        key: "spoofed",
+        value: "val",
+        source: "iso",
+      })
+    ).rejects.toThrow(/Source mismatch/);
   });
 });
 

--- a/services/mcp-server/src/modules/gsp.ts
+++ b/services/mcp-server/src/modules/gsp.ts
@@ -15,6 +15,7 @@
 
 import { getFirestore } from "../firebase/client.js";
 import { AuthContext } from "../auth/authValidator.js";
+import { verifySource } from "../middleware/gate.js";
 import { z } from "zod";
 import type { ValidProgramId } from "../config/programs.js";
 
@@ -425,6 +426,9 @@ export async function gspWriteHandler(auth: AuthContext, rawArgs: unknown): Prom
     });
   }
 
+  // F-360-2: enforce inv.6 on GSP attribution — a basher key cannot write as "iso".
+  const verifiedSource = verifySource(args.source, auth, "mcp");
+
   const db = getFirestore();
   const colPath = gspCollectionPath(auth.userId, args.namespace);
   const docRef = db.doc(`${colPath}/${args.key}`);
@@ -456,7 +460,7 @@ export async function gspWriteHandler(auth: AuthContext, rawArgs: unknown): Prom
       version: newVersion,
       description: args.description || null,
       updatedAt: now,
-      updatedBy: args.source || auth.programId,
+      updatedBy: verifiedSource,
       ...(existing.exists ? {} : { createdAt: now }),
     };
 
@@ -470,7 +474,7 @@ export async function gspWriteHandler(auth: AuthContext, rawArgs: unknown): Prom
 
 
   // Notify subscribers of state change
-  await notifySubscribers(auth, args.namespace, args.key, result.version, args.source || auth.programId);
+  await notifySubscribers(auth, args.namespace, args.key, result.version, verifiedSource);
 
   return jsonResult({
     success: true,


### PR DESCRIPTION
## Summary

- **F-360-1 (HIGH)**: Add `gate.test.ts` — 11 real, unmocked tests for `verifySource` that lock the BUG-005 enforcement against regression. The critical case: `keyProgramId="basher"` + `programId="iso"` (X-Program-Id override) + `claimedSource="iso"` → must throw. Also covers legitimate usage, legacy/mobile exemption, undefined-source attribution, keyProgramId-absent backward compat.
- **F-360-2 (MEDIUM)**: Route `args.source` through `verifySource` in `gspWriteHandler` before persisting as `updatedBy` and before `notifySubscribers`. Closes the GSP write attribution spoofing path — inv.6 now holds on relay, dispatch, and gsp write surfaces.
- **gsp.test.ts**: Update the cross-identity source test to use auth-matching source; add rejection test; add `events` mock for gate.ts dependency chain.

## What was wrong

`gsp.ts:459` (`updatedBy: args.source || auth.programId`) and `:473` (notifySubscribers) persisted raw, unverified `args.source`. A basher key with `X-Program-Id: iso` override could write `source: "iso"` to any GSP entry and it would be stored as `updatedBy: "iso"`. `verifySource` was already enforced on relay/dispatch; GSP was an open surface.

All prior tests mocked `verifySource` as a pass-through — a future simplification could silently revert the enforcement with all tests green.

## Test results

```
Test Suites: 36 passed, 37 total (1 pre-existing skip)
Tests:       596 passed, 617 total (21 pre-existing skips)
```

## SARK re-review checklist

- [x] F-360-1: gate.test.ts exists with real (unmocked) BUG-005 attack case that throws
- [x] F-360-1: legitimate source matches → allowed
- [x] F-360-1: undefined source → attributed to keyProgramId
- [x] F-360-1: legacy/mobile exempt
- [x] F-360-2: gsp.ts imports verifySource; write handler calls it before persisting attribution
- [x] All 596 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)