### PR TITLE
fix(relay): reject unknown/non-local targets — relay false-success guard

### DIFF
--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -750,3 +750,134 @@ describe("E-1/ADR-014 Relay-Mirror Classification at Creation", () => {
     expect(mirror.created_via.tool).toBeDefined();
   });
 });
+
+/**
+ * Relay false-success guard (PR: basher/relay-false-success).
+ *
+ * relay_send_message must NOT silently accept unknown/non-local targets.
+ * Acceptance:
+ *   - Unknown target → explicit failure, no message ID minted.
+ *   - Valid program → still works.
+ *   - Valid hardcoded group → still works (multicast).
+ *   - Dynamic Firestore-only group → resolved to members (multicast).
+ */
+describe("Relay false-success guard", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+    initializeFirebase();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    const testUser = await seedTestUser("test-user-false-success");
+    userId = testUser.userId;
+  });
+
+  it("rejects unknown target with clear error — no message ID minted", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "hello",
+      source: "basher",
+      target: "nonexistent_xyz_program",
+      message_type: "STATUS",
+      idempotency_key: "false-success-unknown-1",
+    }) as never);
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/unknown relay target/i);
+    expect(res.messageId).toBeUndefined();
+    expect(res.multicastId).toBeUndefined();
+
+    // No relay doc written
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    expect(relay.empty).toBe(true);
+  });
+
+  it("allows send to a registered program (SPECIAL_PROGRAMS: iso)", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "hello iso",
+      source: "basher",
+      target: "iso",
+      message_type: "STATUS",
+      idempotency_key: "false-success-iso-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.messageId).toBeDefined();
+  });
+
+  it("allows send to a registered program (REGISTERED_PROGRAMS: sark)", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "hello sark",
+      source: "basher",
+      target: "sark",
+      message_type: "STATUS",
+      idempotency_key: "false-success-sark-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.messageId).toBeDefined();
+  });
+
+  it("allows multicast to a hardcoded group (council)", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "iso"), {
+      message: "hello council",
+      source: "iso",
+      target: "council",
+      message_type: "STATUS",
+      idempotency_key: "false-success-council-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.recipients).toBeGreaterThan(1);
+    expect(res.multicastId).toBeDefined();
+  });
+
+  it("resolves and delivers to a Firestore-only dynamic group (grid-help)", async () => {
+    // Seed grid-help group membership in programs collection
+    await db.doc(`tenants/${userId}/programs/vector`).set({ programId: "vector", groups: ["grid-help"], active: true });
+    await db.doc(`tenants/${userId}/programs/tensor`).set({ programId: "tensor", groups: ["grid-help"], active: true });
+    await db.doc(`tenants/${userId}/programs/scalar`).set({ programId: "scalar", groups: ["grid-help"], active: true });
+
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "help request",
+      source: "basher",
+      target: "grid-help",
+      message_type: "STATUS",
+      idempotency_key: "false-success-gridhelp-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.recipients).toBe(3);
+    expect(res.targets).toEqual(expect.arrayContaining(["vector", "tensor", "scalar"]));
+
+    // Relay docs exist for each member
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    const relayTargets = relay.docs.map((d) => d.data().target);
+    expect(relayTargets).toContain("vector");
+    expect(relayTargets).toContain("tensor");
+    expect(relayTargets).toContain("scalar");
+  });
+
+  it("allows special relay targets: user, admin", async () => {
+    const resUser = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "hello user",
+      source: "basher",
+      target: "user",
+      message_type: "STATUS",
+      idempotency_key: "false-success-user-1",
+    }) as never);
+    expect(resUser.success).toBe(true);
+
+    const resAdmin = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "hello admin",
+      source: "basher",
+      target: "admin",
+      message_type: "STATUS",
+      idempotency_key: "false-success-admin-1",
+    }) as never);
+    expect(resAdmin.success).toBe(true);
+  });
+});

