### PR TITLE
feat(relay): grid-help tenant-route + wake-on-arrival

### DIFF
--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -881,3 +881,112 @@ describe("Relay false-success guard", () => {
     expect(resAdmin.success).toBe(true);
   });
 });
+
+/**
+ * Grid-help tenant-route + wake-on-arrival (PR: basher/grid-help-tenant-route).
+ *
+ * When a message targets "grid-help" and payload.tenant is set:
+ *   - Group members receive the message (existing group fanout).
+ *   - vector_<tenant> ALSO receives a relay doc (tenant-specific delivery).
+ *   - Tenant isolation: other vector_* programs do NOT see the message.
+ *   - message_type is irrelevant — group target is the discriminator.
+ *
+ * Wake-on-arrival is fire-and-forget; tested indirectly (no assertion on spawn).
+ */
+describe("Grid-help tenant-route", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+    initializeFirebase();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    const testUser = await seedTestUser("test-user-grid-help");
+    userId = testUser.userId;
+
+    // Seed grid-help group members and tenant owner
+    await db.doc(`tenants/${userId}/programs/vector`).set({ programId: "vector", groups: ["grid-help"], active: true });
+    await db.doc(`tenants/${userId}/programs/tensor`).set({ programId: "tensor", groups: ["grid-help"], active: true });
+    await db.doc(`tenants/${userId}/programs/scalar`).set({ programId: "scalar", groups: ["grid-help"], active: true });
+    await db.doc(`tenants/${userId}/programs/vector_cerebro`).set({ programId: "vector_cerebro", groups: [], active: true });
+  });
+
+  it("delivers to group members AND vector_<tenant> when payload.tenant is set", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "cerebro needs help",
+      source: "rezzed.agent",
+      target: "grid-help",
+      message_type: "STATUS",
+      payload: { tenant: "cerebro", taskId: "t-abc" },
+      idempotency_key: "grid-help-tenant-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.recipients).toBe(4); // vector, tensor, scalar + vector_cerebro
+
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    const relayTargets = relay.docs.map((d) => d.data().target);
+    expect(relayTargets).toContain("vector");
+    expect(relayTargets).toContain("tensor");
+    expect(relayTargets).toContain("scalar");
+    expect(relayTargets).toContain("vector_cerebro");
+  });
+
+  it("tenant isolation: other vector_* programs do not receive the message", async () => {
+    // Seed a different tenant owner that should NOT receive this message
+    await db.doc(`tenants/${userId}/programs/vector_other`).set({ programId: "vector_other", groups: [], active: true });
+
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "cerebro help request",
+      source: "rezzed.agent",
+      target: "grid-help",
+      message_type: "STATUS",
+      payload: { tenant: "cerebro", taskId: "t-def" },
+      idempotency_key: "grid-help-isolation-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    const relayTargets = relay.docs.map((d) => d.data().target);
+    expect(relayTargets).toContain("vector_cerebro");
+    expect(relayTargets).not.toContain("vector_other"); // tenant isolation
+  });
+
+  it("grid-help without payload.tenant fans out to group only", async () => {
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "basher"), {
+      message: "group-only message",
+      source: "basher",
+      target: "grid-help",
+      message_type: "STATUS",
+      idempotency_key: "grid-help-no-tenant-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    expect(res.recipients).toBe(3); // vector, tensor, scalar only
+
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    const relayTargets = relay.docs.map((d) => d.data().target);
+    expect(relayTargets).not.toContain("vector_cerebro");
+  });
+
+  it("message_type is irrelevant — tenant route triggers on group target only", async () => {
+    // DIRECTIVE type should also get tenant routing
+    const res = parse(await sendMessageHandler(mirrorAuth(userId, "iso"), {
+      message: "help directive",
+      source: "iso",
+      target: "grid-help",
+      message_type: "DIRECTIVE",
+      payload: { tenant: "cerebro" },
+      idempotency_key: "grid-help-msgtype-1",
+    }) as never);
+
+    expect(res.success).toBe(true);
+    const relay = await db.collection(`tenants/${userId}/relay`).get();
+    const relayTargets = relay.docs.map((d) => d.data().target);
+    expect(relayTargets).toContain("vector_cerebro");
+  });
+});

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -176,6 +176,27 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
     }
   }
 
