### PR TITLE
fix(security): cachebash#363 LOW hardening follow-ups F1-F4 (SARK re-gate)

### DIFF
--- a/services/mcp-server/scripts/register-program.ts
+++ b/services/mcp-server/scripts/register-program.ts
@@ -65,6 +65,11 @@ function parseInput(): ProgramEntry[] {
       console.error("ERROR: every entry must have a string programId");
       process.exit(1);
     }
+    // F1: guard against path-injection via '/' — Firestore doc path would redirect to unintended nested path
+    if (!/^[a-z0-9_-]{1,64}$/.test((p as ProgramEntry).programId)) {
+      console.error(`ERROR: programId "${(p as ProgramEntry).programId}" must match ^[a-z0-9_-]{1,64}$`);
+      process.exit(1);
+    }
   }
   return list as ProgramEntry[];
 }

--- a/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
+++ b/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
@@ -2,10 +2,18 @@
  * Tests for POST /v1/relay/messages — portal owner send-message via server REST.
  * Identity Sovereignty inv.6: source is server-derived from Firebase owner token;
  * client cannot impersonate a program ID.
+ *
+ * Test structure:
+ *   1. Handler-level tests — sendMessageHandler behavior (F2: source derivation, impersonation)
+ *   2. Route-level integration tests — real route handler via HTTP (F3: try/catch, F4: guards)
  */
 
 import type { AuthContext } from "../auth/authValidator";
 import { sendMessageHandler } from "../modules/relay";
+import * as http from "http";
+import { createRestRouter } from "../transport/rest";
+
+// --- Module mocks ---
 
 let capturedRelayDoc: Record<string, unknown> = {};
 
