### PR TITLE
test(pulse): handler-level stale-exclusion test + sessions index back-port

### DIFF
--- a/infra/firestore.indexes.json
+++ b/infra/firestore.indexes.json
@@ -149,6 +149,15 @@
       ]
     },
     {
+      "collectionGroup": "sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "archived", "order": "ASCENDING" },
+        { "fieldPath": "programId", "order": "ASCENDING" },
+        { "fieldPath": "lastUpdate", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "tasks",
       "queryScope": "COLLECTION",
       "fields": [

--- a/services/mcp-server/src/__tests__/metrics-endpoints.test.ts
+++ b/services/mcp-server/src/__tests__/metrics-endpoints.test.ts
@@ -9,7 +9,8 @@ import type { AuthContext } from "../auth/authValidator.js";
 // Mock Firestore with chainable query methods
 const mockQuery = {
   where: jest.fn().mockReturnThis(),
-  get: jest.fn(() => Promise.resolve({ docs: [], size: 0 })),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get: jest.fn((): Promise<{ docs: any[]; size: number }> => Promise.resolve({ docs: [], size: 0 })),
 };
 
 jest.mock("../firebase/client.js", () => ({
@@ -73,6 +74,108 @@ describe("Metrics Endpoints - Capability Gates", () => {
       const data = JSON.parse(text);
       expect(data.success).toBe(false);
       expect(data.error).toContain("fleet.read");
+    });
+  });
+
+  describe("get_fleet_health — subscriptionBudget stale-session exclusion", () => {
+    beforeEach(() => {
+      mockQuery.get.mockReset();
+      mockQuery.get.mockResolvedValue({ docs: [], size: 0 });
+    });
+
+    it("excludes stale sessions from activeSessionCount and reports staleSessionsExcluded", async () => {
+      const now = Date.now();
+      // Fresh session: heartbeat 1 minute ago
+      const freshTs = { toDate: () => new Date(now - 1 * 60 * 1000) };
+      // Stale session: heartbeat 45 minutes ago (beyond 30min threshold)
+      const staleTs = { toDate: () => new Date(now - 45 * 60 * 1000) };
+
+      const freshDoc = {
+        id: "fresh-session",
+        data: () => ({
+          model: "claude-sonnet-4-6",
+          lastHeartbeat: freshTs,
+          lastUpdate: freshTs,
+        }),
+      };
+      const staleDoc = {
+        id: "stale-session",
+        data: () => ({
+          model: "claude-opus-4-6",
+          lastHeartbeat: staleTs,
+          lastUpdate: staleTs,
+        }),
+      };
+
+      // getFleetHealthHandler runs Promise.all([programs, pendingRelay, pendingTasks, sessions])
+      // mockQuery.get is called in that order — 4th call returns our session docs
+      mockQuery.get
+        .mockResolvedValueOnce({ docs: [], size: 0 })   // programs
+        .mockResolvedValueOnce({ docs: [], size: 0 })   // pending relay
+        .mockResolvedValueOnce({ docs: [], size: 0 })   // pending tasks
+        .mockResolvedValueOnce({ docs: [freshDoc, staleDoc], size: 2 }); // sessions
+
+      const result = await getFleetHealthHandler(adminAuth, { detail: "summary" });
+      const data = JSON.parse(result.content[0].text);
+
+      expect(data.success).toBe(true);
+      // Only the fresh session counts against the budget
+      expect(data.subscriptionBudget.activeSessionCount).toBe(1);
+      // Stale session is surfaced for diagnosability
+      expect(data.subscriptionBudget.staleSessionsExcluded).toBe(1);
+      // Model tier counts only fresh sessions
+      expect(data.subscriptionBudget.byModelTier.sonnet).toBe(1);
+      expect(data.subscriptionBudget.byModelTier.opus).toBeUndefined();
+      expect(data.subscriptionBudget.utilizationPercent).toBe(6.25); // 1/16
+    });
+
+    it("counts all sessions when all heartbeats are fresh", async () => {
+      const now = Date.now();
+      const freshTs = { toDate: () => new Date(now - 2 * 60 * 1000) }; // 2 min ago
+
+      const docs = [
+        { id: "s1", data: () => ({ model: "claude-opus-4-6", lastHeartbeat: freshTs, lastUpdate: freshTs }) },
+        { id: "s2", data: () => ({ model: "claude-sonnet-4-6", lastHeartbeat: freshTs, lastUpdate: freshTs }) },
+      ];
+
+      mockQuery.get
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: docs, size: 2 });
+
+      const result = await getFleetHealthHandler(adminAuth, { detail: "summary" });
+      const data = JSON.parse(result.content[0].text);
+
+      expect(data.subscriptionBudget.activeSessionCount).toBe(2);
+      expect(data.subscriptionBudget.staleSessionsExcluded).toBe(0);
+    });
+
+    it("falls back to lastUpdate when lastHeartbeat is absent", async () => {
+      const now = Date.now();
+      const recentUpdate = { toDate: () => new Date(now - 5 * 60 * 1000) }; // 5 min ago
+
+      const doc = {
+        id: "no-hb",
+        data: () => ({
+          model: "claude-sonnet-4-6",
+          lastHeartbeat: null,          // no heartbeat field
+          lastUpdate: recentUpdate,     // but lastUpdate is fresh
+        }),
+      };
+
+      mockQuery.get
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: [], size: 0 })
+        .mockResolvedValueOnce({ docs: [doc], size: 1 });
+
+      const result = await getFleetHealthHandler(adminAuth, { detail: "summary" });
+      const data = JSON.parse(result.content[0].text);
+
+      // Fresh lastUpdate should count even without lastHeartbeat
+      expect(data.subscriptionBudget.activeSessionCount).toBe(1);
+      expect(data.subscriptionBudget.staleSessionsExcluded).toBe(0);
     });
   });
 

