### PR TITLE
fix(caps): decouple feedback_submit_feedback → relay.write (SARK ruling)

### DIFF
--- a/services/mcp-server/src/__tests__/capabilities.test.ts
+++ b/services/mcp-server/src/__tests__/capabilities.test.ts
@@ -54,6 +54,30 @@ describe('Capability System', () => {
     });
   });
 
+  describe('SARK-ruling: feedback_submit_feedback capability gating', () => {
+    it('relay.write (without dispatch.write) permits feedback submission', () => {
+      const result = checkToolCapability('feedback_submit_feedback', ['relay.write']);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('dispatch.write alone no longer permits feedback submission', () => {
+      const result = checkToolCapability('feedback_submit_feedback', ['dispatch.write']);
+      expect(result.allowed).toBe(false);
+    });
+
+    it('key with neither relay.write nor dispatch.write is denied', () => {
+      const result = checkToolCapability('feedback_submit_feedback', ['dispatch.read', 'relay.read']);
+      expect(result.allowed).toBe(false);
+      if (!result.allowed) {
+        expect(result.required).toBe('relay.write');
+      }
+    });
+
+    it('feedback_submit_feedback maps to relay.write in TOOL_CAPABILITIES', () => {
+      expect(TOOL_CAPABILITIES['feedback_submit_feedback']).toBe('relay.write');
+    });
+  });
+
   describe('TOOL_CAPABILITIES coverage', () => {
     it('ADR-013: relay read tools stay mapped to relay.read (no new capability)', () => {
       expect(TOOL_CAPABILITIES['relay_query_message_history']).toBe('relay.read');

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -101,8 +101,8 @@ export const TOOL_CAPABILITIES: Record<string, Capability> = {
   // Programs
   programs_list_programs: "programs.read",
   programs_update_program: "programs.write",
-  // Feedback
-  feedback_submit_feedback: "dispatch.write",
+  // Feedback — SARK ruling 2026-06-17: relay.write (tenant-isolated write, no dispatch side effects)
+  feedback_submit_feedback: "relay.write",
   // Admin
   admin_merge_accounts: "dispatch.write",
   // Usage (internal/hidden)


### PR DESCRIPTION
## Summary

- **SARK ruling 2026-06-17 (b) DECOUPLE**: `feedback_submit_feedback` was miscategorized under `dispatch.write`, which is hard-excluded from beta scopes
- Changes capability mapping to `relay.write` — the correct least-privilege home for a handler that writes only to tenant-isolated `feedback` collection with no dispatch/task/relay side effects
- Unblocks feedback intake for cerebro GaaS tenant (Sayf, key `b5c8704c`) without widening the beta scope

## Files Changed

- `services/mcp-server/src/middleware/capabilities.ts:105` — `dispatch.write` → `relay.write`
- `services/mcp-server/src/__tests__/capabilities.test.ts` — 4 new SARK-ruling tests added

## Test Coverage

New tests assert:
- `relay.write` (without `dispatch.write`) permits feedback submission ✓
- `dispatch.write` alone is now **denied** ✓
- Key with neither cap is denied, required cap reported as `relay.write` ✓
- `TOOL_CAPABILITIES['feedback_submit_feedback']` === `'relay.write'` ✓

All 24 capability tests pass.

## Security Review Note

This touches capability gating — tagging for security refuter panel per task spec. Spec of record: `grid/assessments/sark-audit-feedback-cap-decouple-cerebro.md` (merged via #910).

🤖 Generated with [Claude Code](https://claude.com/claude-code)