### PR TITLE
fix(pulse): derez-gate no-leak — archive session even on pattern-extraction miss

### DIFF
--- a/services/mcp-server/src/modules/pulse.ts
+++ b/services/mcp-server/src/modules/pulse.ts
@@ -212,6 +212,7 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
   const lifecycleStatus = stateToLifecycle(args.state || "working");
 
   // W1.2.2: Derez gate — check pattern extraction before completion
+  let patternExtractionMissing = false;
   if (args.state === "complete" && complianceConfig.derezGate.requirePatternExtraction) {
     const sessionRef = db.doc(`tenants/${auth.userId}/sessions/${sessionId}`);
     const sessionDoc = await sessionRef.get();
@@ -241,13 +242,9 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
           const message = `[W1.2.2] Session "${sessionId}" completing without pattern extraction. Program "${programId}" has not updated learnedPatterns since session start.`;
 
           if (complianceConfig.derezGate.mode === "strict") {
-            console.error(message);
-            return jsonResult({
-              success: false,
-              error: "Session cannot complete without pattern extraction. Update program_state.learnedPatterns first.",
-              sessionId,
-              programId,
-            });
+            // Still archive to free the budget slot; surface miss as warning flag
+            console.warn(message);
+            patternExtractionMissing = true;
           } else {
             // Lenient mode: log warning
             console.warn(message);
@@ -331,7 +328,12 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
     success: true,
   });
 
-  return jsonResult({ success: true, sessionId, message: `Status updated: "${args.status}"` });
+  return jsonResult({
+    success: true,
+    sessionId,
+    message: `Status updated: "${args.status}"`,
+    ...(patternExtractionMissing && { patternExtractionMissing: true }),
+  });
 }
 
 /** Max concurrent sessions (hardcoded MVP — will move to config) */


### PR DESCRIPTION
## Bug

In `updateSessionHandler`, when `update_session(state: "complete")` was called in **strict derez-gate mode** without prior pattern extraction, the handler returned `{ success: false }` immediately and never archived the session. The budget slot was permanently leaked — the session counted against the fleet cap forever with no way to reclaim it.

## Fix

- Removed the early `return` in the strict-mode branch of the derez gate check.
- `console.error` → `console.warn` (the session is now proceeding, so it's a warning not a hard error).
- Set `patternExtractionMissing = true` instead of aborting.
- The final return now spreads `patternExtractionMissing: true` into the response when the flag is set, so callers can detect the hygiene miss without blocking archival.

The session now **always archives** when `state: "complete"` is passed, freeing the budget slot. The pattern-extraction miss is surfaced as `patternExtractionMissing: true` in the response.

## ⛔ SARK gate

This change governs the fleet shutdown path. **Do not merge without SARK approval.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)