### PR TITLE
WS-3: Boundary circuit breaker for mutation ceilings

### DIFF
--- a/services/mcp-server/scripts/seed-ceilings.ts
+++ b/services/mcp-server/scripts/seed-ceilings.ts
@@ -1,0 +1,81 @@
+/**
+ * seed-ceilings.ts — Idempotent seed/update of a tenant's WS-3 circuit
+ * breaker ceilings doc: tenants/{org}/_meta/ceilings.
+ *
+ * ── Why this has to run before WS-3 goes live ─────────────────────────────
+ * middleware/circuitBreaker.ts is FAIL-CLOSED: any tenant with no ceilings
+ * doc has ALL mutating tool calls denied (dispatch writes, relay sends,
+ * state writes, ...). That's the correct security posture (SARK #881
+ * finding 5 — never fail open on a boundary control) but it means every
+ * tenant that needs to keep mutating — every existing Grid program tenant
+ * included — must have this doc seeded BEFORE the breaker's enforcement
+ * code is deployed live, not after.
+ *
+ * ── Credential ─────────────────────────────────────────────────────────
+ *   gcloud auth application-default login   # once, as an owner
+ *   (same ADC requirement as provision-program.ts — grid-deployer SA is
+ *   Firestore read-only in prod and will 403 on the write.)
+ *
+ * ── Run ────────────────────────────────────────────────────────────────
+ *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx \
+ *     services/mcp-server/scripts/seed-ceilings.ts lore
+ *
+ *   # override defaults:
+ *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx \
+ *     services/mcp-server/scripts/seed-ceilings.ts lore \
+ *     '{"perKeyLimit":50,"orgLimit":300,"windowMs":60000}'
+ *
+ * Idempotent: merges into the existing doc rather than clobbering it, so
+ * re-running to bump a limit (or to flip `paused`) never resets fields you
+ * didn't pass. Does NOT touch `paused` unless explicitly included in the
+ * override JSON — the kill switch is a separate, deliberate action.
+ */
+
+import * as admin from "firebase-admin";
+import { DEFAULT_CEILINGS } from "../src/middleware/circuitBreaker.js";
+
+function parseArgs(): { org: string; overrides: Record<string, unknown> } {
+  const org = process.argv[2];
+  if (!org || !/^[a-z0-9_-]{1,64}$/.test(org)) {
+    console.error('ERROR: pass a tenant/org id as argv[1], e.g. "lore". Must match ^[a-z0-9_-]{1,64}$');
+    process.exit(1);
+  }
+  const raw = process.argv[3];
+  let overrides: Record<string, unknown> = {};
+  if (raw) {
+    try {
+      overrides = JSON.parse(raw);
+    } catch (err) {
+      console.error(`ERROR: argv[2] is not valid JSON: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  }
+  return { org, overrides };
+}
+
+async function main() {
+  const { org, overrides } = parseArgs();
+
+  admin.initializeApp();
+  const db = admin.firestore();
+
+  const ref = db.doc(`tenants/${org}/_meta/ceilings`);
+  const existing = await ref.get();
+
+  const doc = {
+    ...(existing.exists ? {} : DEFAULT_CEILINGS),
+    ...overrides,
+  };
+
+  await ref.set(doc, { merge: true });
+
+  console.log(
+    `${existing.exists ? "Updated" : "Seeded"} tenants/${org}/_meta/ceilings:`,
+    JSON.stringify((await ref.get()).data()),
+  );
+}
+
+main().catch((err) => {
+  console.error("ERROR:", err);
+  process.exit(1);
+});

--- a/services/mcp-server/scripts/seed-ceilings.ts
+++ b/services/mcp-server/scripts/seed-ceilings.ts
@@ -17,12 +17,15 @@
  *   Firestore read-only in prod and will 403 on the write.)
  *
  * ── Run ────────────────────────────────────────────────────────────────
+ * `org` is the tenant's Firestore userId (the same mixed-case id
+ * auth.userId resolves to at runtime, e.g. a Firebase uid) — NOT always a
+ * lowercase slug.
  *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx \
- *     services/mcp-server/scripts/seed-ceilings.ts lore
+ *     services/mcp-server/scripts/seed-ceilings.ts 7viFKVtl5lgzguhFoZlnYYrqeDG2
  *
  *   # override defaults:
  *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx \
- *     services/mcp-server/scripts/seed-ceilings.ts lore \
+ *     services/mcp-server/scripts/seed-ceilings.ts 7viFKVtl5lgzguhFoZlnYYrqeDG2 \
  *     '{"perKeyLimit":50,"orgLimit":300,"windowMs":60000}'
  *
  * Idempotent: merges into the existing doc rather than clobbering it, so
@@ -36,8 +39,12 @@ import { DEFAULT_CEILINGS } from "../src/middleware/circuitBreaker.js";
 
 function parseArgs(): { org: string; overrides: Record<string, unknown> } {
   const org = process.argv[2];
-  if (!org || !/^[a-z0-9_-]{1,64}$/.test(org)) {
-    console.error('ERROR: pass a tenant/org id as argv[1], e.g. "lore". Must match ^[a-z0-9_-]{1,64}$');
+  // Real tenant ids are Firestore/Firebase userIds and are mixed-case
+  // (e.g. "7viFKVtl5lgzguhFoZlnYYrqeDG2") — the breaker keys ceilings by
+  // auth.userId verbatim (circuitBreaker.ts), so a lowercase-only pattern
+  // here would reject every real tenant and silently seed nothing.
+  if (!org || !/^[a-zA-Z0-9_-]{1,64}$/.test(org)) {
+    console.error('ERROR: pass a tenant/org id (the tenant\'s Firestore userId) as argv[1], e.g. "7viFKVtl5lgzguhFoZlnYYrqeDG2". Must match ^[a-zA-Z0-9_-]{1,64}$');
     process.exit(1);
   }
   const raw = process.argv[3];

--- a/services/mcp-server/src/__tests__/circuitBreaker.test.ts
+++ b/services/mcp-server/src/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,269 @@
+/**
+ * WS-3 — Boundary circuit breaker unit tests.
+ *
+ * Covers: rolling-window math (pure), fail-closed paths (missing/unreadable/
+ * malformed config), the kill switch, per-key + org-aggregate ceilings, and
+ * that read-only tools never touch Firestore or the breaker's counters.
+ */
+
+import type { AuthContext } from "../auth/authValidator";
+import {
+  checkCircuitBreaker,
+  isMutatingTool,
+  pruneWindow,
+  countInWindow,
+  resetCircuitBreakerState,
+  DEFAULT_CEILINGS,
+} from "../middleware/circuitBreaker";
+
+// --- Firestore mock (same pattern as pricing.test.ts) ---
+
+const firestoreDocs = new Map<string, Record<string, any>>();
+let throwOnRead = false;
+
+const mockDb = {
+  doc: jest.fn((path: string) => ({
+    get: jest.fn(async () => {
+      if (throwOnRead) throw new Error("read failed");
+      const data = firestoreDocs.get(path);
+      return { exists: !!data, data: () => data };
+    }),
+  })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(),
+}));
+
+const sendAlertHandler = jest.fn(async (..._args: any[]) => ({ content: [] }));
+jest.mock("../modules/signal.js", () => ({
+  sendAlertHandler: (...args: any[]) => sendAlertHandler(...args),
+}));
+
+function auth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    userId: "org-1",
+    apiKeyHash: "key-1",
+    encryptionKey: Buffer.from("0123456789abcdef0123456789abcdef", "utf-8"),
+    programId: "wingman" as any,
+    capabilities: ["dispatch.read", "dispatch.write"],
+    rateLimitTier: "free",
+    ...overrides,
+  };
+}
+
+function setCeilings(org: string, config: Partial<typeof DEFAULT_CEILINGS>) {
+  firestoreDocs.set(`tenants/${org}/_meta/ceilings`, { ...DEFAULT_CEILINGS, ...config });
+}
+
+beforeEach(() => {
+  firestoreDocs.clear();
+  throwOnRead = false;
+  sendAlertHandler.mockClear();
+  resetCircuitBreakerState();
+});
+
+describe("rolling window math (pure)", () => {
+  it("prunes timestamps outside the window", () => {
+    const now = 100_000;
+    const timestamps = [now - 70_000, now - 30_000, now - 1_000];
+    expect(pruneWindow(timestamps, now, 60_000)).toEqual([now - 30_000, now - 1_000]);
+  });
+
+  it("counts only timestamps inside the window", () => {
+    const now = 100_000;
+    const timestamps = [now - 70_000, now - 30_000, now - 1_000];
+    expect(countInWindow(timestamps, now, 60_000)).toBe(2);
+  });
+
+  it("treats the exact window boundary as expired (strictly greater than cutoff)", () => {
+    const now = 100_000;
+    const windowMs = 60_000;
+    const timestamps = [now - windowMs]; // exactly at cutoff
+    expect(countInWindow(timestamps, now, windowMs)).toBe(0);
+  });
+
+  it("returns empty/zero for an empty window", () => {
+    expect(pruneWindow([], 100_000, 60_000)).toEqual([]);
+    expect(countInWindow([], 100_000, 60_000)).toBe(0);
+  });
+});
+
+describe("isMutatingTool", () => {
+  it("classifies dispatch/relay/state writes as mutating", () => {
+    expect(isMutatingTool("dispatch_create_task")).toBe(true);
+    expect(isMutatingTool("relay_send_message")).toBe(true);
+    expect(isMutatingTool("state_update_program_state")).toBe(true);
+  });
+
+  it("classifies reads as non-mutating", () => {
+    expect(isMutatingTool("dispatch_get_tasks")).toBe(false);
+    expect(isMutatingTool("relay_get_messages")).toBe(false);
+    expect(isMutatingTool("state_get_program_state")).toBe(false);
+  });
+
+  it("resolves legacy flat aliases before classifying", () => {
+    expect(isMutatingTool("create_task")).toBe(true); // alias for dispatch_create_task
+    expect(isMutatingTool("get_tasks")).toBe(false); // alias for dispatch_get_tasks
+  });
+
+  it("fails closed (non-mutating=false -> denies via breaker) for unmapped tool names", () => {
+    // An unmapped tool has no required capability, so isMutatingTool returns
+    // false — but checkCircuitBreaker only skips the Firestore read for
+    // known non-mutating tools. Since this tool is truly unmapped it is
+    // *not* mutating, so it passes through untouched (capability gate is
+    // the actual fail-closed layer for unmapped tools, per capabilities.ts).
+    expect(isMutatingTool("__totally_unknown_tool__")).toBe(false);
+  });
+});
+
+describe("read-only tools bypass the breaker entirely", () => {
+  it("allows reads with zero Firestore access, even with no ceiling config", async () => {
+    const result = await checkCircuitBreaker(auth(), "dispatch_get_tasks");
+    expect(result.allowed).toBe(true);
+    expect(mockDb.doc).not.toHaveBeenCalled();
+  });
+});
+
+describe("fail-closed paths", () => {
+  it("denies mutations when the ceiling doc does not exist", async () => {
+    const result = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+  });
+
+  it("denies mutations when the ceiling read throws", async () => {
+    throwOnRead = true;
+    const result = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+  });
+
+  it("denies mutations when the ceiling doc is malformed (non-numeric / non-positive fields)", async () => {
+    setCeilings("org-1", { perKeyLimit: 0 });
+    const r1 = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(r1.allowed).toBe(false);
+
+    firestoreDocs.set("tenants/org-1/_meta/ceilings", { perKeyLimit: "not-a-number", orgLimit: 10, windowMs: 60_000 });
+    const r2 = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(r2.allowed).toBe(false);
+  });
+
+  it("emits a signal alert when denying due to missing/unreadable config", async () => {
+    await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(sendAlertHandler).toHaveBeenCalledTimes(1);
+    const call = sendAlertHandler.mock.calls[0] as any[];
+    expect(call[1].alertType).toBe("warning");
+  });
+});
+
+describe("kill switch (org pause)", () => {
+  it("denies all mutations for a paused tenant even under budget", async () => {
+    setCeilings("org-1", { perKeyLimit: 100, orgLimit: 100, paused: true });
+    const result = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.code).toBe("CEILING_ORG_PAUSED");
+  });
+
+  it("takes effect on the very next request after being set (no stale cache)", async () => {
+    setCeilings("org-1", { perKeyLimit: 100, orgLimit: 100, paused: false });
+    const before = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(before.allowed).toBe(true);
+
+    setCeilings("org-1", { perKeyLimit: 100, orgLimit: 100, paused: true });
+    const after = await checkCircuitBreaker(auth(), "dispatch_create_task");
+    expect(after.allowed).toBe(false);
+  });
+
+  it("does not affect reads for a paused tenant", async () => {
+    setCeilings("org-1", { paused: true });
+    const result = await checkCircuitBreaker(auth(), "dispatch_get_tasks");
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("per-key ceiling", () => {
+  it("allows exactly perKeyLimit mutations then denies the N+1th with a typed error", async () => {
+    setCeilings("org-1", { perKeyLimit: 2, orgLimit: 100, windowMs: 60_000 });
+    const a = auth();
+
+    const r1 = await checkCircuitBreaker(a, "dispatch_create_task");
+    const r2 = await checkCircuitBreaker(a, "dispatch_create_task");
+    const r3 = await checkCircuitBreaker(a, "dispatch_create_task");
+
+    expect(r1.allowed).toBe(true);
+    expect(r2.allowed).toBe(true);
+    expect(r3.allowed).toBe(false);
+    if (!r3.allowed) expect(r3.code).toBe("CEILING_KEY_EXCEEDED");
+  });
+
+  it("tracks separate keys independently", async () => {
+    setCeilings("org-1", { perKeyLimit: 1, orgLimit: 100, windowMs: 60_000 });
+    const keyA = auth({ apiKeyHash: "key-a" });
+    const keyB = auth({ apiKeyHash: "key-b" });
+
+    expect((await checkCircuitBreaker(keyA, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(keyA, "dispatch_create_task")).allowed).toBe(false);
+    // key-b has its own untouched budget
+    expect((await checkCircuitBreaker(keyB, "dispatch_create_task")).allowed).toBe(true);
+  });
+
+  it("recovers once the window rolls forward", async () => {
+    setCeilings("org-1", { perKeyLimit: 1, orgLimit: 100, windowMs: 1_000 });
+    const a = auth();
+    const nowSpy = jest.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(0);
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(false);
+
+    nowSpy.mockReturnValue(2_000); // past the 1s window
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(true);
+
+    nowSpy.mockRestore();
+  });
+});
+
+describe("org-aggregate ceiling", () => {
+  it("denies once the org aggregate is exhausted, even across distinct keys under their own per-key budget", async () => {
+    setCeilings("org-1", { perKeyLimit: 100, orgLimit: 2, windowMs: 60_000 });
+    const keyA = auth({ apiKeyHash: "key-a" });
+    const keyB = auth({ apiKeyHash: "key-b" });
+    const keyC = auth({ apiKeyHash: "key-c" });
+
+    expect((await checkCircuitBreaker(keyA, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(keyB, "dispatch_create_task")).allowed).toBe(true);
+    const r3 = await checkCircuitBreaker(keyC, "dispatch_create_task");
+    expect(r3.allowed).toBe(false);
+    if (!r3.allowed) expect(r3.code).toBe("CEILING_ORG_EXCEEDED");
+  });
+
+  it("does not consume per-key budget when the org ceiling denies the call", async () => {
+    setCeilings("org-1", { perKeyLimit: 100, orgLimit: 1, windowMs: 60_000 });
+    const keyA = auth({ apiKeyHash: "key-a" });
+    const keyB = auth({ apiKeyHash: "key-b" });
+
+    expect((await checkCircuitBreaker(keyA, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(keyB, "dispatch_create_task")).allowed).toBe(false);
+
+    // Raise the org ceiling — key-b should still have its full per-key budget,
+    // proving the earlier org-denied call never consumed a key-b slot.
+    setCeilings("org-1", { perKeyLimit: 1, orgLimit: 100, windowMs: 60_000 });
+    expect((await checkCircuitBreaker(keyB, "dispatch_create_task")).allowed).toBe(true);
+  });
+});
+
+describe("tenant isolation", () => {
+  it("does not let one org's ceiling or usage affect another org", async () => {
+    setCeilings("org-1", { perKeyLimit: 1, orgLimit: 1, windowMs: 60_000 });
+    // org-2 has no ceiling doc at all — should fail closed independently of org-1's state.
+    const orgOneAuth = auth({ userId: "org-1" });
+    const orgTwoAuth = auth({ userId: "org-2", apiKeyHash: "key-1" });
+
+    expect((await checkCircuitBreaker(orgOneAuth, "dispatch_create_task")).allowed).toBe(true);
+    const orgTwoResult = await checkCircuitBreaker(orgTwoAuth, "dispatch_create_task");
+    expect(orgTwoResult.allowed).toBe(false);
+    if (!orgTwoResult.allowed) expect(orgTwoResult.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+  });
+});

--- a/services/mcp-server/src/__tests__/circuitBreaker.test.ts
+++ b/services/mcp-server/src/__tests__/circuitBreaker.test.ts
@@ -110,6 +110,12 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("dispatch_unquarantine_program")).toBe(true);
   });
 
+  it("classifies metrics_log_rate_limit_event as mutating (writes despite metrics.read cap)", () => {
+    // Gated at metrics.read for read-tier access but appends a Firestore
+    // rate_limit_events doc — must be breaker-covered. SARK WS-3 final panel.
+    expect(isMutatingTool("metrics_log_rate_limit_event")).toBe(true);
+  });
+
   it("resolves legacy flat aliases before classifying", () => {
     expect(isMutatingTool("create_task")).toBe(true); // alias for dispatch_create_task
     expect(isMutatingTool("get_tasks")).toBe(false); // alias for dispatch_get_tasks

--- a/services/mcp-server/src/__tests__/circuitBreaker.test.ts
+++ b/services/mcp-server/src/__tests__/circuitBreaker.test.ts
@@ -103,6 +103,13 @@ describe("isMutatingTool", () => {
     expect(isMutatingTool("state_get_program_state")).toBe(false);
   });
 
+  it("classifies fleet.control tools (quarantine/unquarantine) as mutating", () => {
+    // fleet.control is a non-.write capability but writes program state, so the
+    // breaker (kill switch + fail-closed) must cover it. SARK WS-3 final panel.
+    expect(isMutatingTool("dispatch_quarantine_program")).toBe(true);
+    expect(isMutatingTool("dispatch_unquarantine_program")).toBe(true);
+  });
+
   it("resolves legacy flat aliases before classifying", () => {
     expect(isMutatingTool("create_task")).toBe(true); // alias for dispatch_create_task
     expect(isMutatingTool("get_tasks")).toBe(false); // alias for dispatch_get_tasks

--- a/services/mcp-server/src/__tests__/integration/circuit-breaker-iso-routes.test.ts
+++ b/services/mcp-server/src/__tests__/integration/circuit-breaker-iso-routes.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration Test: WS-3 Boundary Circuit Breaker — ISO MCP transport
+ *
+ * SARK re-panel finding (round 2, PR #383): the ISO admin MCP endpoint
+ * (POST /v1/iso/mcp, handled in iso/isoServer.ts) enforced NEITHER the
+ * capability gate NOR the circuit breaker — its CallToolRequestSchema
+ * handler ran a legacy checkRateLimit and then dispatched
+ * ISO_TOOL_HANDLERS[name] directly. Any valid Bearer key reached mutating
+ * tools (relay_send_message, dispatch_create_task, dispatch_claim_task,
+ * dispatch_complete_task, signal_send_alert, pulse_update_session) with no
+ * capability check and no ceiling — the third transport bypass, after the
+ * main MCP transport (index.ts) and REST transport (rest.ts) were already
+ * fixed.
+ *
+ * This proves the fix end-to-end against the real Firestore emulator and
+ * the real ISO transport handler (not a mocked breaker/capability check):
+ * (a) a key without the required capability is denied before the handler
+ *     ever runs, and (b) the N+1th mutation in the window is denied by the
+ *     breaker, with the true fail-closed (no ceilings doc) path also
+ *     covered. See circuit-breaker.test.ts for the dedicated unit coverage
+ *     of checkCircuitBreaker's window math, and
+ *     circuit-breaker-rest-routes.test.ts for the equivalent REST-transport
+ *     fix.
+ */
+
+import * as admin from "firebase-admin";
+import { getTestFirestore, clearFirestoreData } from "./setup";
+import type { AuthContext } from "../../auth/authValidator";
+
+// Point the module under test at the emulator-backed Firestore instance
+// instead of the production firebase/client.ts singleton.
+jest.mock("../../firebase/client.js", () => ({
+  getFirestore: () => getTestFirestoreLazy(),
+  serverTimestamp: () => admin.firestore.FieldValue.serverTimestamp(),
+}));
+
+function getTestFirestoreLazy(): admin.firestore.Firestore {
+  return getTestFirestore();
+}
+
+// checkCircuitBreaker fires a signal alert on every denial as a deliberate
+// fire-and-forget (see circuitBreaker.ts emitBreakerAlert) — stub it out,
+// same as circuit-breaker-rest-routes.test.ts.
+jest.mock("../../modules/signal.js", () => ({
+  sendAlertHandler: jest.fn(async () => ({ content: [{ type: "text", text: "{}" }] })),
+}));
+
+// Legacy per-tool rate limiter is orthogonal to this fix — always allow so
+// it can't mask the capability/breaker assertions below.
+jest.mock("../../middleware/rateLimiter.js", () => ({
+  checkRateLimit: jest.fn(() => true),
+  getRateLimitResetIn: jest.fn(() => 0),
+}));
+
+// Real MCP SDK Server is a full protocol implementation we don't need here —
+// mock it just enough to capture the CallToolRequestSchema handler that
+// isoServer.ts registers, same technique as iso-tool-registry.test.ts.
+jest.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+  Server: jest.fn().mockImplementation(() => ({
+    setRequestHandler: jest.fn(),
+    connect: jest.fn(),
+  })),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  CallToolRequestSchema: Symbol("CallToolRequestSchema"),
+  ListToolsRequestSchema: Symbol("ListToolsRequestSchema"),
+}));
+
+// Stateless per-request auth transport — mock so the test can set
+// `currentAuth` directly, exactly like production's per-request
+// `transport.currentAuth = authContext` assignment in CustomHTTPTransport.
+jest.mock("../../transport/CustomHTTPTransport.js", () => ({
+  CustomHTTPTransport: jest.fn().mockImplementation(() => ({
+    handleRequest: jest.fn(),
+    currentAuth: null,
+  })),
+}));
+
+// Tool handler modules — mocked so this test observes ONLY whether the gate
+// let the call through, not the handlers' own business logic.
+jest.mock("../../modules/dispatch/index.js", () => ({
+  getTasksHandler: jest.fn(async () => ({ content: [{ type: "text", text: "{}" }] })),
+  createTaskHandler: jest.fn(async () => ({ content: [{ type: "text", text: "{}" }] })),
+  claimTaskHandler: jest.fn(),
+  completeTaskHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/relay.js", () => ({
+  getMessagesHandler: jest.fn(),
+  sendMessageHandler: jest.fn(async () => ({ content: [{ type: "text", text: "{}" }] })),
+  getDeadLettersHandler: jest.fn(),
+  getSentMessagesHandler: jest.fn(),
+  queryMessageHistoryHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/pulse.js", () => ({
+  updateSessionHandler: jest.fn(),
+  getFleetHealthHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/keys.js", () => ({
+  listKeysHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/audit.js", () => ({
+  getAuditHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/metrics.js", () => ({
+  getCostSummaryHandler: jest.fn(),
+  getCommsMetricsHandler: jest.fn(),
+  getOperationalMetricsHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/sprint.js", () => ({
+  getSprintHandler: jest.fn(),
+}));
+
+jest.mock("../../modules/ledger.js", () => ({
+  logToolCall: jest.fn(),
+}));
+
+jest.mock("../../modules/trace.js", () => ({
+  traceToolCall: jest.fn(),
+  queryTracesHandler: jest.fn(),
+}));
+
+import { resetCircuitBreakerState } from "../../middleware/circuitBreaker";
+import { createTaskHandler } from "../../modules/dispatch/index.js";
+import { sendMessageHandler } from "../../modules/relay.js";
+
+describe("WS-3 ISO transport enforcement — POST /v1/iso/mcp CallToolRequestSchema", () => {
+  let db: admin.firestore.Firestore;
+  const userId = "test-org-breaker-iso";
+
+  beforeAll(() => {
+    db = getTestFirestore();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    resetCircuitBreakerState();
+    jest.clearAllMocks();
+    (createTaskHandler as jest.Mock).mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
+    (sendMessageHandler as jest.Mock).mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
+  });
+
+  function auth(overrides: Partial<AuthContext> = {}): AuthContext {
+    return {
+      userId,
+      apiKeyHash: "iso-test-key-hash",
+      encryptionKey: Buffer.from("0123456789abcdef0123456789abcdef"),
+      programId: "wingman" as any,
+      capabilities: ["dispatch.read", "dispatch.write", "relay.read", "relay.write"],
+      rateLimitTier: "free",
+      ...overrides,
+    };
+  }
+
+  async function setCeilings(overrides: Record<string, unknown>): Promise<void> {
+    await db.doc(`tenants/${userId}/_meta/ceilings`).set({
+      perKeyLimit: 3,
+      orgLimit: 10,
+      windowMs: 60_000,
+      paused: false,
+      ...overrides,
+    });
+  }
+
+  /** Boots isoServer.ts and returns its captured CallToolRequestSchema handler + the mocked transport instance. */
+  async function bootIsoCallToolHandler(): Promise<{
+    callTool: (request: { params: { name: string; arguments: unknown } }, extra?: unknown) => Promise<any>;
+    transport: { currentAuth: AuthContext | null };
+  }> {
+    const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+    const { CallToolRequestSchema } = await import("@modelcontextprotocol/sdk/types.js");
+    const { createIsoServer } = await import("../../iso/isoServer.js");
+
+    const { transport } = await createIsoServer();
+
+    const serverMock = Server as unknown as jest.Mock;
+    const instance = serverMock.mock.results[serverMock.mock.results.length - 1].value;
+    const registration = instance.setRequestHandler.mock.calls.find(
+      (call: unknown[]) => call[0] === CallToolRequestSchema
+    );
+    if (!registration) throw new Error("isoServer.ts did not register a CallToolRequestSchema handler");
+
+    return { callTool: registration[1], transport: transport as any };
+  }
+
+  it("denies a key without the required capability before the handler runs", async () => {
+    await setCeilings({ perKeyLimit: 100, orgLimit: 100 });
+    const { callTool, transport } = await bootIsoCallToolHandler();
+
+    // Key has dispatch.* but NOT relay.write — relay_send_message must be denied.
+    transport.currentAuth = auth({ capabilities: ["dispatch.read", "dispatch.write"] });
+
+    const result = await callTool({
+      params: { name: "relay_send_message", arguments: { target: "iso", message_type: "STATUS", message: "hi" } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Insufficient capability");
+    expect(result.content[0].text).toContain("relay.write");
+    expect(sendMessageHandler).not.toHaveBeenCalled();
+  });
+
+  it("allows a key with the required capability through to the handler", async () => {
+    await setCeilings({ perKeyLimit: 100, orgLimit: 100 });
+    const { callTool, transport } = await bootIsoCallToolHandler();
+
+    transport.currentAuth = auth();
+
+    const result = await callTool({
+      params: { name: "relay_send_message", arguments: { target: "iso", message_type: "STATUS", message: "hi" } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(sendMessageHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("the N+1th mutating call in the window is denied by the breaker before the handler runs", async () => {
+    await setCeilings({ perKeyLimit: 1, orgLimit: 100 });
+    const { callTool, transport } = await bootIsoCallToolHandler();
+    transport.currentAuth = auth();
+
+    const first = await callTool({ params: { name: "dispatch_create_task", arguments: { title: "t1", target: "basher" } } });
+    expect(first.isError).toBeFalsy();
+    expect(createTaskHandler).toHaveBeenCalledTimes(1);
+
+    // 2nd call (N+1th): the breaker must deny it BEFORE ISO_TOOL_HANDLERS
+    // dispatches to createTaskHandler — this is exactly the bypass the SARK
+    // re-panel flagged.
+    const second = await callTool({ params: { name: "dispatch_create_task", arguments: { title: "t2", target: "basher" } } });
+    expect(second.isError).toBe(true);
+    const body = JSON.parse(second.content[0].text);
+    expect(body.error).toBe("CEILING_KEY_EXCEEDED");
+    expect(createTaskHandler).toHaveBeenCalledTimes(1);
+
+    // Reads are unaffected by the tripped mutation ceiling.
+    const read = await callTool({ params: { name: "dispatch_get_tasks", arguments: {} } });
+    expect(read.isError).toBeFalsy();
+  });
+
+  it("fails closed: denies mutating calls but allows reads when the tenant has no ceilings doc", async () => {
+    // No setCeilings() call — tenant has no _meta/ceilings doc at all.
+    const { callTool, transport } = await bootIsoCallToolHandler();
+    transport.currentAuth = auth();
+
+    const mutation = await callTool({ params: { name: "dispatch_create_task", arguments: { title: "t1", target: "basher" } } });
+    expect(mutation.isError).toBe(true);
+    const body = JSON.parse(mutation.content[0].text);
+    expect(body.error).toBe("CEILING_CONFIG_UNAVAILABLE");
+    expect(createTaskHandler).not.toHaveBeenCalled();
+
+    const read = await callTool({ params: { name: "dispatch_get_tasks", arguments: {} } });
+    expect(read.isError).toBeFalsy();
+  });
+});

--- a/services/mcp-server/src/__tests__/integration/circuit-breaker-rest-routes.test.ts
+++ b/services/mcp-server/src/__tests__/integration/circuit-breaker-rest-routes.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration Test: WS-3 Boundary Circuit Breaker — REST direct-handler routes
+ *
+ * SARK 2-KILL finding: several REST routes invoked their mutation handler
+ * directly (gspResolveHandler, dreamActivateHandler, sendMessageHandler, and
+ * a raw Firestore batch-write for mark_read), bypassing callTool() and
+ * therefore the breaker entirely — unlike every other mutating route, which
+ * already routes through callTool() and inherits the enforcement added in
+ * circuitBreaker.ts.
+ *
+ * This proves the fix for POST /v1/gsp/proposals/:id/resolve end-to-end
+ * against the real Firestore emulator and the real REST route (not a mocked
+ * breaker): the N+1th resolve call in the window is denied, and a tenant
+ * with no ceilings doc fails closed. See circuit-breaker.test.ts for the
+ * dedicated unit coverage of checkCircuitBreaker's window math, and
+ * portal-owner-send-message.test.ts for POST /v1/relay/messages route-level
+ * coverage of the same fix.
+ */
+
+import * as crypto from "crypto";
+import * as http from "http";
+import * as admin from "firebase-admin";
+import { getTestFirestore, clearFirestoreData, seedTestUser } from "./setup";
+
+// github-sync (pulled in via transport/rest -> tools) imports ESM-only
+// @octokit/rest, which ts-jest does not transform — mock it out (same as
+// relay-delivery.test.ts).
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
+// Point the module under test at the emulator-backed Firestore instance
+// instead of the production firebase/client.ts singleton.
+jest.mock("../../firebase/client.js", () => ({
+  getFirestore: () => getTestFirestoreLazy(),
+  serverTimestamp: () => admin.firestore.FieldValue.serverTimestamp(),
+}));
+
+function getTestFirestoreLazy(): admin.firestore.Firestore {
+  return getTestFirestore();
+}
+
+// checkCircuitBreaker fires a signal alert on every denial as a deliberate
+// fire-and-forget (see circuitBreaker.ts emitBreakerAlert) — not awaited by
+// production code, so it can still be in flight after this test file's HTTP
+// server closes and Jest tears down the module environment. Not the subject
+// of this suite; stub it out.
+jest.mock("../../modules/signal.js", () => ({
+  sendAlertHandler: jest.fn(async () => ({ content: [{ text: "{}" }] })),
+}));
+
+import { resetCircuitBreakerState } from "../../middleware/circuitBreaker";
+import { createRestRouter } from "../../transport/rest";
+
+describe("WS-3 REST route enforcement — POST /v1/gsp/proposals/:id/resolve", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+  let apiKey: string;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    db = getTestFirestore();
+    server = http.createServer(createRestRouter());
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    resetCircuitBreakerState();
+
+    const testUser = await seedTestUser("test-org-breaker-rest");
+    userId = testUser.userId;
+
+    // Real cb_ API key via keyIndex — drives the actual validateApiKey path,
+    // not a mocked auth context.
+    apiKey = `cb_test_${crypto.randomBytes(8).toString("hex")}`;
+    const keyHash = crypto.createHash("sha256").update(apiKey).digest("hex");
+    await db.doc(`keyIndex/${keyHash}`).set({
+      userId,
+      programId: "scalar",
+      capabilities: ["gsp.write"],
+      active: true,
+    });
+  });
+
+  async function resolveProposal(proposalId = "does-not-exist"): Promise<{ status: number; body: any }> {
+    const res = await fetch(`${baseUrl}/v1/gsp/proposals/${proposalId}/resolve`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ decision: "approved", reasoning: "test" }),
+    });
+    const body = await res.json();
+    return { status: res.status, body };
+  }
+
+  it("the N+1th resolve call in the window is denied with the typed breaker error", async () => {
+    await db.doc(`tenants/${userId}/_meta/ceilings`).set({
+      perKeyLimit: 1,
+      orgLimit: 100,
+      windowMs: 60_000,
+      paused: false,
+    });
+
+    // 1st call consumes the single slot. The proposal doesn't exist so the
+    // handler itself reports not-found (400) — this proves the call reached
+    // the handler at all, i.e. the breaker allowed it through.
+    const first = await resolveProposal();
+    expect(first.status).toBe(400);
+
+    // 2nd call (N+1th): must be denied by the breaker BEFORE the handler
+    // runs — this is exactly the bypass the SARK panel flagged.
+    const second = await resolveProposal();
+    expect(second.status).toBe(429);
+    expect(second.body?.error?.code).toBe("CEILING_KEY_EXCEEDED");
+  });
+
+  it("fails closed: denies the resolve call when the tenant has no ceilings doc", async () => {
+    await db.doc(`tenants/${userId}/_meta/ceilings`).delete();
+
+    const res = await resolveProposal();
+    expect(res.status).toBe(503);
+    expect(res.body?.error?.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+  });
+});

--- a/services/mcp-server/src/__tests__/integration/circuit-breaker.test.ts
+++ b/services/mcp-server/src/__tests__/integration/circuit-breaker.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration Test: WS-3 Boundary Circuit Breaker
+ *
+ * Runs against the real Firestore emulator (not mocked) to prove:
+ * - The N+1th mutation in a rolling window is denied with a typed error
+ *   while reads for the same key keep passing.
+ * - The org-aggregate ceiling denies once exhausted, independent of any
+ *   single key's own budget.
+ * - The kill switch (`paused: true`) fails closed on the very next call.
+ * - Fail-closed: a tenant with no `_meta/ceilings` doc denies mutations but
+ *   allows reads.
+ */
+
+import * as admin from "firebase-admin";
+import { getTestFirestore, clearFirestoreData, seedTestUser } from "./setup";
+
+// Point the module under test at the emulator-backed Firestore instance
+// instead of the production firebase/client.ts singleton (which requires
+// initializeFirebase() against real GCP credentials).
+jest.mock("../../firebase/client.js", () => ({
+  getFirestore: () => getTestFirestoreLazy(),
+  serverTimestamp: () => admin.firestore.FieldValue.serverTimestamp(),
+}));
+
+// signal.ts's sendAlertHandler does its own Firestore writes (relay + tasks
+// collections) via the mocked client above, which is fine to let run for
+// real against the emulator — no need to stub it for this test.
+
+function getTestFirestoreLazy(): admin.firestore.Firestore {
+  return getTestFirestore();
+}
+
+import {
+  checkCircuitBreaker,
+  resetCircuitBreakerState,
+} from "../../middleware/circuitBreaker";
+import type { AuthContext } from "../../auth/authValidator";
+
+describe("WS-3 Circuit Breaker Integration", () => {
+  let db: admin.firestore.Firestore;
+  let userId: string;
+
+  beforeAll(() => {
+    db = getTestFirestore();
+  });
+
+  beforeEach(async () => {
+    await clearFirestoreData();
+    resetCircuitBreakerState();
+    const testUser = await seedTestUser("test-org-breaker");
+    userId = testUser.userId;
+  });
+
+  function auth(overrides: Partial<AuthContext> = {}): AuthContext {
+    return {
+      userId,
+      apiKeyHash: "test-key-hash",
+      encryptionKey: Buffer.from("0123456789abcdef0123456789abcdef"),
+      programId: "wingman" as any,
+      capabilities: ["dispatch.read", "dispatch.write"],
+      rateLimitTier: "free",
+      ...overrides,
+    };
+  }
+
+  async function setCeilings(overrides: Record<string, unknown>): Promise<void> {
+    await db.doc(`tenants/${userId}/_meta/ceilings`).set({
+      perKeyLimit: 3,
+      orgLimit: 10,
+      windowMs: 60_000,
+      paused: false,
+      ...overrides,
+    });
+  }
+
+  it("allows exactly perKeyLimit mutations, denies the N+1th with a typed error, while reads keep passing", async () => {
+    await setCeilings({ perKeyLimit: 3, orgLimit: 100 });
+    const a = auth();
+
+    const r1 = await checkCircuitBreaker(a, "dispatch_create_task");
+    const r2 = await checkCircuitBreaker(a, "dispatch_create_task");
+    const r3 = await checkCircuitBreaker(a, "dispatch_create_task");
+    expect(r1.allowed).toBe(true);
+    expect(r2.allowed).toBe(true);
+    expect(r3.allowed).toBe(true);
+
+    // N+1th mutation — must be denied with a typed error code.
+    const r4 = await checkCircuitBreaker(a, "dispatch_create_task");
+    expect(r4.allowed).toBe(false);
+    if (!r4.allowed) {
+      expect(r4.code).toBe("CEILING_KEY_EXCEEDED");
+      expect(typeof r4.message).toBe("string");
+      expect(r4.message.length).toBeGreaterThan(0);
+    }
+
+    // Reads are unaffected by the tripped mutation ceiling.
+    const readResult = await checkCircuitBreaker(a, "dispatch_get_tasks");
+    expect(readResult.allowed).toBe(true);
+  });
+
+  it("denies once the org-aggregate ceiling is exhausted across distinct keys", async () => {
+    await setCeilings({ perKeyLimit: 100, orgLimit: 2 });
+    const keyA = auth({ apiKeyHash: "key-a" });
+    const keyB = auth({ apiKeyHash: "key-b" });
+    const keyC = auth({ apiKeyHash: "key-c" });
+
+    expect((await checkCircuitBreaker(keyA, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(keyB, "dispatch_create_task")).allowed).toBe(true);
+
+    const r3 = await checkCircuitBreaker(keyC, "dispatch_create_task");
+    expect(r3.allowed).toBe(false);
+    if (!r3.allowed) expect(r3.code).toBe("CEILING_ORG_EXCEEDED");
+
+    // Reads for the newly-blocked key still pass.
+    expect((await checkCircuitBreaker(keyC, "dispatch_get_tasks")).allowed).toBe(true);
+  });
+
+  it("kill switch: org pause fails closed on the very next request", async () => {
+    await setCeilings({ perKeyLimit: 100, orgLimit: 100, paused: false });
+    const a = auth();
+
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(true);
+
+    // Flip the kill switch.
+    await db.doc(`tenants/${userId}/_meta/ceilings`).set(
+      { paused: true },
+      { merge: true }
+    );
+
+    const paused = await checkCircuitBreaker(a, "dispatch_create_task");
+    expect(paused.allowed).toBe(false);
+    if (!paused.allowed) expect(paused.code).toBe("CEILING_ORG_PAUSED");
+
+    // Every key for the tenant is affected, not just the one that tripped it.
+    const otherKey = auth({ apiKeyHash: "another-key" });
+    const pausedOther = await checkCircuitBreaker(otherKey, "dispatch_create_task");
+    expect(pausedOther.allowed).toBe(false);
+    if (!pausedOther.allowed) expect(pausedOther.code).toBe("CEILING_ORG_PAUSED");
+  });
+
+  it("fail-closed: denies mutations but allows reads when no ceilings doc exists for the tenant", async () => {
+    // seedTestUser() seeds a generous ceilings doc so unrelated suites aren't
+    // rate-limited by test infra (see setup.ts) — delete it here so this
+    // test can exercise the true "no doc at all" fail-closed path.
+    await db.doc(`tenants/${userId}/_meta/ceilings`).delete();
+    const a = auth();
+
+    const mutation = await checkCircuitBreaker(a, "dispatch_create_task");
+    expect(mutation.allowed).toBe(false);
+    if (!mutation.allowed) expect(mutation.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+
+    const read = await checkCircuitBreaker(a, "dispatch_get_tasks");
+    expect(read.allowed).toBe(true);
+  });
+
+  it("recovers after the rolling window elapses", async () => {
+    await setCeilings({ perKeyLimit: 1, orgLimit: 100, windowMs: 1_000 });
+    const a = auth();
+
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(true);
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+    expect((await checkCircuitBreaker(a, "dispatch_create_task")).allowed).toBe(true);
+  });
+});

--- a/services/mcp-server/src/__tests__/integration/setup.ts
+++ b/services/mcp-server/src/__tests__/integration/setup.ts
@@ -88,6 +88,18 @@ export async function seedTestUser(userId: string): Promise<{
     revoked: false,
   });
 
+  // WS-3: the boundary circuit breaker (middleware/circuitBreaker.ts) fails
+  // closed on mutations for any tenant without a ceilings doc. Seed a
+  // generous (non-restrictive) one here so existing suites that exercise
+  // real mutating tool calls aren't rate-limited by test infra — this is
+  // NOT a recommended production value, see DEFAULT_CEILINGS for that.
+  await db.doc(`tenants/${userId}/_meta/ceilings`).set({
+    perKeyLimit: 10_000,
+    orgLimit: 50_000,
+    windowMs: 60_000,
+    paused: false,
+  });
+
   return {
     userId,
     apiKeyHash,

--- a/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
+++ b/services/mcp-server/src/__tests__/portal-owner-send-message.test.ts
@@ -96,7 +96,10 @@ jest.mock("../auth/authValidator.js", () => ({
   validateAuth: jest.fn(),
 }));
 jest.mock("../tools.js", () => ({
-  TOOL_HANDLERS: {},
+  // WS-3: the route now calls callTool(auth, req, "relay_send_message", ...)
+  // instead of invoking sendMessageHandler directly, so TOOL_HANDLERS must
+  // resolve it to the same (real, unmocked) handler used elsewhere in this file.
+  TOOL_HANDLERS: { relay_send_message: require("../modules/relay").sendMessageHandler },
   TOOL_DEFINITIONS: [],
 }));
 jest.mock("../modules/ledger.js", () => ({
@@ -139,6 +142,12 @@ jest.mock("../modules/dream.js", () => ({
 jest.mock("../modules/gsp.js", () => ({
   gspListNamespacesHandler: jest.fn(),
   gspResolveHandler: jest.fn(),
+}));
+// WS-3: /v1/relay/messages now routes through callTool(), which calls the
+// breaker. Default to allowed so tests unrelated to WS-3 are unaffected;
+// the breaker-enforcement tests below override this per-call.
+jest.mock("../middleware/circuitBreaker.js", () => ({
+  checkCircuitBreaker: jest.fn(async () => ({ allowed: true })),
 }));
 
 // --- Auth fixtures ---
@@ -259,6 +268,7 @@ describe("POST /v1/relay/messages — route-level guards (HTTP)", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedRelayDoc = {};
     // Restore default verifySource mock
     const { verifySource } = require("../middleware/gate.js");
     verifySource.mockImplementation((_claimed: string, auth: AuthContext) => auth.programId);
@@ -321,5 +331,39 @@ describe("POST /v1/relay/messages — route-level guards (HTTP)", () => {
     const result = await makeRequest(ownerAuth());
     expect(result.status).toBe(201);
     expect(capturedRelayDoc.source).toBe("flynn");
+  });
+
+  // WS-3 SARK 2-KILL fix: this route used to call sendMessageHandler directly,
+  // bypassing callTool() and therefore the boundary circuit breaker entirely.
+  // It now goes through callTool(auth, req, "relay_send_message", ...), so a
+  // breaker denial must surface as the same typed 429/503 the other routes get.
+  it("(e) breaker denial (ceiling exceeded) maps to 429 with the typed code, not 500", async () => {
+    const { checkCircuitBreaker } = require("../middleware/circuitBreaker.js");
+    checkCircuitBreaker.mockResolvedValueOnce({
+      allowed: false,
+      code: "CEILING_KEY_EXCEEDED",
+      message: "Per-key mutation ceiling (30 per 60000ms) exceeded.",
+      retryAfterMs: 60_000,
+    });
+
+    const result = await makeRequest(ownerAuth());
+    expect(result.status).toBe(429);
+    expect((result.data as any).error.code).toBe("CEILING_KEY_EXCEEDED");
+    expect(capturedRelayDoc).toEqual({}); // handler must never have run
+  });
+
+  it("(f) breaker fail-closed (no ceilings doc) maps to 503, not 500", async () => {
+    const { checkCircuitBreaker } = require("../middleware/circuitBreaker.js");
+    checkCircuitBreaker.mockResolvedValueOnce({
+      allowed: false,
+      code: "CEILING_CONFIG_UNAVAILABLE",
+      message: "Ceiling configuration missing or unreadable for tenant; mutations deny by default (fail-closed).",
+      retryAfterMs: 60_000,
+    });
+
+    const result = await makeRequest(ownerAuth());
+    expect(result.status).toBe(503);
+    expect((result.data as any).error.code).toBe("CEILING_CONFIG_UNAVAILABLE");
+    expect(capturedRelayDoc).toEqual({});
   });
 });

--- a/services/mcp-server/src/index.ts
+++ b/services/mcp-server/src/index.ts
@@ -30,6 +30,7 @@ import { detectStaleSessions } from "./modules/stale-session-detector.js";
 import { executeSchedulesForUser } from "./modules/schedule-executor.js";
 import { checkSessionCompliance, resetTransportCompliance } from "./middleware/sessionCompliance.js";
 import { checkPricing } from "./middleware/pricingEnforce.js";
+import { checkCircuitBreaker } from "./middleware/circuitBreaker.js";
 import { incrementUsage } from "./middleware/usage.js";
 import { handleOAuthMetadata, handleOAuthProtectedResource } from "./oauth/metadata.js";
 import { handleOAuthRegister, cleanupDcrRateLimits } from "./oauth/register.js";
@@ -190,6 +191,24 @@ async function main() {
     if (!capCheck.allowed) {
       audit.error(name, `Insufficient capability: requires "${capCheck.required}"`, { tool: name, programId: auth.programId, source: auth.programId, endpoint: "mcp" });
       return { content: [{ type: "text", text: `Insufficient capability: ${name} requires "${capCheck.required}" but key has [${auth.capabilities.join(", ")}]` }], isError: true };
+    }
+
+    // WS-3: Boundary circuit breaker — server-measured mutation ceilings, fail-closed.
+    // No-op (and no Firestore read) for read-only tools; only mutating calls pay this cost.
+    const breakerResult = await checkCircuitBreaker(auth, name);
+    if (!breakerResult.allowed) {
+      audit.error(name, `${breakerResult.code}: ${breakerResult.message}`, { tool: name, programId: auth.programId, source: auth.programId, endpoint: "mcp" });
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            error: breakerResult.code,
+            message: breakerResult.message,
+            retryAfterMs: breakerResult.retryAfterMs,
+          }),
+        }],
+        isError: true,
+      };
     }
 
     // OAuth scope enforcement — only applies to OAuth tokens

--- a/services/mcp-server/src/iso/isoServer.ts
+++ b/services/mcp-server/src/iso/isoServer.ts
@@ -19,6 +19,7 @@ import { getAuditHandler } from "../modules/audit.js";
 import { getCostSummaryHandler, getCommsMetricsHandler, getOperationalMetricsHandler } from "../modules/metrics.js";
 import { checkRateLimit, getRateLimitResetIn } from "../middleware/rateLimiter.js";
 import { generateCorrelationId, createAuditLogger } from "../middleware/gate.js";
+import { checkCircuitBreaker } from "../middleware/circuitBreaker.js";
 import { logToolCall } from "../modules/ledger.js";
 import { traceToolCall, queryTracesHandler } from "../modules/trace.js";
 import { getSprintHandler } from "../modules/sprint.js";
@@ -85,6 +86,40 @@ export async function createIsoServer(): Promise<{
       const resetIn = Math.ceil(getRateLimitResetIn(authContext.userId, name) / 1000);
       return {
         content: [{ type: "text", text: `Rate limit exceeded for ${name}. Try again in ${resetIn} seconds.` }],
+        isError: true,
+      };
+    }
+
+    // Capability gate — SARK re-panel: this endpoint dispatched straight to
+    // ISO_TOOL_HANDLERS with no capability check, so any valid Bearer key
+    // reached mutating tools (relay_send_message, dispatch_create_task, etc.)
+    // regardless of what the key was scoped to. Mirrors the gate in index.ts's
+    // main /v1/mcp CallToolRequestSchema handler. Always uses authContext.capabilities
+    // from the validated key — never anything derived from X-Program-Id.
+    const { checkToolCapability } = await import("../middleware/capabilities.js");
+    const capCheck = checkToolCapability(name, authContext.capabilities);
+    if (!capCheck.allowed) {
+      audit.error(name, `Insufficient capability: requires "${capCheck.required}"`, { tool: name, programId: authContext.programId, source: authContext.programId, endpoint: "admin" });
+      return {
+        content: [{ type: "text", text: `Insufficient capability: ${name} requires "${capCheck.required}" but key has [${authContext.capabilities.join(", ")}]` }],
+        isError: true,
+      };
+    }
+
+    // WS-3: Boundary circuit breaker — server-measured mutation ceilings, fail-closed.
+    // No-op (and no Firestore read) for read-only tools; only mutating calls pay this cost.
+    const breakerResult = await checkCircuitBreaker(authContext, name);
+    if (!breakerResult.allowed) {
+      audit.error(name, `${breakerResult.code}: ${breakerResult.message}`, { tool: name, programId: authContext.programId, source: authContext.programId, endpoint: "admin" });
+      return {
+        content: [{
+          type: "text",
+          text: JSON.stringify({
+            error: breakerResult.code,
+            message: breakerResult.message,
+            retryAfterMs: breakerResult.retryAfterMs,
+          }),
+        }],
         isError: true,
       };
     }

--- a/services/mcp-server/src/middleware/capabilities.ts
+++ b/services/mcp-server/src/middleware/capabilities.ts
@@ -72,6 +72,10 @@ export const TOOL_CAPABILITIES: Record<string, Capability> = {
   relay_get_sent_messages: "relay.read",
   relay_query_message_history: "relay.read",
   relay_send_directive: "relay.write",
+  // REST-only: POST /v1/messages/mark_read mutates relay message read-state
+  // directly (no MCP tool handler) — mapped here purely for capability +
+  // circuit-breaker gating via enforceBreaker() in rest.ts.
+  relay_mark_read: "relay.write",
   // Pulse
   pulse_create_session: "pulse.write",
   pulse_update_session: "pulse.write",

--- a/services/mcp-server/src/middleware/circuitBreaker.ts
+++ b/services/mcp-server/src/middleware/circuitBreaker.ts
@@ -67,11 +67,22 @@ export type BreakerDecision =
 const NON_WRITE_MUTATING_CAPABILITIES = new Set(["fleet.control"]);
 
 /**
- * A tool is "mutating" when its required capability writes state — normally a
- * `*.write` grant, plus the explicit non-`.write` mutating capabilities above.
+ * Tools that write state but whose required capability does not reflect it, so
+ * capability-based classification alone would miss them. `metrics_log_rate_limit_event`
+ * is gated at `metrics.read` (read-tier access) yet appends a Firestore
+ * `rate_limit_events` doc — breaker-gate it by name so the ceiling + kill switch
+ * cover the write WITHOUT changing the capability required to call it.
+ * (SARK WS-3 final panel.)
+ */
+const EXPLICITLY_MUTATING_TOOLS = new Set(["metrics_log_rate_limit_event"]);
+
+/**
+ * A tool is "mutating" when it writes state — normally a `*.write` grant, plus
+ * the explicit non-`.write` mutating capabilities and the by-name write tools above.
  */
 export function isMutatingTool(toolName: string): boolean {
   const canonical = resolveToolAlias(toolName);
+  if (EXPLICITLY_MUTATING_TOOLS.has(canonical)) return true;
   const required = TOOL_CAPABILITIES[canonical];
   if (!required) return false;
   return required.endsWith(".write") || NON_WRITE_MUTATING_CAPABILITIES.has(required);

--- a/services/mcp-server/src/middleware/circuitBreaker.ts
+++ b/services/mcp-server/src/middleware/circuitBreaker.ts
@@ -57,11 +57,24 @@ export type BreakerDecision =
   | { allowed: true }
   | { allowed: false; code: BreakerCode; message: string; retryAfterMs: number };
 
-/** A tool is "mutating" when its required capability is a `*.write` grant. */
+/**
+ * Capabilities that grant a mutating operation but are NOT suffixed `.write`.
+ * These must still be breaker-gated so the kill switch and fail-closed
+ * invariants cover EVERY mutation. `fleet.control` gates
+ * dispatch_quarantine_program / dispatch_unquarantine_program, both of which
+ * write program state in a Firestore transaction. (SARK WS-3 final panel.)
+ */
+const NON_WRITE_MUTATING_CAPABILITIES = new Set(["fleet.control"]);
+
+/**
+ * A tool is "mutating" when its required capability writes state — normally a
+ * `*.write` grant, plus the explicit non-`.write` mutating capabilities above.
+ */
 export function isMutatingTool(toolName: string): boolean {
   const canonical = resolveToolAlias(toolName);
   const required = TOOL_CAPABILITIES[canonical];
-  return !!required && required.endsWith(".write");
+  if (!required) return false;
+  return required.endsWith(".write") || NON_WRITE_MUTATING_CAPABILITIES.has(required);
 }
 
 // --- Rolling window math — pure, unit-tested independently of Firestore/state. ---

--- a/services/mcp-server/src/middleware/circuitBreaker.ts
+++ b/services/mcp-server/src/middleware/circuitBreaker.ts
@@ -1,0 +1,194 @@
+/**
+ * Circuit Breaker Middleware — Boundary-enforced mutation ceilings (WS-3).
+ *
+ * SARK #881 finding 5: breaker state must be measured AT THE BOUNDARY, below
+ * the agent — never self-reported by the caller (that finding was about a
+ * spend breaker gated on agent-submitted cost_usd). This breaker counts
+ * mutating tool calls server-side from auth context the caller cannot shape;
+ * nothing here trusts an agent-submitted value.
+ *
+ * Ceilings are per-tenant, configurable in Firestore at
+ * tenants/{org}/_meta/ceilings: { perKeyLimit, orgLimit, windowMs, paused }.
+ *
+ * FAIL-CLOSED: if that config is missing, malformed, or the read throws,
+ * mutations are denied. Reads never enter this breaker at all (checked via
+ * isMutatingTool before any Firestore access), so they're unaffected by
+ * both the ceiling and any config outage — this is also what keeps the read
+ * hot path free of the added Firestore round trip.
+ *
+ * Kill switch: config.paused denies every mutation for the tenant. Since
+ * config is read fresh (no cross-request cache) on every mutating call,
+ * flipping `paused` takes effect on the very next request.
+ */
+
+import type { AuthContext } from "../auth/authValidator.js";
+import { getFirestore } from "../firebase/client.js";
+import { sendAlertHandler } from "../modules/signal.js";
+import { TOOL_CAPABILITIES } from "./capabilities.js";
+import { resolveToolAlias } from "../tools/tool-aliases.js";
+
+export interface CeilingConfig {
+  perKeyLimit: number;
+  orgLimit: number;
+  windowMs: number;
+  paused: boolean;
+}
+
+/**
+ * Conservative seed values for a tenant's ceiling doc. Exported for
+ * provisioning tooling — NEVER consulted as a runtime fallback. A missing
+ * doc fails closed (see loadCeilingConfig / checkCircuitBreaker), it does
+ * not silently adopt these numbers.
+ */
+export const DEFAULT_CEILINGS: CeilingConfig = {
+  perKeyLimit: 30,
+  orgLimit: 150,
+  windowMs: 60_000,
+  paused: false,
+};
+
+export type BreakerCode =
+  | "CEILING_CONFIG_UNAVAILABLE"
+  | "CEILING_ORG_PAUSED"
+  | "CEILING_KEY_EXCEEDED"
+  | "CEILING_ORG_EXCEEDED";
+
+export type BreakerDecision =
+  | { allowed: true }
+  | { allowed: false; code: BreakerCode; message: string; retryAfterMs: number };
+
+/** A tool is "mutating" when its required capability is a `*.write` grant. */
+export function isMutatingTool(toolName: string): boolean {
+  const canonical = resolveToolAlias(toolName);
+  const required = TOOL_CAPABILITIES[canonical];
+  return !!required && required.endsWith(".write");
+}
+
+// --- Rolling window math — pure, unit-tested independently of Firestore/state. ---
+
+export function pruneWindow(timestamps: number[], now: number, windowMs: number): number[] {
+  const cutoff = now - windowMs;
+  return timestamps.filter((t) => t > cutoff);
+}
+
+export function countInWindow(timestamps: number[], now: number, windowMs: number): number {
+  return pruneWindow(timestamps, now, windowMs).length;
+}
+
+// --- In-memory sliding-window counters — same single-instance architecture as
+// rateLimiter.ts's `windows` map. Firestore holds ceiling CONFIG, not counts.
+
+const keyWindows = new Map<string, number[]>();
+const orgWindows = new Map<string, number[]>();
+
+/** Prune expired entries and return the live count, without consuming a slot. */
+function peekCount(store: Map<string, number[]>, cacheKey: string, now: number, windowMs: number): number {
+  const pruned = pruneWindow(store.get(cacheKey) || [], now, windowMs);
+  store.set(cacheKey, pruned);
+  return pruned.length;
+}
+
+/** Consume one slot (call only after all ceiling checks for a request have passed). */
+function consume(store: Map<string, number[]>, cacheKey: string, now: number): void {
+  const arr = store.get(cacheKey) || [];
+  arr.push(now);
+  store.set(cacheKey, arr);
+}
+
+/** Test-only: clear all in-memory breaker state between test cases. */
+export function resetCircuitBreakerState(): void {
+  keyWindows.clear();
+  orgWindows.clear();
+}
+
+// --- Firestore-backed ceiling config ---
+
+async function loadCeilingConfig(org: string): Promise<CeilingConfig | null> {
+  const db = getFirestore();
+  const snap = await db.doc(`tenants/${org}/_meta/ceilings`).get();
+  if (!snap.exists) return null;
+
+  const data = snap.data() || {};
+  const perKeyLimit = Number(data.perKeyLimit);
+  const orgLimit = Number(data.orgLimit);
+  const windowMs = Number(data.windowMs);
+
+  if (
+    !Number.isFinite(perKeyLimit) || perKeyLimit <= 0 ||
+    !Number.isFinite(orgLimit) || orgLimit <= 0 ||
+    !Number.isFinite(windowMs) || windowMs <= 0
+  ) {
+    // Malformed config is treated as missing — fail closed, not "best effort".
+    return null;
+  }
+
+  return { perKeyLimit, orgLimit, windowMs, paused: data.paused === true };
+}
+
+function emitBreakerAlert(auth: AuthContext, tool: string, code: BreakerCode, message: string): void {
+  sendAlertHandler(auth, {
+    message: `Circuit breaker tripped (${code}) on "${tool}": ${message}`,
+    alertType: "warning",
+    priority: "high",
+  }).catch((err) => {
+    console.error("[CircuitBreaker] Failed to emit signal alert:", err);
+  });
+}
+
+/**
+ * Enforce the boundary circuit breaker for one tool call. Read-only tools
+ * bypass entirely (no Firestore read, always allowed). Callers are expected
+ * to also write an audit record on denial via the existing gate.ts audit
+ * logger, mirroring how the capability-gate denial path already works.
+ */
+export async function checkCircuitBreaker(auth: AuthContext, toolName: string): Promise<BreakerDecision> {
+  if (!isMutatingTool(toolName)) return { allowed: true };
+
+  const org = auth.userId;
+  const now = Date.now();
+
+  let config: CeilingConfig | null;
+  try {
+    config = await loadCeilingConfig(org);
+  } catch (err) {
+    console.error("[CircuitBreaker] Ceiling config read failed — failing closed:", err);
+    config = null;
+  }
+
+  if (!config) {
+    const message = `Ceiling configuration missing or unreadable for tenant "${org}"; mutations deny by default (fail-closed).`;
+    emitBreakerAlert(auth, toolName, "CEILING_CONFIG_UNAVAILABLE", message);
+    return { allowed: false, code: "CEILING_CONFIG_UNAVAILABLE", message, retryAfterMs: 60_000 };
+  }
+
+  if (config.paused) {
+    const message = `Tenant "${org}" is paused; all mutations fail closed until unpaused.`;
+    emitBreakerAlert(auth, toolName, "CEILING_ORG_PAUSED", message);
+    return { allowed: false, code: "CEILING_ORG_PAUSED", message, retryAfterMs: config.windowMs };
+  }
+
+  const keyCacheKey = `key:${auth.apiKeyHash}`;
+  const orgCacheKey = `org:${org}`;
+
+  const keyCount = peekCount(keyWindows, keyCacheKey, now, config.windowMs);
+  if (keyCount >= config.perKeyLimit) {
+    const message = `Per-key mutation ceiling (${config.perKeyLimit} per ${config.windowMs}ms) exceeded.`;
+    emitBreakerAlert(auth, toolName, "CEILING_KEY_EXCEEDED", message);
+    return { allowed: false, code: "CEILING_KEY_EXCEEDED", message, retryAfterMs: config.windowMs };
+  }
+
+  const orgCount = peekCount(orgWindows, orgCacheKey, now, config.windowMs);
+  if (orgCount >= config.orgLimit) {
+    const message = `Org-aggregate mutation ceiling (${config.orgLimit} per ${config.windowMs}ms) exceeded.`;
+    emitBreakerAlert(auth, toolName, "CEILING_ORG_EXCEEDED", message);
+    return { allowed: false, code: "CEILING_ORG_EXCEEDED", message, retryAfterMs: config.windowMs };
+  }
+
+  // Both ceilings clear — consume one slot from each. Consuming only after
+  // both checks pass keeps a call that trips the org ceiling from silently
+  // costing the key its own budget.
+  consume(keyWindows, keyCacheKey, now);
+  consume(orgWindows, orgCacheKey, now);
+
+  return { allowed: true };
+}

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -18,6 +18,7 @@ import { sendMessageHandler } from "../modules/relay.js";
 import { enforceRateLimit, checkAuthRateLimit } from "../middleware/rateLimiter.js";
 import { checkSessionCompliance, resetTransportCompliance } from "../middleware/sessionCompliance.js";
 import { checkPricing } from "../middleware/pricingEnforce.js";
+import { checkCircuitBreaker, type BreakerCode } from "../middleware/circuitBreaker.js";
 import { incrementUsage } from "../middleware/usage.js";
 import { ADMIN_READERS } from "../config/access-tiers.js";
 import { CONSTANTS } from "../config/constants.js";
@@ -47,6 +48,17 @@ class PricingError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "PricingError";
+  }
+}
+
+class BreakerError extends Error {
+  code: BreakerCode;
+  retryAfterMs: number;
+  constructor(message: string, code: BreakerCode, retryAfterMs: number) {
+    super(message);
+    this.name = "BreakerError";
+    this.code = code;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
@@ -187,6 +199,17 @@ async function callTool(auth: AuthContext, req: http.IncomingMessage, toolName: 
     throw new Error(
       `Insufficient capability: ${toolName} requires "${capCheck.required}" but key has [${capCheck.held.join(", ")}]`
     );
+  }
+
+  // WS-3: Boundary circuit breaker — server-measured mutation ceilings, fail-closed.
+  // No-op (and no Firestore read) for read-only tools; only mutating calls pay this cost.
+  const breakerResult = await checkCircuitBreaker(auth, toolName);
+  if (!breakerResult.allowed) {
+    createAuditLogger(generateCorrelationId(), auth.userId).error(
+      toolName, `${breakerResult.code}: ${breakerResult.message}`,
+      { tool: toolName, programId: auth.programId, source: auth.programId, endpoint: "rest" }
+    );
+    throw new BreakerError(breakerResult.message, breakerResult.code, breakerResult.retryAfterMs);
   }
 
   let complianceWarning: string | undefined;
@@ -998,6 +1021,14 @@ export function createRestRouter(): (req: http.IncomingMessage, res: http.Server
             code: "PRICING_LIMIT_REACHED",
             message: err.message,
           }, 402);
+        }
+        if (err instanceof BreakerError) {
+          res.setHeader("Retry-After", String(Math.ceil(err.retryAfterMs / 1000)));
+          const status = err.code === "CEILING_ORG_PAUSED" || err.code === "CEILING_CONFIG_UNAVAILABLE" ? 503 : 429;
+          return restResponse(res, false, {
+            code: err.code,
+            message: err.message,
+          }, status);
         }
         return restResponse(res, false, {
           code: "INTERNAL_ERROR",

--- a/services/mcp-server/src/transport/rest.ts
+++ b/services/mcp-server/src/transport/rest.ts
@@ -12,9 +12,8 @@ import { traceToolCall } from "../modules/trace.js";
 import { getFirestore } from "../firebase/client.js";
 import * as admin from "firebase-admin";
 import { generateCorrelationId, createAuditLogger } from "../middleware/gate.js";
-import { dreamPeekHandler, dreamActivateHandler } from "../modules/dream.js";
-import { gspListNamespacesHandler, gspResolveHandler } from "../modules/gsp.js";
-import { sendMessageHandler } from "../modules/relay.js";
+import { dreamPeekHandler } from "../modules/dream.js";
+import { gspListNamespacesHandler } from "../modules/gsp.js";
 import { enforceRateLimit, checkAuthRateLimit } from "../middleware/rateLimiter.js";
 import { checkSessionCompliance, resetTransportCompliance } from "../middleware/sessionCompliance.js";
 import { checkPricing } from "../middleware/pricingEnforce.js";
@@ -285,6 +284,35 @@ async function callTool(auth: AuthContext, req: http.IncomingMessage, toolName: 
   }
 }
 
+/**
+ * Capability + circuit-breaker gate for REST routes whose write logic runs
+ * outside callTool() — either because there's no corresponding MCP tool
+ * handler (mark_read) or because the route needs custom pre/post handling
+ * around the handler call. Throws the same typed errors callTool() throws
+ * (a plain capability Error, or BreakerError) so the top-level dispatcher's
+ * existing instanceof handling produces the same 403/429/503 responses.
+ * Does NOT rate-limit or run compliance/pricing — callers that need those
+ * should route through callTool() instead (the preferred path).
+ */
+async function enforceBreaker(auth: AuthContext, toolName: string): Promise<void> {
+  const { checkToolCapability } = await import("../middleware/capabilities.js");
+  const capCheck = checkToolCapability(toolName, auth.capabilities);
+  if (!capCheck.allowed) {
+    throw new Error(
+      `Insufficient capability: ${toolName} requires "${capCheck.required}" but key has [${capCheck.held.join(", ")}]`
+    );
+  }
+
+  const breakerResult = await checkCircuitBreaker(auth, toolName);
+  if (!breakerResult.allowed) {
+    createAuditLogger(generateCorrelationId(), auth.userId).error(
+      toolName, `${breakerResult.code}: ${breakerResult.message}`,
+      { tool: toolName, programId: auth.programId, source: auth.programId, endpoint: "rest" }
+    );
+    throw new BreakerError(breakerResult.message, breakerResult.code, breakerResult.retryAfterMs);
+  }
+}
+
 const routes: Route[] = [
   // Dispatch
   route("GET", "/v1/tasks/stats", async (auth, req, res) => {
@@ -399,6 +427,7 @@ const routes: Route[] = [
     restResponse(res, true, { messages, count: messages.length });
   }),
   route("POST", "/v1/messages/mark_read", async (auth, req, res) => {
+    await enforceBreaker(auth, "relay_mark_read");
     const body = await readBody(req);
     const messageIds = body.messageIds as string[];
     if (!Array.isArray(messageIds) || messageIds.length === 0) {
@@ -447,11 +476,15 @@ const routes: Route[] = [
     const body = await readBody(req);
     const source = auth.keyProgramId ?? auth.programId;
     try {
-      const result = await sendMessageHandler(auth, { ...body, source });
-      const text = result?.content?.[0]?.text;
-      const parsed = text ? JSON.parse(text) : result;
+      const parsed = await callTool(auth, req, "relay_send_message", { ...body, source }) as { success?: boolean };
       restResponse(res, parsed.success !== false, parsed, parsed.success !== false ? 201 : 400);
     } catch (err) {
+      // Rate limit / compliance / pricing / breaker denials carry their own typed
+      // status+headers handling in the top-level route dispatcher — let those bubble.
+      if (err instanceof ComplianceError || err instanceof PricingError || err instanceof BreakerError ||
+          (err instanceof Error && (err as any).rateLimitResult)) {
+        throw err;
+      }
       if (err instanceof Error && err.message.includes("Source mismatch")) {
         sendJson(res, 403, { success: false, error: "SOURCE_MISMATCH", message: err.message });
       } else {
@@ -674,9 +707,8 @@ const routes: Route[] = [
     restResponse(res, true, text ? JSON.parse(text) : result);
   }),
   route("POST", "/v1/dreams/:id/activate", async (auth, req, res, p) => {
-    const result = await dreamActivateHandler(auth, { dreamId: p.id });
-    const text = result?.content?.[0]?.text;
-    restResponse(res, true, text ? JSON.parse(text) : result);
+    const result = await callTool(auth, req, "dream_activate", { dreamId: p.id });
+    restResponse(res, true, result);
   }),
 
 
@@ -743,9 +775,7 @@ const routes: Route[] = [
   // GSP Resolve — approve, reject, or withdraw a proposal
   route("POST", "/v1/gsp/proposals/:id/resolve", async (auth, req, res, p) => {
     const body = await readBody(req);
-    const result = await gspResolveHandler(auth, { proposalId: p.id, ...body });
-    const text = result?.content?.[0]?.text;
-    const parsed = text ? JSON.parse(text) : result;
+    const parsed = await callTool(auth, req, "gsp_resolve", { proposalId: p.id, ...body }) as { success?: boolean };
     restResponse(res, parsed.success !== false, parsed, parsed.success !== false ? 200 : 400);
   }),
 
@@ -830,9 +860,8 @@ const routes: Route[] = [
   }),
   route("POST", "/v1/dreams/activate", async (auth, req, res) => {
     const body = await readBody(req);
-    const result = await dreamActivateHandler(auth, body);
-    const text = result?.content?.[0]?.text;
-    restResponse(res, true, text ? JSON.parse(text) : result);
+    const result = await callTool(auth, req, "dream_activate", body);
+    restResponse(res, true, result);
   }),
 
   // Traces


### PR DESCRIPTION
## Summary

Server-side, per-tenant circuit breaker on mutating tool calls (dispatch creates, relay sends, state writes, ...), measured at the boundary — never self-reported by the caller (SARK #881 finding 5: the spend-breaker finding explicitly required boundary-measured, agent-can't-shape enforcement; this applies the same principle to mutation ceilings).

New: `src/middleware/circuitBreaker.ts`, wired into both `index.ts` (MCP) and `transport/rest.ts` (REST) right after the existing capability gate. Plus `scripts/seed-ceilings.ts`, a provisioning helper — **required before deploy**, see "Deploy prerequisite" below.

## Acceptance criteria → where they're met

| Criterion | Where |
|---|---|
| Per-key ceilings on mutating actions (dispatch creates, relay sends, state writes), per rolling window | `circuitBreaker.ts` — `isMutatingTool()` classifies any tool whose required capability ends in `.write` (covers dispatch/relay/state and every other write capability generically); `checkCircuitBreaker()` enforces `perKeyLimit` via an in-memory sliding window keyed by `apiKeyHash`, same single-instance architecture as the existing `rateLimiter.ts` |
| Org-aggregate ceiling | Same function, second sliding window keyed by tenant (`orgLimit`) |
| Kill switch: org pause → all tenant keys fail closed within one request | `config.paused` checked on every mutating call via a **live** Firestore read (no cross-request cache) — the very next request after `paused: true` is written is denied, for every key in the tenant. Integration-tested. |
| Ceilings configurable per key/tenant in Firestore, conservative defaults | `tenants/{org}/_meta/ceilings` (`perKeyLimit`, `orgLimit`, `windowMs`, `paused`); `DEFAULT_CEILINGS` exported as the conservative seed value for `scripts/seed-ceilings.ts` — **never** consulted as a runtime fallback |
| FAIL-CLOSED: missing/unreadable config ⇒ deny mutations, allow reads | `loadCeilingConfig()` returns `null` on missing doc, malformed fields, or a thrown read — `checkCircuitBreaker()` denies (`CEILING_CONFIG_UNAVAILABLE`) in all three cases. Reads never enter the function at all (`isMutatingTool` check is the first line, before any Firestore access) |
| Breaker trips emit an audit record + a signal alert | Signal alert: `emitBreakerAlert()` inside `circuitBreaker.ts` (fire-and-forget `sendAlertHandler`). Audit record: both call sites (`index.ts`, `rest.ts`) call the existing `gate.ts` audit logger on denial, identical to how the capability-gate denial path already does it |
| Enforce in the request/capability middleware path, reuse usage-counter middleware where possible | Sits directly after `checkToolCapability()` in both transports; reuses `rateLimiter.ts`'s in-memory sliding-window architecture and `gate.ts`'s audit logger rather than inventing new plumbing |
| Unit tests: rolling-window math + fail-closed paths | `src/__tests__/circuitBreaker.test.ts` — 22 tests: pure `pruneWindow`/`countInWindow` math, missing/throwing/malformed config, kill switch, per-key + org ceilings, tenant isolation, window recovery |
| Integration test: N+1th mutation denied with a typed error, reads still pass | `src/__tests__/integration/circuit-breaker.test.ts` — 5 tests against the real Firestore emulator, including the exact N+1th-denied-while-reads-pass scenario and kill-switch verification |
| Kill switch verified | Same integration file — pause takes effect on the next request, affects all keys for the tenant |
| No hot-path latency regression > 10ms p50 | Reads bypass the breaker before any Firestore access (zero added cost — this is the majority of traffic). Mutating calls pay exactly one Firestore `.get()` per request; ceiling counts themselves are in-memory (no write on the hot path, matching `rateLimiter.ts`'s existing fire-and-forget persistence pattern for anything durable) |

## Deploy prerequisite (read before merge)

Fail-closed means **any tenant without a `_meta/ceilings` doc loses all mutation ability** the moment this deploys — confirmed directly: the existing integration suite broke (5 suites, `relay-delivery`/`task-telemetry`/`programState`/`gsp`/`keys`) until I seeded a ceilings doc in the shared test harness (`setup.ts`). The same thing will happen to every real tenant (`lore` included) unless seeded first.

**Before `gcloud run deploy`:** run `scripts/seed-ceilings.ts <org>` for every active tenant (owner ADC required, same credential story as `provision-program.ts`). I did not run this against prod — that's a deploy-time action, not a code change.

## Test plan

- [x] `npm run build` (tsc) — clean
- [x] `npm test` — 721/742 passing (21 pre-existing skips), 0 failures, includes 22 new circuit-breaker unit tests
- [x] `npm run test:integration` (Firestore emulator) — same 4-suite/13-test baseline failure as unmodified `main` (confirmed via `git stash` diff — pre-existing, unrelated to this PR), all 5 new circuit-breaker integration tests pass
- [ ] SARK 3-voter security panel (per PRD §5 gate for WS-3)
- [ ] ISO: seed ceilings for active tenants via `scripts/seed-ceilings.ts` before deploy
- [ ] ISO: `gcloud run deploy` + authed verify per deploy discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8fx1VKe7xgxXdJSHq3eBr