+  // Grid-help tenant routing: when a message targets the grid-help group and the
+  // sender supplies payload.tenant, also deliver to vector_<tenant> — the orchestrator
+  // that owns that tenant and acts on the help request. The group members (vector,
+  // tensor, scalar) always receive it too; the extra delivery is tenant-specific.
+  //
+  // Tenant isolation: only vector_<tenant> is added — other vector_* programs never
+  // see requests for a different tenant.
+  //
+  // message_type decision (item 3): routing is triggered by rawTarget === "grid-help",
+  // NOT by message_type. The bridge may use STATUS, ALERT, DIRECTIVE — all are treated
+  // equally. No dedicated help message_type is needed; the group target is the discriminator.
+  let tenantOwnerToWake: string | null = null;
+  if (rawTarget === "grid-help" && args.payload?.tenant) {
+    const tenantOwner = `vector_${String(args.payload.tenant)}`;
+    const isTenantOwnerRegistered = await isProgramRegistered(auth.userId, tenantOwner);
+    if (isTenantOwnerRegistered && !targets.includes(tenantOwner)) {
+      targets = [...targets, tenantOwner];
+      tenantOwnerToWake = tenantOwner;
+    }
+  }
+
   const isMulticast = targets.length > 1;
   const multicastId = isMulticast ? db.collection("_").doc().id : undefined;
 
@@ -253,6 +274,14 @@ export async function sendMessageHandler(auth: AuthContext, rawArgs: unknown): P
     });
 
     await batch.commit();
+
+    // Wake tenant owner after delivery (fire-and-forget — don't block the send response)
+    if (tenantOwnerToWake) {
+      const tenantOwnerCapture = tenantOwnerToWake;
+      import("./wake/onDemandWake.js").then(({ wakeTarget }) =>
+        wakeTarget({ userId: auth.userId, target: tenantOwnerCapture, waitForAlive: false, callerSource: args.source })
+      ).catch((err) => console.warn(`[grid-help] wake ${tenantOwnerCapture}:`, err));
+    }
 
     // Record idempotency key for multicast
     if (args.idempotency_key) {


### PR DESCRIPTION
## Problem

When the cerebro bridge calls `relay_send_message` to `grid-help` with `payload.tenant=cerebro`, the home grid fans out to the group members (vector, tensor, scalar) but no tenant-specific orchestrator receives it. `vector_cerebro` — the program that actually acts — is never notified.

## Fix

After the false-success guard resolves `grid-help` to its members, if `payload.tenant` is set:
1. Compute `vector_<tenant>` (e.g. `vector_cerebro`)
2. Validate it's a registered program (`isProgramRegistered`)
3. Append it to the fanout targets — so it receives its own relay doc
4. After the batch commit, call `wakeTarget` fire-and-forget for the tenant owner

**Tenant isolation:** only `vector_<tenant>` is added — `vector_other` and any other tenant orchestrators are never included.

**message_type decision (spec item 3):** routing is triggered by `rawTarget === "grid-help"`, NOT by `message_type`. The bridge may send STATUS, ALERT, or DIRECTIVE — all are treated identically. The group target is the discriminator; no dedicated help message_type needed.

## Acceptance

- ✅ `payload.tenant=cerebro` → group members + `vector_cerebro` receive relay docs
- ✅ `vector_other` does NOT receive the message (tenant isolation)
- ✅ No `payload.tenant` → group fanout only (vector_cerebro not added)
- ✅ Any `message_type` gets tenant routing when target is `grid-help`
- ✅ Wake-on-arrival fires for `vector_cerebro` (fire-and-forget)

## Tests

4 new cases in `"Grid-help tenant-route"` describe block. Seeded programs: vector, tensor, scalar (grid-help members) + vector_cerebro (tenant owner).

**Depends on:** #375 (false-success guard — dynamic group resolution for grid-help)  
**SARK gate:** relay trust boundary + cross-grid egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)