### PR TITLE
fix(lite): suppress OAuth/Route-A surface on lite tenants (SARK FU)

### DIFF
--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -379,6 +379,12 @@ async function main() {
 
     // Discovery metadata (RFC 8414 + RFC 9728). startsWith covers the
     // path-suffixed variants (e.g. /.well-known/oauth-protected-resource/v1/mcp).
+    // Lite tenants SUPPRESS the entire OAuth/Route-A surface (PRD #897: Route A OAuth
+    // DEFERRED, Route B cb_ bearer COMMITTED). Without this guard, lite advertises an
+    // OAuth AS and Claude Desktop pivots to a broken/unintended OAuth flow. Bearer +
+    // /enroll are unaffected. Per SARK assessment (task k6zV3jstFLkr26gCD81j).
+    const IS_LITE = (process.env.CACHEBASH_PROFILE ?? "full") === "lite";
+    if (!IS_LITE) {
     if (req.method === "GET" && url?.startsWith("/.well-known/oauth-authorization-server")) {
       return handleOAuthMetadata(req, res);
     }
@@ -408,6 +414,7 @@ async function main() {
     if (url === "/authorize/callback" && req.method === "GET") {
       return handleOAuthCallback(req, res);
     }
+    } // end if (!IS_LITE): OAuth/Route-A surface is suppressed on lite tenants
 
     // Service account management (requires Bearer auth)
     if (url?.startsWith("/oauth/service-accounts")) {
@@ -818,7 +825,9 @@ async function main() {
         // the stdio proxy and never hit this branch. A client with a key but
         // an INVALID one still gets the plain header below — it must not be
         // lured into OAuth discovery.
-        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": oauthWwwAuth });
+        // LITE: OAuth is suppressed (Route A deferred), so never advertise discovery —
+        // otherwise Claude Desktop pivots to the suppressed OAuth flow instead of bearer.
+        res.writeHead(401, { "Content-Type": "application/json", "WWW-Authenticate": IS_LITE ? plainWwwAuth : oauthWwwAuth });
         res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
         return;
       }


### PR DESCRIPTION
Implements SARK's recommendation from task `k6zV3jstFLkr26gCD81j` — aligned with PRD #897 (Route A OAuth **DEFERRED**, Route B `cb_` bearer **COMMITTED**).

**Problem:** `cachebash-lite` mounted all 8 OAuth routes + `.well-known` discovery with no profile guard, so lite tenants advertised a full OAuth authorization server. Claude Desktop auto-discovered it and pivoted to a broken/unintended OAuth flow (Firebase `auth/unauthorized-domain`) instead of using the bearer key. SARK: medium severity (DCR/authorize Firestore writes with no Armor rate rule; `mcp:admin` advertised needlessly) → low after suppress. No unauthorized token issuance was possible (two server-side gates), so this is fail-safe today.

**Change (2 edits, index.ts):**
1. `const IS_LITE = (process.env.CACHEBASH_PROFILE ?? 'full') === 'lite'`; wrap all 8 OAuth route handlers in `if (!IS_LITE)`.
2. `/mcp` no-token 401 returns a plain `Bearer` challenge (no `resource_metadata`) when lite, so Desktop stays on bearer.

**Unaffected:** bearer auth, `/enroll`, and full (non-lite) profile behavior. `tsc --noEmit` clean.

⚠️ **Gating:** touches the auth surface — requesting **SARK review** before merge, and it only takes effect after a **cachebash-lite redeploy** to cerebro-grid (same deploy path as `/enroll`). Indentation of the wrapped block left as-is for diff clarity; formatter can normalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)