### PR TITLE
feat(armor): WAF rule 3000 preview→enforce (SARK FU-2) [HELD]

### DIFF
--- a/infra/terraform/envs/cerebro-grid/main.tf
+++ b/infra/terraform/envs/cerebro-grid/main.tf
@@ -139,14 +139,14 @@ resource "google_compute_security_policy" "cerebro_armor" {
     }
   }
 
-  # Rule 3000: OWASP CRS WAF — preview mode to avoid JSON-RPC false positives.
-  # SARK G-3: "preview-tuned to avoid false positives on JSON-RPC/MCP".
-  # Switch preview = false once tuning is validated against real MCP traffic.
+  # Rule 3000: OWASP CRS WAF — ENFORCING at sensitivity=1 (flipped from preview).
+  # SARK FU-2: enforce only after preview-mode logs show no /mcp JSON-RPC false positives.
+  # ⚠️ DO NOT APPLY until that log review passes against real MCP traffic (PR held as draft).
   rule {
     priority    = 3000
     action      = "deny(403)"
-    preview     = true
-    description = "SARK G-3: OWASP SQLi WAF (preview — sensitivity=1, tune before enforcing)"
+    preview     = false
+    description = "SARK G-3/FU-2: OWASP SQLi WAF (enforcing, sensitivity=1)"
 
     match {
       expr {


### PR DESCRIPTION
## What
Flip Cloud Armor `cachebash-lite-armor` rule 3000 (OWASP SQLi WAF, sensitivity 1) from `preview = true` → `false` (enforcing).

## ⚠️ HELD AS DRAFT — do not merge/apply yet
SARK FU-2 GO is **conditional on a preview-log review**: confirm no `/mcp` JSON-RPC false positives before enforcing. Right now there is essentially **no MCP traffic** (Sayf hasn't connected), so preview logs have nothing to validate against. Enforcing now risks blocking the first real requests.

## Sequence to ship
1. Let Sayf use the grid → `/mcp` traffic accumulates in Cloud Armor preview logs.
2. Review preview logs for false positives on rule 3000 (needs cerebro-grid log access — Flynn/christian@/dev@).
3. If clean: mark this PR ready, merge, then `terraform apply` in cerebro-grid (cerebro-grid creds; grid-deployer is walled off).
4. Verify `/mcp` still 200s for legit JSON-RPC and a SQLi probe gets 403.

## Context
The 401 auth gate already blocks injection probes, so this is pure defense-in-depth — no exposure in waiting. Scheduled vector_cerebro review reminder set for Sat 2026-06-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)