### PR TITLE
config(pulse): bump fleet session cap 8 → 16

### DIFF
--- a/services/mcp-server/src/__tests__/integration/fleet-health-dashboard.test.ts
+++ b/services/mcp-server/src/__tests__/integration/fleet-health-dashboard.test.ts
@@ -161,9 +161,9 @@ describe("Fleet Health Dashboard Integration", () => {
       expect(byModelTier.sonnet).toBe(2);
 
       // Verify utilization calc
-      const maxSessions = 8;
+      const maxSessions = 16;
       const utilizationPercent = Math.round((3 / maxSessions) * 10000) / 100;
-      expect(utilizationPercent).toBe(37.5);
+      expect(utilizationPercent).toBe(18.75);
     });
 
     it("should handle empty fleet gracefully", async () => {
@@ -345,8 +345,8 @@ describe("Fleet Health Dashboard Integration", () => {
       expect(byModelTier.sonnet).toBe(2); // sonnet + haiku → both non-opus
       expect(snap.size).toBe(4);
 
-      const utilizationPercent = Math.round((4 / 8) * 10000) / 100;
-      expect(utilizationPercent).toBe(50);
+      const utilizationPercent = Math.round((4 / 16) * 10000) / 100;
+      expect(utilizationPercent).toBe(25);
     });
   });
 });

--- a/services/mcp-server/src/modules/pulse.ts
+++ b/services/mcp-server/src/modules/pulse.ts
@@ -335,7 +335,7 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
 }
 
 /** Max concurrent sessions (hardcoded MVP — will move to config) */
-const MAX_SESSIONS = 8;
+const MAX_SESSIONS = 16;
 /** Context threshold for "above threshold" classification */
 const CONTEXT_THRESHOLD_PERCENT = 60;
 


### PR DESCRIPTION
## What
Raises `MAX_SESSIONS` (fleet concurrency / subscription-budget cap) in `pulse.ts` from **8 → 16**.

## Why
Fleet hit **137.5% utilization (11 active / 8 cap)** this morning — over budget, forcing programs to hold or derez instead of working. Flynn directed the cap raised to 16 for headroom.

## Changes
- `services/mcp-server/src/modules/pulse.ts` — `MAX_SESSIONS = 16` (drives `get_fleet_health` `subscriptionBudget.maxSessions` + `utilizationPercent`).
- `fleet-health-dashboard.test.ts` — updated the two inline utilization-math expectations (3/16 → 18.75, 4/16 → 25). Neither test imports the constant (they recompute inline), so both passed regardless; updated to avoid leaving a misleading hardcoded `8`.

## Notes
- No other component independently caps fleet sessions (dispatcher's `maxConcurrent: 5` is enrichment-task concurrency, unrelated).
- Constant is still hardcoded (comment: "MVP — will move to config"); this is a value bump, not the config-extraction refactor.
- Takes effect on next mcp-server Cloud Run deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)