@@ -36,6 +44,7 @@ jest.mock("../middleware/gate.js", () => ({
   isAdmin: jest.fn(() => false),
   logAudit: jest.fn(),
   generateCorrelationId: jest.fn(() => "mock-corr-id"),
+  createAuditLogger: jest.fn(() => ({ log: jest.fn(), error: jest.fn() })),
 }));
 
 jest.mock("../modules/events.js", () => ({
@@ -80,12 +89,65 @@ jest.mock("../utils/trace.js", () => ({
   generateSpanId: jest.fn(() => "mock-span"),
 }));
 
+// Additional mocks needed by createRestRouter (not used by sendMessageHandler directly)
+jest.mock("../auth/authValidator.js", () => ({
+  validateAuth: jest.fn(),
+}));
+jest.mock("../tools.js", () => ({
+  TOOL_HANDLERS: {},
+  TOOL_DEFINITIONS: [],
+}));
+jest.mock("../modules/ledger.js", () => ({
+  logToolCall: jest.fn(),
+}));
+jest.mock("../modules/trace.js", () => ({
+  traceToolCall: jest.fn(),
+}));
+jest.mock("../middleware/rateLimiter.js", () => ({
+  enforceRateLimit: jest.fn(() => ({ allowed: true })),
+  checkAuthRateLimit: jest.fn(() => true),
+}));
+jest.mock("../middleware/sessionCompliance.js", () => ({
+  checkSessionCompliance: jest.fn(async () => ({ allowed: true })),
+  resetTransportCompliance: jest.fn(),
+}));
+jest.mock("../middleware/pricingEnforce.js", () => ({
+  checkPricing: jest.fn(async () => ({ allowed: true })),
+}));
+jest.mock("../middleware/usage.js", () => ({
+  incrementUsage: jest.fn(),
+}));
+jest.mock("../config/access-tiers.js", () => ({
+  ADMIN_READERS: [],
+  ADMIN_PROGRAMS: [],
+}));
+jest.mock("../config/constants.js", () => ({
+  CONSTANTS: { limits: { maxBodySizeBytes: 65536 } },
+}));
+jest.mock("../tools/tool-aliases.js", () => ({
+  resolveToolAlias: jest.fn((name: string) => name),
+}));
+jest.mock("../modules/openapi.js", () => ({
+  generateOpenApiSpec: jest.fn(() => ({})),
+}));
+jest.mock("../modules/dream.js", () => ({
+  dreamPeekHandler: jest.fn(),
+  dreamActivateHandler: jest.fn(),
+}));
+jest.mock("../modules/gsp.js", () => ({
+  gspListNamespacesHandler: jest.fn(),
+  gspResolveHandler: jest.fn(),
+}));
+
+// --- Auth fixtures ---
+
 function ownerAuth(): AuthContext {
   return {
     userId: "7viFKVtl5lgzguhFoZlnYYrqeDG2",
     apiKeyHash: "firebase:7viFKVtl5lgzguhFoZlnYYrqeDG2",
     encryptionKey: Buffer.from("abc"),
     programId: "flynn" as any,
+    keyProgramId: "flynn" as any,
     capabilities: ["*"],
     rateLimitTier: "paid",
   };
@@ -97,6 +159,7 @@ function mobileAuth(): AuthContext {
     apiKeyHash: "firebase:unknown-uid",
     encryptionKey: Buffer.from("abc"),
     programId: "mobile" as any,
+    keyProgramId: "mobile" as any,
     capabilities: [],
     rateLimitTier: "free",
   };
@@ -108,15 +171,21 @@ function apiKeyAuth(): AuthContext {
     apiKeyHash: "cb_abc123",
     encryptionKey: Buffer.from("abc"),
     programId: "flynn" as any,
+    keyProgramId: "flynn" as any,
     capabilities: ["*"],
     rateLimitTier: "paid",
   };
 }
 
-describe("portal owner send-message (POST /v1/relay/messages)", () => {
+// --- 1. Handler-level tests ---
+
+describe("portal owner send-message — handler level", () => {
   beforeEach(() => {
     capturedRelayDoc = {};
     jest.clearAllMocks();
+    // Restore default verifySource mock (returns programId — no mismatch)
+    const { verifySource } = require("../middleware/gate.js");
+    verifySource.mockImplementation((_claimed: string, auth: AuthContext) => auth.programId);
   });
 
   it("writes relay doc with source=flynn when owner sends a message", async () => {
@@ -137,15 +206,25 @@ describe("portal owner send-message (POST /v1/relay/messages)", () => {
     expect(capturedRelayDoc.status).toBe("pending");
   });
 
-  it("rejects client-supplied program source (impersonation) via verifySource", async () => {
-    const { verifySource } = require("../middleware/gate.js");
-    verifySource.mockImplementationOnce(() => {
-      throw new Error('Source mismatch: key belongs to "flynn", claimed "iso". Each program must use its own API key.');
-    });
+  it("real verifySource rejects impersonation: keyProgramId=basher claiming source=iso", async () => {
+    // Unmock verifySource for this test — use the real implementation
+    const { verifySource } = jest.requireActual("../middleware/gate.js") as { verifySource: typeof import("../middleware/gate.js").verifySource };
+    require("../middleware/gate.js").verifySource.mockImplementationOnce(
+      (claimed: string, auth: AuthContext, endpoint: "mcp" | "admin" | "rest") => verifySource(claimed, auth, endpoint)
+    );
 
-    const auth = ownerAuth();
+    const basherAuth: AuthContext = {
+      userId: "7viFKVtl5lgzguhFoZlnYYrqeDG2",
+      apiKeyHash: "firebase:7viFKVtl5lgzguhFoZlnYYrqeDG2",
+      encryptionKey: Buffer.from("abc"),
+      programId: "basher" as any,
+      keyProgramId: "basher" as any,
+      capabilities: ["*"],
+      rateLimitTier: "paid",
+    };
+
     await expect(
-      sendMessageHandler(auth, {
+      sendMessageHandler(basherAuth, {
         source: "iso",
         target: "basher",
         message: "Impersonation attempt",
@@ -153,20 +232,92 @@ describe("portal owner send-message (POST /v1/relay/messages)", () => {
       })
     ).rejects.toThrow("Source mismatch");
   });
+});
 
-  it("non-owner Firebase user (mobile) is blocked at the route layer", () => {
-    // Simulate the route-level check that the REST handler applies.
-    // mobile programId = unknown Firebase user — must be rejected.
-    const auth = mobileAuth();
-    expect(auth.programId).toBe("mobile");
-    expect(auth.apiKeyHash.startsWith("firebase:")).toBe(true);
-    // The route checks programId === "mobile" → 403 OWNER_REQUIRED
+// --- 2. Route-level integration tests (F3 + F4) ---
+// These drive the real route handler in rest.ts via HTTP,
+// covering branches that handler-level tests cannot reach.
+
+describe("POST /v1/relay/messages — route-level guards (HTTP)", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll((done) => {
+    server = http.createServer(createRestRouter());
+    server.listen(0, () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      done();
+    });
   });
 
-  it("non-Firebase API key is blocked at the route layer", () => {
-    // Route checks apiKeyHash.startsWith("firebase:") — cb_ keys must be rejected.
-    const auth = apiKeyAuth();
-    expect(auth.apiKeyHash.startsWith("firebase:")).toBe(false);
-    // The route checks → 403 PORTAL_OWNER_ONLY
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore default verifySource mock
+    const { verifySource } = require("../middleware/gate.js");
+    verifySource.mockImplementation((_claimed: string, auth: AuthContext) => auth.programId);
+  });
+
+  function makeRequest(auth: AuthContext, body: object = {}): Promise<{ status: number; data: Record<string, unknown> }> {
+    const { validateAuth } = require("../auth/authValidator.js");
+    validateAuth.mockResolvedValueOnce(auth);
+
+    return new Promise((resolve, reject) => {
+      const payload = JSON.stringify({ target: "iso", message: "test", message_type: "DIRECTIVE", ...body });
+      const options = {
+        method: "POST",
+        headers: {
+          "Authorization": "Bearer test-token",
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      };
+      const req = http.request(new URL("/v1/relay/messages", baseUrl), options, (res) => {
+        let raw = "";
+        res.on("data", (chunk) => { raw += chunk; });
+        res.on("end", () => {
+          try { resolve({ status: res.statusCode ?? 0, data: JSON.parse(raw) }); }
+          catch (e) { reject(e); }
+        });
+      });
+      req.on("error", reject);
+      req.write(payload);
+      req.end();
+    });
+  }
+
+  it("(a) rejects cb_ API key with 403 PORTAL_OWNER_ONLY", async () => {
+    const result = await makeRequest(apiKeyAuth());
+    expect(result.status).toBe(403);
+    expect((result.data as any).error).toBe("PORTAL_OWNER_ONLY");
+  });
+
+  it("(b) rejects mobile Firebase token with 403 OWNER_REQUIRED", async () => {
+    const result = await makeRequest(mobileAuth());
+    expect(result.status).toBe(403);
+    expect((result.data as any).error).toBe("OWNER_REQUIRED");
+  });
+
+  it("(c) maps SOURCE_MISMATCH throw from sendMessageHandler to 403 not 500 (F3)", async () => {
+    // verifySource throws SOURCE_MISMATCH → route try/catch must return 403, not 500
+    const { verifySource } = require("../middleware/gate.js");
+    verifySource.mockImplementationOnce(() => {
+      throw new Error('Source mismatch: key belongs to "basher", claimed "iso". Each program must use its own API key.');
+    });
+
+    const result = await makeRequest(ownerAuth());
+    expect(result.status).toBe(403);
+    expect((result.data as any).error).toBe("SOURCE_MISMATCH");
+  });
+
+  it("(d) owner with keyProgramId derives source correctly — F2 keyProgramId takes precedence", async () => {
+    // ownerAuth has keyProgramId="flynn"; relay doc should be attributed to "flynn"
+    const result = await makeRequest(ownerAuth());
+    expect(result.status).toBe(201);
+    expect(capturedRelayDoc.source).toBe("flynn");
   });
 });

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -421,11 +421,19 @@ const routes: Route[] = [
       return;
     }
     const body = await readBody(req);
-    const source = auth.programId;
-    const result = await sendMessageHandler(auth, { ...body, source });
-    const text = result?.content?.[0]?.text;
-    const parsed = text ? JSON.parse(text) : result;
-    restResponse(res, parsed.success !== false, parsed, parsed.success !== false ? 201 : 400);
+    const source = auth.keyProgramId ?? auth.programId;
+    try {
+      const result = await sendMessageHandler(auth, { ...body, source });
+      const text = result?.content?.[0]?.text;
+      const parsed = text ? JSON.parse(text) : result;
+      restResponse(res, parsed.success !== false, parsed, parsed.success !== false ? 201 : 400);
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("Source mismatch")) {
+        sendJson(res, 403, { success: false, error: "SOURCE_MISMATCH", message: err.message });
+      } else {
+        sendJson(res, 500, { success: false, error: "INTERNAL", message: "Internal server error" });
+      }
+    }
   }),
   route("GET", "/v1/messages/sent", async (auth, req, res) => {
     const query = coerceQueryParams(parseQuery(req.url || ""));


### PR DESCRIPTION
## Summary

4 LOW hardening follow-ups from SARK's cachebash#363 security gate (`grid/decisions/sark-assessment-cachebash-363-register-program.md`). All non-blocking; sequenced after P0 work per gate conditions.

- **F1** (`register-program.ts`): Add `^[a-z0-9_-]{1,64}$` charset guard on `programId` in `parseInput()` — prevents Firestore doc path injection via `/` in trusted-operator input.
- **F2** (`rest.ts`): Derive `source` from `auth.keyProgramId ?? auth.programId` (the non-overridable credential identity) instead of `auth.programId` (subject to X-Program-Id override). Removes reliance on downstream `verifySource` guard; endpoint now sources identity correctly itself.
- **F3** (`rest.ts`): Wrap `sendMessageHandler` in `try/catch`; map `Source mismatch` errors to `403 SOURCE_MISMATCH` instead of leaking a `500`.
- **F4** (`portal-owner-send-message.test.ts`): Replace two shallow fixture-assertion tests with a real HTTP integration suite via `createRestRouter` that exercises the actual route handler (covering the 403 branches). Replace mocked `verifySource` impersonation test with a real `verifySource` call (`keyProgramId=basher` claiming `source=iso` → `SOURCE_MISMATCH` throw). 6 tests total, all green.

## Test plan

- [x] `npx jest portal-owner-send-message` — 6/6 pass
- [ ] SARK re-review required per cachebash#363 gate conditions (endpoint change: F2+F3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)