--- a/services/mcp-server/src/modules/pulse.ts
+++ b/services/mcp-server/src/modules/pulse.ts
@@ -336,6 +336,14 @@ export async function updateSessionHandler(auth: AuthContext, rawArgs: unknown):
 
 /** Max concurrent sessions (hardcoded MVP — will move to config) */
 const MAX_SESSIONS = 16;
+/**
+ * A session silent longer than this is presumed dead/wedged and stops holding a
+ * budget slot (it is still archived:false and still surfaced as stale — it is
+ * reaped separately by the dispatcher). Decouples the budget from the reaper so
+ * dead sessions don't lock out new spawns. See grid decision
+ * vector-fleet-session-pruning. Generous so a long single op still counts.
+ */
+const BUDGET_STALE_MINUTES = 30;
 /** Context threshold for "above threshold" classification */
 const CONTEXT_THRESHOLD_PERCENT = 60;
 
@@ -413,18 +421,34 @@ export async function getFleetHealthHandler(auth: AuthContext, rawArgs: unknown)
   });
 
   // === subscriptionBudget (both modes) ===
+  // Count only LIVE sessions against the budget: archived==false alone is
+  // liveness-blind, so dead/wedged sessions that never self-completed used to
+  // hold slots forever (observed 14/16 with working:0). A session whose
+  // heartbeat is stale beyond BUDGET_STALE_MINUTES no longer counts; it stays
+  // archived:false and reap-eligible. See grid decision vector-fleet-session-pruning.
   const byModelTier: Record<string, number> = {};
+  let activeSessionCount = 0;
   for (const doc of activeSessionsSnap.docs) {
-    const model = doc.data().model as string | undefined;
+    const sdata = doc.data();
+    const hbTime = sdata.lastHeartbeat?.toDate?.()?.getTime()
+      ?? sdata.lastUpdate?.toDate?.()?.getTime()
+      ?? 0;
+    const ageMinutes = hbTime ? (now - hbTime) / 60000 : Infinity;
+    if (ageMinutes > BUDGET_STALE_MINUTES) continue; // dead/wedged — excluded from budget, still reaped separately
+    activeSessionCount++;
+    const model = sdata.model as string | undefined;
     const tier = model?.includes("opus") ? "opus" : "sonnet";
     byModelTier[tier] = (byModelTier[tier] || 0) + 1;
   }
-  const activeSessionCount = activeSessionsSnap.size;
+  const staleSessionsExcluded = activeSessionsSnap.size - activeSessionCount;
   const subscriptionBudget = {
     activeSessionCount,
     byModelTier,
     maxSessions: MAX_SESSIONS,
     utilizationPercent: Math.round((activeSessionCount / MAX_SESSIONS) * 10000) / 100,
+    // archived==false but heartbeat-stale beyond BUDGET_STALE_MINUTES — not
+    // counted against the cap; pending reap. Surfaced for diagnosability.
+    staleSessionsExcluded,
   };
 
   // Summary mode: return early


### PR DESCRIPTION
## Summary

- Adds handler-level unit tests for `getFleetHealthHandler` proving stale sessions (heartbeat > `BUDGET_STALE_MINUTES = 30min`) are excluded from `subscriptionBudget.activeSessionCount` and counted in `staleSessionsExcluded`, while fresh sessions are counted normally
- Back-ports the sessions composite index (`archived`, `programId`, `lastUpdate`) that VECTOR created live on cerebro-grid to `infra/firestore.indexes.json`

## Test plan

- [x] `excludes stale sessions from activeSessionCount and reports staleSessionsExcluded` — 1 fresh + 1 stale doc, verifies count=1, staleSessionsExcluded=1, correct byModelTier, utilizationPercent=6.25
- [x] `counts all sessions when all heartbeats are fresh` — 2 fresh docs, verifies count=2, staleSessionsExcluded=0
- [x] `falls back to lastUpdate when lastHeartbeat is absent` — null lastHeartbeat + fresh lastUpdate, verifies session still counted
- [x] All 16 tests pass locally (`npx jest --testPathPattern metrics-endpoints --no-coverage`)

Closes the test gap noted in cachebash PR #371. Depends on #371 merging first (or can be reviewed independently — CI will go green once #371 merges). Also back-ports the sessions composite index that VECTOR created live on cerebro-grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)