### PR TITLE
fix(deploy): exclude apps/ from gcloud source upload

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,5 +1,6 @@
 # Ignore everything except the MCP server
 app/
+apps/
 /firebase/
 .git/
 node_modules/


### PR DESCRIPTION
## What
Add `apps/` to `.gcloudignore` so the lite Cloud Run source deploy stops uploading the 631M mobile app dir.

## Why
`gcloud run deploy cachebash-lite --source .` (cerebro-grid LITE deploy) **crashed** during source upload:
```
ERROR: gcloud crashed (FileNotFoundError): apps/mobile/ios/Pods/Headers/Public/expo-dev-launcher/EXDevLauncher/EXDevLauncherReactNativeFactory.h
```
`.gcloudignore` excluded `app/` (singular) but not `apps/` (the mobile app, 631M, with broken iOS Pods symlinks). `apps/` is unrelated to the MCP server build. Without this, every future lite/tenant deploy crashes.

## Verified
Re-ran the lite deploy with this fix → upload succeeded → **cachebash-lite rev 00005-k64** deployed clean (relay false-success guard #375 + grid-help tenant-route #376 now live on cerebro tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)