### PR TITLE
security(auth): BUG-006 structural fix — flip AUTH_MODE default to key_identity

### DIFF
--- a/services/mcp-server/src/__tests__/auth-phase0.test.ts
+++ b/services/mcp-server/src/__tests__/auth-phase0.test.ts
@@ -297,6 +297,71 @@ describe('Auth Phase 0: Dual-mode auth middleware', () => {
     });
   });
 
+  describe('default mode (no AUTH_MODE env set) — BUG-006 regression guard', () => {
+    beforeEach(() => {
+      delete process.env.AUTH_MODE;
+    });
+
+    it('key A + X-Program-Id: B does NOT gain B capabilities (fail-secure default is key_identity)', async () => {
+      const keyDocRef = {
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => ({
+            userId: testUserId,
+            programId: 'basher',
+            capabilities: ['dispatch.read', 'relay.write'],
+            active: true,
+            rateLimitTier: 'free',
+          }),
+        }),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockDb.doc.mockImplementation((path: string) => {
+        if (path === `keyIndex/${keyHash}`) return keyDocRef;
+        // Program lookup must NOT be called in key_identity mode
+        throw new Error(`Unexpected Firestore lookup: ${path}`);
+      });
+
+      // basher key + X-Program-Id: iso — must NOT resolve to iso's capabilities
+      const result = await validateApiKey(testApiKey, 'iso');
+
+      expect(result).not.toBeNull();
+      expect(result?.programId).toBe('basher');
+      expect(result?.capabilities).not.toContain('*');
+      expect(result?.capabilities).toContain('dispatch.read');
+    });
+
+    it('X-Program-Id header is ignored for programId resolution', async () => {
+      const keyDocRef = {
+        get: jest.fn().mockResolvedValue({
+          exists: true,
+          data: () => ({
+            userId: testUserId,
+            programId: 'basher',
+            active: true,
+            rateLimitTier: 'free',
+          }),
+        }),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockDb.doc.mockImplementation((path: string) => {
+        if (path === `keyIndex/${keyHash}`) return keyDocRef;
+        throw new Error(`Unexpected Firestore lookup: ${path}`);
+      });
+
+      mockGetDefaultCapabilities.mockReturnValue(['dispatch.read']);
+
+      const result = await validateApiKey(testApiKey, 'vector');
+
+      expect(result).not.toBeNull();
+      expect(result?.programId).toBe('basher');
+      expect(mockGetDefaultCapabilities).toHaveBeenCalledWith('basher');
+      expect(mockGetDefaultCapabilities).not.toHaveBeenCalledWith('vector');
+    });
+  });
+
   describe('validateAuth wrapper', () => {
     it('passes programIdOverride to validateApiKey for cb_ keys', async () => {
       const keyDocRef = {

--- a/services/mcp-server/src/auth/authValidator.ts
+++ b/services/mcp-server/src/auth/authValidator.ts
@@ -56,8 +56,8 @@ export async function validateApiKey(
     // The key's canonical identity — never overridable. Used for source enforcement (BUG-005).
     const keyProgramId: ValidProgramId = (data.programId || "legacy") as ValidProgramId;
 
-    // Phase 0: Auth Mode logic
-    const AUTH_MODE = process.env.AUTH_MODE || 'hybrid';
+    // Phase 0: Auth Mode logic — fail-secure default: key_identity ignores X-Program-Id for authz
+    const AUTH_MODE = process.env.AUTH_MODE || 'key_identity';
 
     // gsp_identity mode: reject cb_ keys without X-Program-Id header
     if (AUTH_MODE === 'gsp_identity' && apiKey.startsWith('cb_') && !programIdOverride) {


### PR DESCRIPTION
## Summary

- **BUG-006 CONFIRMED-LIVE CRITICAL**: hybrid mode (previous default) allowed any valid `cb_` key + `X-Program-Id: <program>` to recompute capabilities from the target program's role. Most roles resolve to `['*']` → full fleet access.
- **Stopgap already deployed**: `AUTH_MODE=key_identity` env set on both prod services (cachebash-lite rev 00009-jxh, cachebash-mcp rev 00162-lgh). This PR makes that permanent at the code level.
- **One-line change**: `authValidator.ts:60` — `|| 'hybrid'` → `|| 'key_identity'`
- **Two regression tests**: default-mode (no `AUTH_MODE` env) confirms `X-Program-Id` cannot escalate capabilities

## What changes

| File | Change |
|------|--------|
| `services/mcp-server/src/auth/authValidator.ts` | Line 60: default `'hybrid'` → `'key_identity'` |
| `services/mcp-server/src/__tests__/auth-phase0.test.ts` | 2 new tests: BUG-006 regression guard for default mode |

In `key_identity` mode (now the default), `programIdOverride` from `X-Program-Id` is ignored entirely for capability computation. The key's own `programId` and capabilities are always used. `X-Program-Id` may still be parsed by callers for non-authz display but has no effect on access control.

## Why the hybrid path still exists

`hybrid` mode remains available via `AUTH_MODE=hybrid` env for any tenant that has a legitimate need. The code path is preserved; only the unsafe default is removed. `gsp_identity` mode is also unaffected.

## Test plan

- [x] `npx jest --testPathPattern=auth-phase0` — 12/12 pass, including 2 new BUG-006 guards
- [ ] SARK security refuter panel (3 voters, 2-KILL blocks merge) — required per constraints, same gate as #379
- [ ] Post-merge: prod env stopgap (`AUTH_MODE=key_identity`) can remain as belt-and-suspenders or be removed

## References

- BUG-006: `grid/reference/known-bugs.md`, `grid/assessments/sark-assessment-redesign-study-881-security-triage-2026-06-22.md` (via #911)
- GaaS expansion gated on this fix: spec #897, spec-wingman-grid #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)