### PR TITLE
feat(mcp-lite): request_help tool — cerebro tenant help-drop egress

### DIFF
--- a/services/mcp-server/src/__tests__/requestHelp.test.ts
+++ b/services/mcp-server/src/__tests__/requestHelp.test.ts
@@ -1,0 +1,305 @@
+/**
+ * request_help tool — unit tests.
+ *
+ * Verifies:
+ *   1. Handler sends correct MCP handshake sequence (initialize → notifications/initialized → tools/call)
+ *   2. Payload carries tenant stamp for home-grid routing
+ *   3. target=grid-help, source=rezzed.agent, message_type=DIRECTIVE
+ *   4. Returns Sayf-facing lexicon string + correlationId
+ *   5. Session is reused across calls (no re-handshake)
+ *   6. Re-handshakes on 401
+ *   7. Missing REZZED_AGENT_KEY throws clearly (misconfiguration)
+ *   8. request_help absent from full profile, present in lite profile
+ */
+
+// Break ESM chains (@octokit/rest is ESM-only; Jest cannot parse it without these mocks)
+jest.mock("../modules/github-sync", () => ({}));
+jest.mock("../tools/feedback", () => ({ handlers: {}, definitions: [] }));
+
+import { requestHelpHandler, _setFetchFn } from "../modules/requestHelp";
+import { TOOL_DEFINITIONS } from "../tools/index";
+
+// ── Mock fetch helpers ────────────────────────────────────────────────────────
+
+interface MockCall {
+  url: string;
+  method: string;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+}
+
+function makeMcpFetch({
+  sessionId = "test-sid-001",
+  toolsCallStatus = 200,
+  rejectOn = null as string | null,
+} = {}) {
+  const calls: MockCall[] = [];
+  const fn = async (url: string, opts: RequestInit) => {
+    const body = opts?.body ? JSON.parse(opts.body as string) : {};
+    calls.push({
+      url,
+      method: opts?.method as string,
+      body,
+      headers: (opts?.headers ?? {}) as Record<string, string>,
+    });
+
+    if (rejectOn && body.method === rejectOn) {
+      throw new Error("ECONNREFUSED");
+    }
+
+    if (body.method === "initialize") {
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: (h: string) =>
+            h.toLowerCase() === "mcp-session-id" ? sessionId : null,
+        },
+        text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }),
+      } as unknown as Response;
+    }
+    if (body.method === "notifications/initialized") {
+      return {
+        ok: true,
+        status: 202,
+        headers: { get: () => null },
+        text: async () => "",
+      } as unknown as Response;
+    }
+    if (body.method === "tools/call") {
+      return {
+        ok: toolsCallStatus < 400,
+        status: toolsCallStatus,
+        headers: { get: () => null },
+        text: async () =>
+          toolsCallStatus < 400
+            ? JSON.stringify({ jsonrpc: "2.0", id: 2, result: { content: [] } })
+            : "error",
+      } as unknown as Response;
+    }
+    return {
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      text: async () => "unexpected",
+    } as unknown as Response;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const fakeAuth = {} as any;
+
+beforeEach(() => {
+  process.env.REZZED_AGENT_KEY = "cb_testrelaykey00000000000000000000000000000";
+  process.env.CACHEBASH_TENANT_ID = "cerebro";
+  process.env.HOME_GRID_MCP = "https://api.cachebash.dev/v1/mcp";
+});
+
+afterEach(() => {
+  delete process.env.REZZED_AGENT_KEY;
+  _setFetchFn(globalThis.fetch);
+});
+
+// ── MCP handshake sequence ────────────────────────────────────────────────────
+
+describe("MCP handshake", () => {
+  it("does 3-step sequence on first call: initialize → notifications/initialized → tools/call", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "email fetch failed", loopId: "morning-queue" });
+    // Give the async fire-and-forget a tick to run
+    await new Promise((r) => setImmediate(r));
+
+    const methods = mockFetch.calls.map((c) => c.body.method);
+    expect(methods[0]).toBe("initialize");
+    expect(methods[1]).toBe("notifications/initialized");
+    expect(methods[2]).toBe("tools/call");
+    expect(mockFetch.calls).toHaveLength(3);
+  });
+
+  it("passes Mcp-Session-Id header to tools/call", async () => {
+    const SID = "sid-abc-123";
+    const mockFetch = makeMcpFetch({ sessionId: SID });
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "test" });
+    await new Promise((r) => setImmediate(r));
+
+    const toolsCall = mockFetch.calls.find((c) => c.body.method === "tools/call");
+    expect(toolsCall?.headers["Mcp-Session-Id"]).toBe(SID);
+  });
+
+  it("reuses session across calls — no re-handshake on second call", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "first" });
+    await new Promise((r) => setImmediate(r));
+    await requestHelpHandler(fakeAuth, { symptom: "second" });
+    await new Promise((r) => setImmediate(r));
+
+    // First: 3 calls. Second: 1 (tools/call only).
+    expect(mockFetch.calls).toHaveLength(4);
+    expect(mockFetch.calls[3].body.method).toBe("tools/call");
+  });
+
+  it("re-handshakes on 401 and retries tools/call", async () => {
+    let callCount = 0;
+    const mockFetch = async (url: string, opts: RequestInit) => {
+      const body = JSON.parse(opts.body as string);
+      callCount++;
+      if (body.method === "initialize") {
+        return {
+          ok: true, status: 200,
+          headers: { get: (h: string) => h.toLowerCase() === "mcp-session-id" ? "new-sid" : null },
+          text: async () => "{}",
+        } as unknown as Response;
+      }
+      if (body.method === "notifications/initialized") {
+        return { ok: true, status: 202, headers: { get: () => null }, text: async () => "" } as unknown as Response;
+      }
+      if (body.method === "tools/call") {
+        // First tools/call returns 401; after re-handshake it succeeds
+        if (callCount <= 3) {
+          return { ok: false, status: 401, headers: { get: () => null }, text: async () => "unauthorized" } as unknown as Response;
+        }
+        return { ok: true, status: 200, headers: { get: () => null }, text: async () => "{}" } as unknown as Response;
+      }
+      return { ok: false, status: 500, headers: { get: () => null }, text: async () => "" } as unknown as Response;
+    };
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "session expired" });
+    await new Promise((r) => setImmediate(r));
+    // 3 (first handshake+call) + 3 (re-handshake + retry call)
+    expect(callCount).toBe(6);
+  });
+});
+
+// ── Payload ───────────────────────────────────────────────────────────────────
+
+describe("relay payload", () => {
+  it("sets source=rezzed.agent, target=grid-help, message_type=DIRECTIVE", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "x" });
+    await new Promise((r) => setImmediate(r));
+
+    const toolsCall = mockFetch.calls.find((c) => c.body.method === "tools/call");
+    const callArgs = (toolsCall?.body as any)?.params?.arguments;
+    expect(callArgs?.source).toBe("rezzed.agent");
+    expect(callArgs?.target).toBe("grid-help");
+    expect(callArgs?.message_type).toBe("DIRECTIVE");
+  });
+
+  it("stamps payload.tenant with CACHEBASH_TENANT_ID for home-grid routing", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, { symptom: "stuck" });
+    await new Promise((r) => setImmediate(r));
+
+    const toolsCall = mockFetch.calls.find((c) => c.body.method === "tools/call");
+    const payload = (toolsCall?.body as any)?.params?.arguments?.payload;
+    expect(payload?.tenant).toBe("cerebro");
+  });
+
+  it("carries symptom, loopId, context, and msgId in payload", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await requestHelpHandler(fakeAuth, {
+      symptom: "transcript missing",
+      loopId: "call-review",
+      context: "third attempt",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    const toolsCall = mockFetch.calls.find((c) => c.body.method === "tools/call");
+    const payload = (toolsCall?.body as any)?.params?.arguments?.payload;
+    expect(payload?.symptom).toBe("transcript missing");
+    expect(payload?.loopId).toBe("call-review");
+    expect(payload?.context).toBe("third attempt");
+    expect(typeof payload?.msgId).toBe("string");
+  });
+});
+
+// ── Return value ──────────────────────────────────────────────────────────────
+
+describe("return value", () => {
+  it("returns sayf string with no grid jargon", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    const result = await requestHelpHandler(fakeAuth, { symptom: "x" });
+    const jargon = ["dispatch", "derez", "worktree", "gsp", "iso", "vector", "tensor", "relay"];
+    const found = jargon.filter((w) => result.sayf.toLowerCase().includes(w));
+    expect(found).toHaveLength(0);
+    expect(result.sayf).toContain("support");
+  });
+
+  it("returns a correlationId UUID", async () => {
+    const mockFetch = makeMcpFetch();
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    const result = await requestHelpHandler(fakeAuth, { symptom: "x" });
+    expect(result.correlationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+});
+
+// ── Fire-and-forget safety ────────────────────────────────────────────────────
+
+describe("fire-and-forget", () => {
+  it("does not throw when egress returns 500", async () => {
+    const mockFetch = makeMcpFetch({ toolsCallStatus: 500 });
+    _setFetchFn(mockFetch as unknown as typeof fetch);
+
+    await expect(
+      requestHelpHandler(fakeAuth, { symptom: "x" })
+    ).resolves.toBeDefined();
+  });
+
+  it("does not throw on network error", async () => {
+    const errorFetch = async () => { throw new Error("ECONNREFUSED"); };
+    _setFetchFn(errorFetch as unknown as typeof fetch);
+
+    await expect(
+      requestHelpHandler(fakeAuth, { symptom: "x" })
+    ).resolves.toBeDefined();
+  });
+});
+
+// ── Misconfiguration ──────────────────────────────────────────────────────────
+
+describe("misconfiguration", () => {
+  it("throws clearly when REZZED_AGENT_KEY is absent", async () => {
+    delete process.env.REZZED_AGENT_KEY;
+    await expect(
+      requestHelpHandler(fakeAuth, { symptom: "x" })
+    ).rejects.toThrow("REZZED_AGENT_KEY");
+  });
+});
+
+// ── Profile gating ────────────────────────────────────────────────────────────
+
+describe("profile gating", () => {
+  it("request_help is absent from full-profile TOOL_DEFINITIONS when CACHEBASH_PROFILE=full", () => {
+    // index.ts reads IS_LITE at module load time from CACHEBASH_PROFILE.
+    // In CI the profile defaults to 'full'. This test verifies the guard works
+    // by checking the currently-loaded definitions (process started without IS_LITE).
+    const names = TOOL_DEFINITIONS.map((d: any) => d.name);
+    // When running under full profile (CI default), request_help must be absent.
+    // When running under lite profile, it must be present.
+    const isLite = (process.env.CACHEBASH_PROFILE ?? "full") === "lite";
+    if (isLite) {
+      expect(names).toContain("request_help");
+    } else {
+      expect(names).not.toContain("request_help");
+    }
+  });
+});

--- a/services/mcp-server/src/modules/requestHelp.ts
+++ b/services/mcp-server/src/modules/requestHelp.ts
@@ -1,0 +1,155 @@
+/**
+ * requestHelp module — LITE-profile only.
+ *
+ * Server-side cross-grid egress: tenant (cerebro) asks the home grid for help
+ * via the `grid-help` alias, authenticating as `rezzed.agent` (relay-only key).
+ *
+ * Uses the stateful MCP handshake transport — REST /v1/messages is owner-only
+ * (403 PORTAL_OWNER_ONLY for a cb_ relay key; verified live by VECTOR).
+ * Handshake sequence: initialize → capture Mcp-Session-Id → notifications/initialized → tools/call
+ *
+ * ALERT maps to DIRECTIVE at the relay layer (relay API does not accept ALERT).
+ * Session is cached and re-handshaked on 401 / session-invalid.
+ */
+import { randomUUID } from "crypto";
+import { AuthContext } from "../auth/authValidator.js";
+
+const HOME_GRID_MCP_URL =
+  process.env.HOME_GRID_MCP ?? "https://api.cachebash.dev/v1/mcp";
+
+const LEXICON = {
+  helpDrop: "I've asked my support team — they'll be in touch shortly.",
+};
+
+export interface RequestHelpArgs {
+  symptom: string;
+  loopId?: string;
+  context?: string;
+}
+
+export interface RequestHelpResult {
+  sayf: string;
+  correlationId: string;
+}
+
+// Module-level session cache — reused across calls within the same process.
+let _cachedSession: string | null = null;
+// Injectable fetch for tests.
+let _fetchFn: typeof fetch = globalThis.fetch;
+
+/** Injectable for tests only — replaces the global fetch implementation. */
+export function _setFetchFn(fn: typeof fetch) {
+  _fetchFn = fn;
+  _cachedSession = null; // reset session when fetch changes (test isolation)
+}
+
+async function handshake(mcpUrl: string, key: string): Promise<string> {
+  const initResp = await _fetchFn(mcpUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "cachebash-lite-request-help", version: "1.0" },
+      },
+    }),
+  });
+
+  const sid = initResp.headers.get("mcp-session-id");
+  if (!sid) {
+    throw new Error("[request_help] MCP initialize returned no Mcp-Session-Id");
+  }
+
+  await _fetchFn(mcpUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${key}`,
+      "Mcp-Session-Id": sid,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+  });
+
+  return sid;
+}
+
+async function sendViaHandshake(
+  mcpUrl: string,
+  key: string,
+  args: Record<string, unknown>
+): Promise<void> {
+  if (!_cachedSession) {
+    _cachedSession = await handshake(mcpUrl, key);
+  }
+
+  const doCall = async (sessionId: string) =>
+    _fetchFn(mcpUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+        "Mcp-Session-Id": sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "relay_send_message", arguments: args },
+      }),
+    });
+
+  let resp = await doCall(_cachedSession);
+
+  if (resp.status === 401 || resp.status === 400) {
+    const text = await resp.text().catch(() => "");
+    if (resp.status === 401 || text.toLowerCase().includes("session")) {
+      _cachedSession = await handshake(mcpUrl, key);
+      resp = await doCall(_cachedSession);
+    }
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    // Fire-and-forget: log but do not throw — uplink failures must not surface to Sayf.
+    console.error(`[request_help] egress ${resp.status}: ${text.slice(0, 200)}`);
+  }
+}
+
+export async function requestHelpHandler(
+  _auth: AuthContext,
+  args: RequestHelpArgs
+): Promise<RequestHelpResult> {
+  const { symptom, loopId = "unknown", context = "" } = args;
+
+  const key = process.env.REZZED_AGENT_KEY;
+  if (!key) {
+    // Misconfiguration — surface clearly so ops can fix; not a Sayf-visible string.
+    throw new Error("[request_help] REZZED_AGENT_KEY not configured");
+  }
+
+  const tenant = process.env.CACHEBASH_TENANT_ID ?? "cerebro";
+  const correlationId = randomUUID();
+
+  const relayArgs = {
+    source: "rezzed.agent",
+    target: "grid-help",
+    message_type: "DIRECTIVE",
+    message: `[${tenant}-bridge] help-drop tenant="${tenant}" loop="${loopId}" symptom="${symptom}"`,
+    payload: { source: tenant, tenant, loopId, symptom, context, msgId: correlationId },
+  };
+
+  // Fire-and-forget: errors logged server-side, not surfaced to Sayf.
+  sendViaHandshake(HOME_GRID_MCP_URL, key, relayArgs).catch((err) => {
+    console.error(`[request_help] egress error: ${err?.message}`);
+  });
+
+  return { sayf: LEXICON.helpDrop, correlationId };
+}

--- a/services/mcp-server/src/tools/index.ts
+++ b/services/mcp-server/src/tools/index.ts
@@ -31,6 +31,7 @@ import * as patternConsolidation from "./patternConsolidation.js";
 import * as schedule from "./schedule.js";
 import * as policy from "./policy.js";
 import * as webhook from "./webhook.js";
+import * as requestHelp from "./requestHelp.js";
 
 type Handler = (auth: AuthContext, args: any) => Promise<any>;
 
@@ -59,6 +60,8 @@ export const TOOL_HANDLERS: Record<string, Handler> = {
   ...(!IS_LITE ? clu.handlers : {}),
   ...(!IS_LITE ? patternConsolidation.handlers : {}),
   ...(!IS_LITE ? schedule.handlers : {}),
+  // cross-grid egress — lite profile only (tenant→home-grid help-drop)
+  ...(IS_LITE ? requestHelp.handlers : {}),
 };
 
 export const TOOL_DEFINITIONS = [
@@ -84,4 +87,6 @@ export const TOOL_DEFINITIONS = [
   ...(!IS_LITE ? clu.definitions : []),
   ...(!IS_LITE ? patternConsolidation.definitions : []),
   ...(!IS_LITE ? schedule.definitions : []),
+  // cross-grid egress — lite profile only (tenant→home-grid help-drop)
+  ...(IS_LITE ? requestHelp.definitions : []),
 ];

--- a/services/mcp-server/src/tools/requestHelp.ts
+++ b/services/mcp-server/src/tools/requestHelp.ts
@@ -1,0 +1,42 @@
+/**
+ * Request Help Tool Registry — LITE profile only.
+ * Exposes `request_help` so cerebro tenants can ask the home grid for support.
+ * Must NOT appear on the full/home-grid profile (gated in index.ts via IS_LITE).
+ */
+import { AuthContext } from "../auth/authValidator.js";
+import { requestHelpHandler } from "../modules/requestHelp.js";
+
+type Handler = (auth: AuthContext, args: any) => Promise<any>;
+
+export const handlers: Record<string, Handler> = {
+  request_help: requestHelpHandler,
+};
+
+export const definitions = [
+  {
+    name: "request_help",
+    description:
+      "Ask the support team for help. Use when you're stuck or need assistance — they'll be notified and in touch shortly.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        symptom: {
+          type: "string",
+          maxLength: 1000,
+          description: "What went wrong or why you need help",
+        },
+        loopId: {
+          type: "string",
+          maxLength: 200,
+          description: "Which feature or loop is affected (optional)",
+        },
+        context: {
+          type: "string",
+          maxLength: 500,
+          description: "Additional context for the support team (optional)",
+        },
+      },
+      required: ["symptom"],
+    },
+  },
+];


### PR DESCRIPTION
## Summary

- Adds `request_help` MCP tool exposed **LITE-profile only** (`IS_LITE` gate in `tools/index.ts` — same pattern as enrichment exclusions, inverted)
- Handler (`modules/requestHelp.ts`) performs server-side cross-grid egress via stateful MCP handshake: `initialize` → capture `Mcp-Session-Id` → `notifications/initialized` → `tools/call relay_send_message`
- Authenticates as `rezzed.agent` via `REZZED_AGENT_KEY` (Cloud Run secret already provisioned); target `grid-help`, tenant-stamped payload for home-grid routing to `vector_cerebro`
- Fire-and-forget egress — failures logged server-side, never surfaced to Sayf (lexicon: "I've asked my support team — they'll be in touch shortly.")

## Test plan

- [x] 13 unit tests (jest): handshake 3-step sequence, `Mcp-Session-Id` header, session reuse, 401 re-handshake + retry, payload correctness (`source`, `target`, `message_type`, `tenant` stamp), lexicon guard (no grid jargon), fire-and-forget safety (500 + ECONNREFUSED), missing key misconfiguration, full/lite profile gating
- [x] Full suite: 640 passed, 0 failed (1 pre-existing skip)
- [x] `request_help` confirmed absent from full-profile `TOOL_DEFINITIONS` (CI default `CACHEBASH_PROFILE=full`)

## Gates

**⚠️ SARK egress-boundary review required before deploying to live cerebro tenant.**  
Deploy sequence (owned by vector_cerebro after SARK GO): redeploy `cachebash-lite` with `REZZED_AGENT_KEY=rezzed-agent-key:latest` secret added (already in `deploy/cloud-run-cerebro-grid.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)