### PR TITLE
chore(ws-3): ceiling ops tooling (seed-all + enumerate tenants)

### DIFF
--- a/services/mcp-server/scripts/enumerate-tenants.ts
+++ b/services/mcp-server/scripts/enumerate-tenants.ts
@@ -1,0 +1,36 @@
+/**
+ * enumerate-tenants.ts — list distinct active-key tenant orgs + whether each
+ * already has a WS-3 ceilings doc. Owner ADC required (read-only is fine).
+ *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx services/mcp-server/scripts/enumerate-tenants.ts
+ */
+import * as admin from "firebase-admin";
+
+async function main() {
+  if (!admin.apps.length) admin.initializeApp();
+  const db = admin.firestore();
+
+  const keys = await db.collection("keyIndex").get();
+  const orgs = new Map<string, { active: number; programs: Set<string> }>();
+  for (const doc of keys.docs) {
+    const d = doc.data();
+    if (d.active !== true) continue;
+    const org = d.userId;
+    if (!org) continue;
+    const e = orgs.get(org) || { active: 0, programs: new Set<string>() };
+    e.active += 1;
+    if (d.programId) e.programs.add(d.programId);
+    orgs.set(org, e);
+  }
+
+  console.error(`\nDistinct active-key tenant orgs: ${orgs.size}\n`);
+  for (const [org, e] of orgs) {
+    const snap = await db.doc(`tenants/${org}/_meta/ceilings`).get();
+    const c = snap.exists ? snap.data()! : null;
+    const ceil = c ? `perKey=${c.perKeyLimit} org=${c.orgLimit} win=${c.windowMs} paused=${c.paused === true}` : "MISSING";
+    console.error(`${org}  keys=${e.active}  programs=[${[...e.programs].join(",")}]`);
+    console.error(`    ceilings: ${snap.exists ? "EXISTS" : "MISSING"}  ${ceil}`);
+  }
+  console.error("\ndone");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/services/mcp-server/scripts/seed-all-tenants.ts
+++ b/services/mcp-server/scripts/seed-all-tenants.ts
@@ -1,0 +1,53 @@
+/**
+ * seed-all-tenants.ts — one-shot pre-deploy seed of WS-3 ceilings for EVERY
+ * active tenant org, so the fail-closed breaker does not deny the fleet the
+ * moment enforcement deploys. Owner ADC required (write).
+ *   GOOGLE_CLOUD_PROJECT=cachebash-app npx tsx services/mcp-server/scripts/seed-all-tenants.ts
+ *
+ * Idempotent (merge). Never sets paused (kill switch is a separate action).
+ * Go-live posture: generous ceilings — per-key catches a single runaway,
+ * org caps a multi-program storm; tighten after observing real volume via
+ * the breaker's signal alerts. Any active org NOT in OVERRIDES gets
+ * DEFAULT_CEILINGS.
+ */
+import * as admin from "firebase-admin";
+import { DEFAULT_CEILINGS } from "../src/middleware/circuitBreaker.js";
+
+// Per-tenant overrides keyed by Firestore userId (auth.userId at runtime).
+const OVERRIDES: Record<string, { perKeyLimit: number; orgLimit: number; windowMs: number }> = {
+  // Main Grid fleet — 29 programs share this org; each program is its own key.
+  "7viFKVtl5lgzguhFoZlnYYrqeDG2": { perKeyLimit: 100, orgLimit: 1500, windowMs: 60_000 },
+  // Dispatcher — single key, high task-mutation volume (claim/complete/create/retry).
+  "T0NWeYZIfcY7cvLK4BrOEIzaUHJ2": { perKeyLimit: 120, orgLimit: 300, windowMs: 60_000 },
+};
+
+async function main() {
+  if (!admin.apps.length) admin.initializeApp();
+  const db = admin.firestore();
+
+  // Ground-truth the active orgs from keyIndex (do not hardcode the list).
+  const keys = await db.collection("keyIndex").get();
+  const orgs = new Set<string>();
+  for (const doc of keys.docs) {
+    const d = doc.data();
+    if (d.active === true && d.userId) orgs.add(d.userId);
+  }
+
+  console.error(`\nSeeding ceilings for ${orgs.size} active orgs...\n`);
+  for (const org of orgs) {
+    const cfg = OVERRIDES[org] ?? {
+      perKeyLimit: DEFAULT_CEILINGS.perKeyLimit,
+      orgLimit: DEFAULT_CEILINGS.orgLimit,
+      windowMs: DEFAULT_CEILINGS.windowMs,
+    };
+    const ref = db.doc(`tenants/${org}/_meta/ceilings`);
+    // merge:true — never clobber a paused flag or other future fields.
+    await ref.set({ ...cfg, updatedAt: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+    const after = (await ref.get()).data()!;
+    const tag = OVERRIDES[org] ? "OVERRIDE" : "default ";
+    console.error(`  ${org}  [${tag}] perKey=${after.perKeyLimit} org=${after.orgLimit} win=${after.windowMs} paused=${after.paused === true}`);
+  }
+  console.error("\ndone");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Ops tooling used at WS-3 go-live to seed `tenants/{org}/_meta/ceilings` for all active tenants before the fail-closed breaker deployed.

- `enumerate-tenants.ts` — lists active-key orgs + each one's ceiling status (read-only, owner ADC).
- `seed-all-tenants.ts` — idempotent (merge) seed of every active org; generous go-live overrides for main fleet (perKey=100/org=1500) + dispatcher (120/300); DEFAULT_CEILINGS for 8 external single-key tenants. Never touches `paused`.

Both ran successfully at go-live (rev cachebash-mcp-00165-cg6). Complements committed `seed-ceilings.ts`. No server/runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)