--- a/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
+++ b/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
@@ -65,10 +65,12 @@ jest.mock("../config/compliance.js", () => ({
 jest.mock("../config/programs.js", () => ({
   isGroupTarget: jest.fn(() => false),
   PROGRAM_GROUPS: {},
+  isProgramRegistered: jest.fn(async () => true),
 }));
 
 jest.mock("../modules/programRegistry.js", () => ({
   resolveTargetsAsync: jest.fn(async (_uid: string, target: string) => [target]),
+  resolveGroupAsync: jest.fn(async () => []),
   listGroupsAsync: jest.fn(async () => []),
 }));
 

--- a/services/mcp-server/src/__tests__/relay-owner-send.test.ts
+++ b/services/mcp-server/src/__tests__/relay-owner-send.test.ts
@@ -57,9 +57,11 @@ jest.mock("../config/compliance.js", () => ({
 jest.mock("../config/programs.js", () => ({
   isGroupTarget: jest.fn(() => false),
   PROGRAM_GROUPS: {},
+  isProgramRegistered: jest.fn(async () => true),
 }));
 jest.mock("../../src/modules/programRegistry.js", () => ({
   resolveTargetsAsync: jest.fn(async (_uid: string, target: string) => [target]),
+  resolveGroupAsync: jest.fn(async () => []),
 }));
 jest.mock("../types/relay-schemas.js", () => ({
   validatePayload: jest.fn(() => ({ valid: true })),

--- a/services/mcp-server/src/__tests__/send-directive.test.ts
+++ b/services/mcp-server/src/__tests__/send-directive.test.ts
@@ -48,10 +48,12 @@ jest.mock("../config/compliance.js", () => ({
 jest.mock("../config/programs.js", () => ({
   isGroupTarget: jest.fn(() => false),
   PROGRAM_GROUPS: {},
+  isProgramRegistered: jest.fn(async () => true),
 }));
 
 jest.mock("./../../src/modules/programRegistry.js", () => ({
   resolveTargetsAsync: jest.fn(async (_uid: string, target: string) => [target]),
+  resolveGroupAsync: jest.fn(async () => []),
 }));
 
 jest.mock("../types/relay-schemas.js", () => ({

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -8,8 +8,8 @@ import { verifySource, isAdmin, logAudit, generateCorrelationId } from "../middl
 import * as admin from "firebase-admin";
 import { AuthContext } from "../auth/authValidator.js";
 import { RELAY_DEFAULT_TTL_SECONDS } from "../types/relay.js";
-import { isGroupTarget } from "../config/programs.js";
-import { resolveTargetsAsync, listGroupsAsync } from "./programRegistry.js";
+import { isGroupTarget, isProgramRegistered, PROGRAM_GROUPS } from "../config/programs.js";
+import { resolveTargetsAsync, resolveGroupAsync, listGroupsAsync } from "./programRegistry.js";
 import { validatePayload } from "../types/relay-schemas.js";
 import { emitEvent } from "./events.js";
 import { emitAnalyticsEvent } from "./analytics.js";
@@ -149,7 +149,33 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
   const expiresAt = admin.firestore.Timestamp.fromMillis(Date.now() + ttl * 1000);
 
   // Resolve target — may be a group (fan-out) or single program
-  const targets = await resolveTargetsAsync(auth.userId, args.target);
+  let targets = await resolveTargetsAsync(auth.userId, args.target);
+
+  // Validate target reachability — reject unknown/non-local targets (false-success guard).
+  // If the target wasn't resolved by the hardcoded group list or @role prefix, it came
+  // back as-is. Check Firestore-only groups first (e.g. grid-help), then program registry.
+  // Note: use rawTarget string to avoid isGroupTarget's type guard narrowing to never.
+  const rawTarget: string = args.target;
+  if (!(rawTarget in PROGRAM_GROUPS) && !rawTarget.startsWith("@") && targets.length === 1 && targets[0] === rawTarget) {
+    const dynamicGroupMembers = await resolveGroupAsync(auth.userId, rawTarget);
+    if (dynamicGroupMembers.length > 0) {
+      // Dynamic group (Firestore-only, e.g. "grid-help") — fan out to members
+      targets = dynamicGroupMembers;
+    } else {
+      // Not a group — must be a registered program or a known special relay target
+      const RELAY_SPECIAL_TARGETS = new Set(["user", "admin"]);
+      if (!RELAY_SPECIAL_TARGETS.has(rawTarget)) {
+        const registered = await isProgramRegistered(auth.userId, rawTarget);
+        if (!registered) {
+          return jsonResult({
+            success: false,
+            error: `Unknown relay target "${rawTarget}". Target must be a registered program, group, or role. Message not sent.`,
+          });
+        }
+      }
+    }
+  }
+
   const isMulticast = targets.length > 1;
   const multicastId = isMulticast ? db.collection("_").doc().id : undefined;
 


### PR DESCRIPTION
## Problem

`relay_send_message` accepted any target string and returned `success:true` with a minted message ID, regardless of whether the target was reachable. A tenant program (e.g. cerebro) calling `relay_send_message` to `grid-help` or `vector_cerebro` received false success — the message was silently stranded in its isolated relay, delivered nowhere.

## Fix

After `resolveTargetsAsync`, if the resolved targets array is `[target]` (the target came back unmodified — not a hardcoded group, not a @role):

1. **Dynamic Firestore group check** — call `resolveGroupAsync` to detect Firestore-only groups (e.g. `grid-help` with members seeded in the programs collection). If it resolves to members, fan out to them.
2. **Program registration check** — if it's not a group, validate via `isProgramRegistered`. Reject with a clear error if unknown.

Special relay targets `user` and `admin` are whitelisted. All hardcoded programs (`REGISTERED_PROGRAMS`, `SPECIAL_PROGRAMS`) and groups (`PROGRAM_GROUPS`) continue to work unchanged.

## Acceptance

- ✅ Unknown target → `success:false`, explicit error, no message ID minted, no relay doc written
- ✅ Valid program (iso, sark) → still works
- ✅ Hardcoded group (council) → multicast, still works
- ✅ Firestore-only dynamic group (grid-help) → resolved to members, proper multicast
- ✅ Special targets (user, admin) → allowed

## Tests

5 new cases in `"Relay false-success guard"` describe block in `relay-delivery.test.ts`. Regression: all existing relay tests pass.

**SARK gate:** relay trust boundary (cross-grid egress validity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)