### PR TITLE
Implement durable dispatch uptake contract

### DIFF
--- a/services/mcp-server/docs/dispatch-uptake-contract.md
+++ b/services/mcp-server/docs/dispatch-uptake-contract.md
@@ -1,0 +1,48 @@
+# Dispatch Uptake Contract
+
+`dispatch_dispatch` is the canonical API for actionable work dispatch. It creates a durable dispatch obligation, task, and DIRECTIVE relay message together, then waits for target uptake when requested.
+
+`relay_send_message` remains asynchronous. A successful relay send only means the message was stored for delivery; it does not prove a target accepted work.
+
+## Invariant
+
+Actionable dispatch must never report `success: true` until one of these is observed:
+
+- the task leaves `created` and is claimed by the target program
+- the target sends an `ACK` whose `reply_to` is the dispatch DIRECTIVE id
+
+If uptake is not observed, the API returns `success: false` with `pendingHandle`. Supervisors should track `pendingHandle.obligationId` instead of redispatching blindly.
+
+## Durable Records
+
+Each dispatch writes `tenants/{tenant}/dispatch_obligations/{obligationId}` with:
+
+- `taskId`, `directiveId`, `source`, `target`, `threadId`
+- `deliveryState`
+- `claimSlaSeconds`, `claimDeadlineAt`
+- wake result and target-state metadata
+- telemetry such as `timeToClaimMs`, `timeToAckMs`, and `escalatedAt`
+
+The task also stores `dispatchObligationId` and `dispatchDeliveryState` for quick inspection.
+
+## Delivery States
+
+- `stored`: obligation exists and queued work is durable
+- `wake-attempted`: server attempted host wake/relaunch
+- `notified`: DIRECTIVE relay was stored
+- `claimed`: target claimed the task or ACKed the DIRECTIVE
+- `rejected`: policy/runtime state means target cannot accept work, such as paused or quarantined
+- `escalated`: claim SLA elapsed without claim or ACK
+- `expired`: reserved for TTL cleanup
+
+## Idempotency
+
+Callers may pass `idempotency_key`. Reusing the key returns the existing obligation/task/directive instead of creating duplicate work. Use this for retries after client timeouts.
+
+## Operating Guidance
+
+For absent or stale targets, keep `autoWake: true`. The server may wake or launch the target through the wake host, but senders must not inject into another program's attended terminal.
+
+For busy targets, work remains queued as a task. A timeout from `dispatch_dispatch` is not a lost dispatch; it is an escalated pending obligation.
+
+For `waitForUptake: false`, the response is intentionally not successful. It returns a tracked pending handle and `action_required: "monitor_pending"`.

--- a/services/mcp-server/docs/dispatch-uptake-contract.md
+++ b/services/mcp-server/docs/dispatch-uptake-contract.md
@@ -1,6 +1,6 @@
 # Dispatch Uptake Contract
 
-`dispatch_dispatch` is the canonical API for actionable work dispatch. It creates a durable dispatch obligation, task, and DIRECTIVE relay message together, then waits for target uptake when requested.
+`dispatch_dispatch` is the canonical API for actionable work dispatch. It creates or reuses a durable dispatch obligation, task, and DIRECTIVE relay message before runtime assessment or wake, then waits for target uptake when requested.
 
 `relay_send_message` remains asynchronous. A successful relay send only means the message was stored for delivery; it does not prove a target accepted work.
 
@@ -9,7 +9,7 @@
 Actionable dispatch must never report `success: true` until one of these is observed:
 
 - the task leaves `created` and is claimed by the target program
-- the target sends an `ACK` whose `reply_to` is the dispatch DIRECTIVE id
+- the intended target sends an `ACK` whose `reply_to` is the dispatch DIRECTIVE id and whose recipient is the dispatch source
 
 If uptake is not observed, the API returns `success: false` with `pendingHandle`. Supervisors should track `pendingHandle.obligationId` instead of redispatching blindly.
 
@@ -24,6 +24,8 @@ Each dispatch writes `tenants/{tenant}/dispatch_obligations/{obligationId}` with
 - telemetry such as `timeToClaimMs`, `timeToAckMs`, and `escalatedAt`
 
 The task also stores `dispatchObligationId` and `dispatchDeliveryState` for quick inspection.
+
+Runtime preflight and wake metadata are annotations on the existing obligation. A preflight or wake failure must not erase the persisted obligation/task/directive handle.
 
 ## Delivery States
 
@@ -46,3 +48,5 @@ For absent or stale targets, keep `autoWake: true`. The server may wake or launc
 For busy targets, work remains queued as a task. A timeout from `dispatch_dispatch` is not a lost dispatch; it is an escalated pending obligation.
 
 For `waitForUptake: false`, the response is intentionally not successful. It returns a tracked pending handle and `action_required: "monitor_pending"`.
+
+Skipping the uptake wait does not downgrade a `notified` obligation back to `stored`; delivery-state transitions are monotonic.

--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -103,6 +103,7 @@ const mockFirestore = {
       mockData[fullPath] = data;
       return Promise.resolve({ id, path: fullPath, _path: fullPath });
     }),
+    get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
     where: jest.fn(() => ({
       where: jest.fn(() => ({
         where: jest.fn(() => ({
@@ -364,8 +365,107 @@ describe("Policy Modes", () => {
     });
 
     const data = JSON.parse(result.content[0].text);
-    // Should succeed (governance warnings are advisory in normal mode)
+    // Governance warnings remain advisory, but skipped uptake is a tracked pending obligation.
+    expect(data.success).toBe(false);
+    expect(data.action_required).toBe("monitor_pending");
     expect(data.taskId).toBeDefined();
+  });
+
+  it("should return pending handle instead of false success when uptake wait is skipped", async () => {
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Durable pending dispatch",
+      instructions: "Track this until claim or ACK.",
+      policy_mode: "normal",
+      waitForUptake: false,
+      idempotency_key: "pending-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.uptakeConfirmed).toBe(false);
+    expect(data.action_required).toBe("monitor_pending");
+    expect(data.deliveryState).toBe("stored");
+    expect(data.pendingHandle).toMatchObject({
+      obligationId: "dispatch:pending-contract-1",
+      taskId: data.taskId,
+      directiveId: data.directiveId,
+      deliveryState: "stored",
+    });
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:pending-contract-1"];
+    expect(obligation).toBeDefined();
+    expect(obligation.taskId).toBe(data.taskId);
+    expect(obligation.directiveId).toBe(data.directiveId);
+    expect(obligation.deliveryState).toBe("stored");
+  });
+
+  it("should reuse an idempotent dispatch obligation without duplicate work", async () => {
+    const args = {
+      source: "iso",
+      target: "builder-test",
+      title: "Idempotent dispatch",
+      instructions: "Retry-safe dispatch.",
+      policy_mode: "normal",
+      waitForUptake: false,
+      idempotency_key: "dedupe-contract-1",
+    };
+
+    const first = JSON.parse((await dispatchHandler(mockAuth, args)).content[0].text);
+    const second = JSON.parse((await dispatchHandler(mockAuth, args)).content[0].text);
+
+    expect(first.success).toBe(false);
+    expect(second.success).toBe(false);
+    expect(second.idempotent).toBe(true);
+    expect(second.taskId).toBe(first.taskId);
+    expect(second.directiveId).toBe(first.directiveId);
+    expect(second.obligationId).toBe("dispatch:dedupe-contract-1");
+
+    const taskDocs = Object.keys(mockData).filter((key) => key.startsWith("tenants/test-user/tasks/"));
+    const directiveDocs = Object.keys(mockData).filter((key) => key.startsWith("tenants/test-user/relay/"));
+    const obligationDocs = Object.keys(mockData).filter((key) => key.startsWith("tenants/test-user/dispatch_obligations/"));
+    expect(taskDocs).toHaveLength(1);
+    expect(directiveDocs).toHaveLength(1);
+    expect(obligationDocs).toHaveLength(1);
+  });
+
+  it("should track absent non-spawnable target as pending spawn work, not success", async () => {
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockResolvedValueOnce({
+      targetState: "absent",
+      heartbeatAge: "never",
+      heartbeatAgeMs: Infinity,
+    });
+    wakeModule.wakeTarget.mockResolvedValueOnce({
+      outcome: "not_spawnable",
+      targetState: "absent",
+      heartbeatAge: "never",
+      heartbeatAgeMs: Infinity,
+    });
+
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Absent target dispatch",
+      policy_mode: "normal",
+      waitForUptake: false,
+      autoWake: true,
+      idempotency_key: "absent-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.targetState).toBe("absent");
+    expect(data.wakeAttempted).toBe(true);
+    expect(data.wakeResult).toBe("not_spawnable");
+    expect(data.action_required).toBe("spawn_target");
+    expect(data.pendingHandle).toBeDefined();
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:absent-contract-1"];
+    expect(obligation).toBeDefined();
+    expect(obligation.wakeAttempted).toBe(true);
+    expect(obligation.wakeResult).toBe("not_spawnable");
   });
 
   it("should approve a supervised task", async () => {

--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -57,6 +57,7 @@ jest.mock("../modules/dispatch/governance.js", () => ({
 
 // Track Firestore data in memory
 const mockData: Record<string, any> = {};
+const queryFilterChains: Array<Array<[string, string, any]>> = [];
 
 const createMockDoc = (path: string) => ({
   exists: !!mockData[path],
@@ -105,6 +106,7 @@ const createMockQuery = (path: string, filters: Array<[string, string, any]> = [
     limit: jest.fn(() => query),
     orderBy: jest.fn(() => query),
     get: jest.fn(() => {
+      queryFilterChains.push(filters);
       const docs = Object.entries(mockData)
         .filter(([key]) => key.startsWith(`${path}/`))
         .filter(([, value]) =>
@@ -168,6 +170,7 @@ jest.mock("../firebase/client.js", () => ({
 // Reset mock data before each test
 beforeEach(() => {
   Object.keys(mockData).forEach(key => delete mockData[key]);
+  queryFilterChains.length = 0;
   jest.clearAllMocks();
 });
 
@@ -442,6 +445,13 @@ describe("Policy Modes", () => {
     const relayEntry = await waitForDirectiveEntry();
     expect(relayEntry).toBeDefined();
     const directiveId = relayEntry![0].split("/").pop()!;
+    mockData["tenants/test-user/relay/ack-decoy"] = {
+      reply_to: directiveId,
+      message_type: "STATUS",
+      source: "builder-test",
+      target: "iso",
+      createdAt: admin.firestore.Timestamp.now(),
+    };
     mockData["tenants/test-user/relay/ack-valid"] = {
       reply_to: directiveId,
       message_type: "ACK",
@@ -456,6 +466,7 @@ describe("Policy Modes", () => {
     expect(data.uptakeConfirmed).toBe(true);
     expect(data.uptakeVia).toBe("ack");
     expect(data.ackId).toBe("ack-valid");
+    expect(queryFilterChains).toContainEqual([["reply_to", "==", directiveId]]);
   });
 
   it("should reject spoofed ACKs from foreign programs", async () => {
@@ -656,6 +667,46 @@ describe("Policy Modes", () => {
     expect(obligation.escalationReason).toBe("target_unavailable");
     expect(obligation.wakeAttempted).toBe(true);
     expect(obligation.wakeResult).toBe("timeout");
+  });
+
+  it("should return a pending handle when preflight throws after durable persistence", async () => {
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockRejectedValueOnce(new Error("preflight backend unavailable"));
+
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Preflight throw dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      idempotency_key: "preflight-throw-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.uptakeConfirmed).toBe(false);
+    expect(data.deliveryState).toBe("escalated");
+    expect(data.action_required).toBe("monitor_pending");
+    expect(data.taskId).toBeDefined();
+    expect(data.directiveId).toBeDefined();
+    expect(data.pendingHandle).toMatchObject({
+      obligationId: "dispatch:preflight-throw-contract-1",
+      taskId: data.taskId,
+      directiveId: data.directiveId,
+      deliveryState: "escalated",
+    });
+    expect(data.message).toContain("runtime preflight failed");
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:preflight-throw-contract-1"];
+    expect(obligation.taskId).toBe(data.taskId);
+    expect(obligation.directiveId).toBe(data.directiveId);
+    expect(obligation.deliveryState).toBe("escalated");
+    expect(obligation.escalationReason).toBe("preflight_failed");
+    expect(obligation.runtimeFailure).toMatchObject({
+      reason: "preflight_failed",
+      message: "preflight backend unavailable",
+    });
   });
 
   it("should approve a supervised task", async () => {

--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -23,6 +23,8 @@ import { isProgramQuarantined } from "../modules/pulse.js";
 import type { AuthContext } from "../auth/authValidator.js";
 import * as admin from "firebase-admin";
 
+jest.setTimeout(20_000);
+
 // Mock program registry
 jest.mock("../modules/programRegistry.js", () => ({
   isProgramRegistered: jest.fn(() => Promise.resolve(true)),
@@ -95,6 +97,30 @@ const createMockTransaction = () => {
 };
 
 // Mock Firestore
+const createMockQuery = (path: string, filters: Array<[string, string, any]> = []) => {
+  const query: any = {
+    where: jest.fn((field: string, op: string, value: any) =>
+      createMockQuery(path, [...filters, [field, op, value]])
+    ),
+    limit: jest.fn(() => query),
+    orderBy: jest.fn(() => query),
+    get: jest.fn(() => {
+      const docs = Object.entries(mockData)
+        .filter(([key]) => key.startsWith(`${path}/`))
+        .filter(([, value]) =>
+          filters.every(([field, op, expected]) => op === "==" && value?.[field] === expected)
+        )
+        .map(([key, value]) => ({
+          id: key.split("/").pop(),
+          exists: true,
+          data: () => value,
+        }));
+      return Promise.resolve({ docs, size: docs.length, empty: docs.length === 0 });
+    }),
+  };
+  return query;
+};
+
 const mockFirestore = {
   collection: jest.fn((path: string) => ({
     add: jest.fn((data: any) => {
@@ -103,21 +129,10 @@ const mockFirestore = {
       mockData[fullPath] = data;
       return Promise.resolve({ id, path: fullPath, _path: fullPath });
     }),
-    get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
-    where: jest.fn(() => ({
-      where: jest.fn(() => ({
-        where: jest.fn(() => ({
-          get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
-        })),
-        get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
-      })),
-      get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
-    })),
-    orderBy: jest.fn(() => ({
-      limit: jest.fn(() => ({
-        get: jest.fn(() => Promise.resolve({ docs: [], size: 0, empty: true })),
-      })),
-    })),
+    get: createMockQuery(path).get,
+    where: createMockQuery(path).where,
+    orderBy: createMockQuery(path).orderBy,
+    limit: createMockQuery(path).limit,
   })),
   doc: jest.fn((path: string) => ({
     get: jest.fn(() => Promise.resolve(createMockDoc(path))),
@@ -165,6 +180,17 @@ const mockAuth: AuthContext = {
   encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
   rateLimitTier: "internal",
 };
+
+async function waitForDirectiveEntry() {
+  for (let i = 0; i < 20; i++) {
+    const relayEntry = Object.entries(mockData).find(([key, value]) =>
+      key.startsWith("tenants/test-user/relay/") && value.message_type === "DIRECTIVE"
+    );
+    if (relayEntry) return relayEntry;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  return undefined;
+}
 
 // ─── AUTO-QUARANTINE TESTS ───────────────────────────────────────────────────
 
@@ -386,19 +412,80 @@ describe("Policy Modes", () => {
     expect(data.success).toBe(false);
     expect(data.uptakeConfirmed).toBe(false);
     expect(data.action_required).toBe("monitor_pending");
-    expect(data.deliveryState).toBe("stored");
+    expect(data.deliveryState).toBe("notified");
     expect(data.pendingHandle).toMatchObject({
       obligationId: "dispatch:pending-contract-1",
       taskId: data.taskId,
       directiveId: data.directiveId,
-      deliveryState: "stored",
+      deliveryState: "notified",
     });
 
     const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:pending-contract-1"];
     expect(obligation).toBeDefined();
     expect(obligation.taskId).toBe(data.taskId);
     expect(obligation.directiveId).toBe(data.directiveId);
-    expect(obligation.deliveryState).toBe("stored");
+    expect(obligation.deliveryState).toBe("notified");
+    expect(obligation.pendingReason).toBe("uptake_wait_skipped");
+  });
+
+  it("should confirm uptake from a valid target ACK only", async () => {
+    const pending = dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Valid ACK dispatch",
+      instructions: "ACK from target should satisfy uptake.",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+    });
+
+    const relayEntry = await waitForDirectiveEntry();
+    expect(relayEntry).toBeDefined();
+    const directiveId = relayEntry![0].split("/").pop()!;
+    mockData["tenants/test-user/relay/ack-valid"] = {
+      reply_to: directiveId,
+      message_type: "ACK",
+      source: "builder-test",
+      target: "iso",
+      createdAt: admin.firestore.Timestamp.now(),
+    };
+
+    const data = JSON.parse((await pending).content[0].text);
+
+    expect(data.success).toBe(true);
+    expect(data.uptakeConfirmed).toBe(true);
+    expect(data.uptakeVia).toBe("ack");
+    expect(data.ackId).toBe("ack-valid");
+  });
+
+  it("should reject spoofed ACKs from foreign programs", async () => {
+    const pending = dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Spoofed ACK dispatch",
+      instructions: "Foreign ACK must not satisfy uptake.",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+    });
+
+    const relayEntry = await waitForDirectiveEntry();
+    expect(relayEntry).toBeDefined();
+    const directiveId = relayEntry![0].split("/").pop()!;
+    mockData["tenants/test-user/relay/ack-spoof"] = {
+      reply_to: directiveId,
+      message_type: "ACK",
+      source: "foreign-program",
+      target: "iso",
+      createdAt: admin.firestore.Timestamp.now(),
+    };
+
+    const data = JSON.parse((await pending).content[0].text);
+
+    expect(data.success).toBe(false);
+    expect(data.uptakeConfirmed).toBe(false);
+    expect(data.ackId).toBeUndefined();
+    expect(data.deliveryState).toBe("escalated");
   });
 
   it("should reuse an idempotent dispatch obligation without duplicate work", async () => {
@@ -428,6 +515,66 @@ describe("Policy Modes", () => {
     expect(taskDocs).toHaveLength(1);
     expect(directiveDocs).toHaveLength(1);
     expect(obligationDocs).toHaveLength(1);
+  });
+
+  it("should resume an idempotent dispatch after a late claim", async () => {
+    const args = {
+      source: "iso",
+      target: "builder-test",
+      title: "Late claim dispatch",
+      instructions: "Client timed out before target claimed.",
+      policy_mode: "normal",
+      waitForUptake: false,
+      idempotency_key: "late-claim-contract-1",
+      uptakeTimeoutSeconds: 5,
+    };
+
+    const first = JSON.parse((await dispatchHandler(mockAuth, args)).content[0].text);
+    mockData[`tenants/test-user/tasks/${first.taskId}`] = {
+      ...mockData[`tenants/test-user/tasks/${first.taskId}`],
+      status: "active",
+      claimedBy: "builder-test",
+      claimedAt: admin.firestore.Timestamp.now(),
+    };
+
+    const resumed = JSON.parse((await dispatchHandler(mockAuth, {
+      ...args,
+      waitForUptake: true,
+    })).content[0].text);
+
+    expect(resumed.idempotent).toBe(true);
+    expect(resumed.taskId).toBe(first.taskId);
+    expect(resumed.success).toBe(true);
+    expect(resumed.uptakeConfirmed).toBe(true);
+    expect(resumed.uptakeVia).toBe("claim");
+    expect(resumed.claimedBy).toBe("builder-test");
+    expect(mockData["tenants/test-user/dispatch_obligations/dispatch:late-claim-contract-1"].deliveryState).toBe("claimed");
+  });
+
+  it("should reject paused targets with a durable pending handle", async () => {
+    mockData["tenants/test-user/programs/builder-test"] = {
+      paused: true,
+    };
+
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Paused target dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      idempotency_key: "paused-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.deliveryState).toBe("rejected");
+    expect(data.action_required).toBe("monitor_pending");
+    expect(data.pendingHandle).toMatchObject({
+      obligationId: "dispatch:paused-contract-1",
+      deliveryState: "rejected",
+    });
+    expect(mockData["tenants/test-user/dispatch_obligations/dispatch:paused-contract-1"].rejectionReason).toBe("target_paused");
   });
 
   it("should track absent non-spawnable target as pending spawn work, not success", async () => {
@@ -464,8 +611,51 @@ describe("Policy Modes", () => {
 
     const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:absent-contract-1"];
     expect(obligation).toBeDefined();
+    expect(obligation.targetState).toBe("absent");
     expect(obligation.wakeAttempted).toBe(true);
     expect(obligation.wakeResult).toBe("not_spawnable");
+  });
+
+  it("should escalate wedged wake timeouts with a durable proof path", async () => {
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockResolvedValueOnce({
+      targetState: "stale",
+      heartbeatAge: "30m",
+      heartbeatAgeMs: 30 * 60 * 1000,
+    });
+    wakeModule.wakeTarget.mockResolvedValueOnce({
+      outcome: "timeout",
+      targetState: "stale",
+      heartbeatAge: "30m",
+      heartbeatAgeMs: 30 * 60 * 1000,
+    });
+
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Wedged target dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      autoWake: true,
+      idempotency_key: "wedged-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.targetState).toBe("stale");
+    expect(data.wakeAttempted).toBe(true);
+    expect(data.wakeResult).toBe("timeout");
+    expect(data.deliveryState).toBe("escalated");
+    expect(data.action_required).toBe("spawn_target");
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:wedged-contract-1"];
+    expect(obligation.taskId).toBe(data.taskId);
+    expect(obligation.directiveId).toBe(data.directiveId);
+    expect(obligation.deliveryState).toBe("escalated");
+    expect(obligation.escalationReason).toBe("target_unavailable");
+    expect(obligation.wakeAttempted).toBe(true);
+    expect(obligation.wakeResult).toBe("timeout");
   });
 
   it("should approve a supervised task", async () => {

--- a/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
+++ b/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
@@ -54,10 +54,20 @@ const DispatchSchema = z.object({
   autoWake: z.boolean().default(true),
   threadId: z.string().optional(),
   projectId: z.string().optional(),
+  idempotency_key: z.string().max(100).optional(),
   traceId: z.string().optional(),
   spanId: z.string().optional(),
   parentSpanId: z.string().optional(),
 });
+
+type DispatchDeliveryState =
+  | "stored"
+  | "wake-attempted"
+  | "notified"
+  | "claimed"
+  | "rejected"
+  | "escalated"
+  | "expired";
 
 /** Sleep helper */
 function sleep(ms: number): Promise<void> {
@@ -155,6 +165,9 @@ async function suggestBetterTarget(
 interface SendResult {
   taskId: string;
   directiveId: string | null;
+  obligationId: string;
+  deduplicated?: boolean;
+  deliveryState?: DispatchDeliveryState;
 }
 
 /**
@@ -165,11 +178,23 @@ async function sendTaskAndDirective(
   auth: AuthContext,
   args: z.infer<typeof DispatchSchema>,
   verifiedSource: string,
+  initialTargetState: TargetState,
+  wakeAttempted: boolean,
+  wakeResult: WakeResult,
 ): Promise<SendResult> {
   const db = getFirestore();
   const now = serverTimestamp();
   const traceId = args.traceId || generateSpanId();
   const spanId = args.spanId || generateSpanId();
+  const idempotencyKey = args.idempotency_key ? `dispatch:${args.idempotency_key}` : null;
+  const generatedTaskId = `dispatch_${generateSpanId()}`;
+  const generatedDirectiveId = `directive_${generateSpanId()}`;
+  const generatedObligationId = idempotencyKey || `obligation_${generateSpanId()}`;
+  const obligationRef = idempotencyKey
+    ? db.doc(`tenants/${auth.userId}/dispatch_obligations/${idempotencyKey}`)
+    : db.doc(`tenants/${auth.userId}/dispatch_obligations/${generatedObligationId}`);
+  const taskRef = db.doc(`tenants/${auth.userId}/tasks/${generatedTaskId}`);
+  const relayRef = db.doc(`tenants/${auth.userId}/relay/${generatedDirectiveId}`);
 
   // ── Create task ──
   const preview = args.title.length > 50 ? args.title.substring(0, 47) + "..." : args.title;
@@ -204,6 +229,9 @@ async function sendTaskAndDirective(
     attempt_count: 0,
     // Dispatch metadata
     dispatched_via: "dispatch_tool",
+    dispatchObligationId: generatedObligationId,
+    dispatchDeliveryState: wakeAttempted ? "wake-attempted" : "stored",
+    claimSlaSeconds: args.uptakeTimeoutSeconds,
   };
 
   // Set TTL expiration
@@ -212,13 +240,99 @@ async function sendTaskAndDirective(
     taskData.expiresAt = admin.firestore.Timestamp.fromMillis(Date.now() + effectiveTtl * 1000);
   }
 
-  const taskRef = await db.collection(`tenants/${auth.userId}/tasks`).add(taskData);
+  const directiveMessage = args.instructions
+    ? `[dispatch:${generatedTaskId}] ${args.title}\n\n${args.instructions.substring(0, 1800)}`
+    : `[dispatch:${generatedTaskId}] ${args.title}`;
+
+  const relayData: Record<string, unknown> = {
+    payload: directiveMessage.substring(0, 2000),
+    source: verifiedSource,
+    target: args.target,
+    message_type: "DIRECTIVE",
+    action: "interrupt",
+    priority: args.priority || "high",
+    status: "pending",
+    ttl: 86400,
+    expiresAt: admin.firestore.Timestamp.fromMillis(Date.now() + 86400 * 1000),
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    threadId: args.threadId || null,
+    traceId,
+    spanId: generateSpanId(),
+    parentSpanId: spanId,
+    taskId: generatedTaskId,
+    dispatchObligationId: generatedObligationId,
+  };
+
+  const obligationData: Record<string, unknown> = {
+    schemaVersion: "1.0",
+    source: verifiedSource,
+    target: args.target,
+    taskId: generatedTaskId,
+    directiveId: generatedDirectiveId,
+    title: args.title,
+    priority: args.priority,
+    action: args.action,
+    threadId: args.threadId || null,
+    projectId: args.projectId || null,
+    traceId,
+    spanId,
+    parentSpanId: args.parentSpanId || null,
+    idempotency_key: args.idempotency_key || null,
+    deliveryState: wakeAttempted ? "wake-attempted" : "stored",
+    targetState: initialTargetState,
+    wakeAttempted,
+    wakeResult: wakeAttempted ? wakeResult : null,
+    claimSlaSeconds: args.uptakeTimeoutSeconds,
+    claimDeadlineAt: admin.firestore.Timestamp.fromMillis(Date.now() + args.uptakeTimeoutSeconds * 1000),
+    waitForUptake: args.waitForUptake,
+    retryCount: 0,
+    maxRetries: 1,
+    escalationLevel: 0,
+    createdAt: now,
+    updatedAt: now,
+    telemetry: {
+      timeToClaimMs: null,
+      timeToAckMs: null,
+      escalatedAt: null,
+    },
+  };
+
+  const txResult = await db.runTransaction(async (tx) => {
+    if (idempotencyKey) {
+      const existing = await tx.get(obligationRef);
+      if (existing.exists) {
+        const data = existing.data()!;
+        return {
+          deduplicated: true,
+          taskId: data.taskId as string,
+          directiveId: (data.directiveId as string | null) || null,
+          obligationId: generatedObligationId,
+          deliveryState: data.deliveryState as DispatchDeliveryState,
+        };
+      }
+    }
+
+    tx.set(taskRef, taskData);
+    tx.set(relayRef, relayData);
+    tx.set(obligationRef, obligationData);
+    return {
+      deduplicated: false,
+      taskId: generatedTaskId,
+      directiveId: generatedDirectiveId,
+      obligationId: generatedObligationId,
+      deliveryState: obligationData.deliveryState as DispatchDeliveryState,
+    };
+  });
+
+  if (txResult.deduplicated) {
+    return txResult;
+  }
 
   // Fire-and-forget: telemetry, GitHub sync, dispatcher webhook
   emitEvent(auth.userId, {
     event_type: "TASK_CREATED",
     program_id: verifiedSource,
-    task_id: taskRef.id,
+    task_id: txResult.taskId,
     task_class: taskData.task_class as "WORK" | "CONTROL",
     target: args.target,
     type: "task",
@@ -238,7 +352,7 @@ async function sendTaskAndDirective(
   });
 
   notifyDispatcher({
-    taskId: taskRef.id,
+    taskId: txResult.taskId,
     target: args.target,
     priority: args.priority || "high",
     title: args.title,
@@ -247,7 +361,7 @@ async function sendTaskAndDirective(
 
   syncTaskCreated(
     auth.userId,
-    taskRef.id,
+    txResult.taskId,
     args.title,
     args.instructions || "",
     args.action || "interrupt",
@@ -257,60 +371,40 @@ async function sendTaskAndDirective(
     undefined,
   );
 
-  // ── Send directive ──
-  let directiveId: string | null = null;
-  try {
-    const directiveMessage = args.instructions
-      ? `[dispatch:${taskRef.id}] ${args.title}\n\n${args.instructions.substring(0, 1800)}`
-      : `[dispatch:${taskRef.id}] ${args.title}`;
+  // Log for ACK compliance
+  logDirective(auth.userId, txResult.directiveId!, verifiedSource, args.target, directiveMessage.substring(0, 2000), args.threadId).catch(() => {});
 
-    const relayData: Record<string, unknown> = {
-      payload: directiveMessage.substring(0, 2000),
-      source: verifiedSource,
-      target: args.target,
-      message_type: "DIRECTIVE",
-      action: "interrupt",
-      priority: args.priority || "high",
-      status: "pending",
-      ttl: 86400,
-      expiresAt: admin.firestore.Timestamp.fromMillis(Date.now() + 86400 * 1000),
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      threadId: args.threadId || null,
-      traceId,
-      spanId: generateSpanId(),
-      parentSpanId: spanId,
-      // Link back to the task
-      taskId: taskRef.id,
-    };
+  await updateDispatchObligation(auth.userId, txResult.obligationId, {
+    deliveryState: "notified",
+    notifiedAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
 
-    const relayRef = await db.collection(`tenants/${auth.userId}/relay`).add(relayData);
-    directiveId = relayRef.id;
+  await db.doc(`tenants/${auth.userId}/tasks/${txResult.taskId}`).update({
+    dispatchDeliveryState: "notified",
+  });
 
-    // Log for ACK compliance
-    logDirective(auth.userId, relayRef.id, verifiedSource, args.target, directiveMessage.substring(0, 2000), args.threadId).catch(() => {});
+  emitEvent(auth.userId, {
+    event_type: "RELAY_SENT",
+    program_id: verifiedSource,
+    message_id: txResult.directiveId!,
+    message_type: "DIRECTIVE",
+    target: args.target,
+    dispatched_via: "dispatch_tool",
+  });
 
-    emitEvent(auth.userId, {
-      event_type: "RELAY_SENT",
-      program_id: verifiedSource,
-      message_id: relayRef.id,
-      message_type: "DIRECTIVE",
-      target: args.target,
-      dispatched_via: "dispatch_tool",
-    });
-  } catch (err) {
-    // Directive send failed — task still exists for target to discover
-    console.error(`[Dispatch] Directive send failed for task ${taskRef.id}:`, err);
-  }
-
-  return { taskId: taskRef.id, directiveId };
+  return { ...txResult, deliveryState: "notified" };
 }
 
 // ─── UPTAKE WAIT ─────────────────────────────────────────────────────────────
 
 interface UptakeResult {
   confirmed: boolean;
+  via?: "claim" | "ack";
   claimedBy?: string;
   claimedAt?: string;
+  ackId?: string;
+  ackAt?: string;
 }
 
 /**
@@ -320,6 +414,7 @@ interface UptakeResult {
 async function waitForUptake(
   userId: string,
   taskId: string,
+  directiveId: string | null,
   timeoutSeconds: number,
 ): Promise<UptakeResult> {
   const db = getFirestore();
@@ -339,13 +434,122 @@ async function waitForUptake(
     if (data.status === "active" || data.status === "completing" || data.status === "done") {
       return {
         confirmed: true,
+        via: "claim",
         claimedBy: data.claimedBy || data.sessionId || undefined,
         claimedAt: data.startedAt?.toDate?.()?.toISOString() || new Date().toISOString(),
       };
     }
+
+    if (directiveId) {
+      const ack = await db.collection(`tenants/${userId}/relay`)
+        .where("reply_to", "==", directiveId)
+        .where("message_type", "==", "ACK")
+        .limit(1)
+        .get();
+      if (!ack.empty) {
+        const ackDoc = ack.docs[0];
+        const ackData = ackDoc.data();
+        return {
+          confirmed: true,
+          via: "ack",
+          ackId: ackDoc.id,
+          ackAt: ackData.createdAt?.toDate?.()?.toISOString() || new Date().toISOString(),
+        };
+      }
+    }
   }
 
   return { confirmed: false };
+}
+
+async function updateDispatchObligation(
+  userId: string,
+  obligationId: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const db = getFirestore();
+  await db.doc(`tenants/${userId}/dispatch_obligations/${obligationId}`).set({
+    ...patch,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+}
+
+async function markUptakeClaimed(
+  userId: string,
+  taskId: string,
+  obligationId: string,
+  uptake: UptakeResult,
+): Promise<void> {
+  const db = getFirestore();
+  const taskRef = db.doc(`tenants/${userId}/tasks/${taskId}`);
+  const obligationRef = db.doc(`tenants/${userId}/dispatch_obligations/${obligationId}`);
+  await db.runTransaction(async (tx) => {
+    const taskDoc = await tx.get(taskRef);
+    const obligationDoc = await tx.get(obligationRef);
+    const taskData = taskDoc.exists ? taskDoc.data()! : {};
+    const obligationData = obligationDoc.exists ? obligationDoc.data()! : {};
+    const createdAtMs = obligationData.createdAt?.toMillis?.() || taskData.createdAt?.toMillis?.() || Date.now();
+    const claimedAtMs = taskData.claimedAt?.toMillis?.() || taskData.startedAt?.toMillis?.() || Date.now();
+    const ackAtMs = uptake.ackAt ? new Date(uptake.ackAt).getTime() : Date.now();
+
+    tx.set(obligationRef, {
+      deliveryState: "claimed",
+      claimedBy: uptake.claimedBy || taskData.claimedBy || null,
+      claimedAt: taskData.claimedAt || taskData.startedAt || admin.firestore.FieldValue.serverTimestamp(),
+      ackId: uptake.ackId || null,
+      ackAt: uptake.ackId ? admin.firestore.FieldValue.serverTimestamp() : null,
+      uptakeVia: uptake.via || "claim",
+      telemetry: {
+        ...(obligationData.telemetry || {}),
+        timeToClaimMs: uptake.via === "claim" ? Math.max(0, claimedAtMs - createdAtMs) : null,
+        timeToAckMs: uptake.via === "ack" ? Math.max(0, ackAtMs - createdAtMs) : null,
+      },
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true });
+
+    if (taskDoc.exists) {
+      tx.update(taskRef, {
+        dispatchDeliveryState: "claimed",
+        dispatchUptakeVia: uptake.via || "claim",
+      });
+    }
+  });
+}
+
+async function markUptakeEscalated(
+  userId: string,
+  taskId: string,
+  obligationId: string,
+  reason: string,
+): Promise<void> {
+  const db = getFirestore();
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  await db.runTransaction(async (tx) => {
+    const taskRef = db.doc(`tenants/${userId}/tasks/${taskId}`);
+    const obligationRef = db.doc(`tenants/${userId}/dispatch_obligations/${obligationId}`);
+    const taskDoc = await tx.get(taskRef);
+    const obligationDoc = await tx.get(obligationRef);
+    const obligationData = obligationDoc.exists ? obligationDoc.data()! : {};
+
+    tx.set(obligationRef, {
+      deliveryState: "escalated",
+      escalationReason: reason,
+      escalationLevel: ((obligationData.escalationLevel as number) || 0) + 1,
+      escalatedAt: now,
+      telemetry: {
+        ...(obligationData.telemetry || {}),
+        escalatedAt: now,
+      },
+      updatedAt: now,
+    }, { merge: true });
+
+    if (taskDoc.exists) {
+      tx.update(taskRef, {
+        dispatchDeliveryState: "escalated",
+        dispatchEscalationReason: reason,
+      });
+    }
+  });
 }
 
 // ─── MAIN HANDLER ────────────────────────────────────────────────────────────
@@ -540,18 +744,63 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   }
 
   // ── 3. SEND (always — even if target is stale, task queues for later) ──
-  const { taskId, directiveId } = await sendTaskAndDirective(auth, args, verifiedSource);
+  const { taskId, directiveId, obligationId, deduplicated, deliveryState: initialDeliveryState } = await sendTaskAndDirective(
+    auth,
+    args,
+    verifiedSource,
+    currentTargetState,
+    wakeAttempted,
+    wakeResultStr,
+  );
 
   // ── 4. UPTAKE WAIT ──
   let uptakeConfirmed = false;
+  let uptakeVia: "claim" | "ack" | undefined;
   let claimedBy: string | undefined;
   let claimedAt: string | undefined;
+  let ackId: string | undefined;
+  let ackAt: string | undefined;
+  let deliveryState: DispatchDeliveryState = initialDeliveryState || (deduplicated ? "stored" : "notified");
 
   if (args.waitForUptake) {
-    const uptake = await waitForUptake(auth.userId, taskId, args.uptakeTimeoutSeconds);
+    const uptake = await waitForUptake(auth.userId, taskId, directiveId, args.uptakeTimeoutSeconds);
     uptakeConfirmed = uptake.confirmed;
+    uptakeVia = uptake.via;
     claimedBy = uptake.claimedBy;
     claimedAt = uptake.claimedAt;
+    ackId = uptake.ackId;
+    ackAt = uptake.ackAt;
+    if (uptakeConfirmed) {
+      deliveryState = "claimed";
+      await markUptakeClaimed(auth.userId, taskId, obligationId, uptake);
+    }
+  } else {
+    if (!deduplicated) {
+      await updateDispatchObligation(auth.userId, obligationId, {
+        deliveryState: "stored",
+        pendingReason: "uptake_wait_skipped",
+      });
+      deliveryState = "stored";
+    }
+  }
+
+  if (!uptakeConfirmed && args.waitForUptake) {
+    const escalationReason = targetPaused
+      ? "target_paused"
+      : targetQuarantined
+        ? "target_quarantined"
+        : currentTargetState === "alive"
+          ? "claim_sla_missed"
+          : "target_unavailable";
+    deliveryState = targetPaused || targetQuarantined ? "rejected" : "escalated";
+    if (deliveryState === "rejected") {
+      await updateDispatchObligation(auth.userId, obligationId, {
+        deliveryState,
+        rejectionReason: escalationReason,
+      });
+    } else {
+      await markUptakeEscalated(auth.userId, taskId, obligationId, escalationReason);
+    }
   }
 
   // ── Build response ──
@@ -561,16 +810,31 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   // Override success if target is paused or quarantined
   const successResult = targetPaused || targetQuarantined
     ? false
-    : uptakeConfirmed || (currentTargetState === "alive" && !args.waitForUptake);
+    : uptakeConfirmed;
 
   const response: DispatchResponse = {
     success: successResult,
     taskId,
     directiveId,
+    obligationId,
+    pendingHandle: !uptakeConfirmed
+      ? {
+          obligationId,
+          taskId,
+          directiveId,
+          deliveryState,
+          claimSlaSeconds: args.uptakeTimeoutSeconds,
+        }
+      : undefined,
+    deliveryState,
+    idempotent: deduplicated || undefined,
     targetState: currentTargetState,
     uptakeConfirmed: targetPaused || targetQuarantined ? false : uptakeConfirmed,
+    uptakeVia,
     claimedBy,
     claimedAt,
+    ackId,
+    ackAt,
     heartbeatAge: flight.heartbeatAge,
     wakeAttempted: wakeAttempted || undefined,
     wakeResult: wakeAttempted ? wakeResultStr : undefined,
@@ -580,7 +844,7 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
         ? "spawn_target"
         : uptakeConfirmed && !targetPaused
           ? "none"
-          : "retry",
+          : "monitor_pending",
     spawnSpec: needsSpawn && spawnConfig
       ? {
           programId: args.target,
@@ -594,10 +858,10 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
       : targetPaused
         ? `Task created but target "${args.target}" is PAUSED. Task will remain queued until target is resumed.`
         : uptakeConfirmed
-          ? `Dispatched to ${args.target} — task claimed${claimedBy ? ` by ${claimedBy}` : ""}.`
+          ? `Dispatched to ${args.target} — uptake confirmed by ${uptakeVia || "claim"}${claimedBy ? ` from ${claimedBy}` : ""}.`
           : currentTargetState === "alive" && !args.waitForUptake
-            ? `Dispatched to ${args.target} (alive, uptake check skipped).`
-            : `Dispatched to ${args.target} but uptake NOT confirmed. Target is ${currentTargetState} (heartbeat: ${flight.heartbeatAge}).${needsSpawn ? " Spawn required." : ""}`,
+            ? `Dispatch obligation stored for ${args.target}; uptake wait skipped by caller. Track pendingHandle.obligationId until claim or ACK.`
+            : `Dispatch obligation stored for ${args.target} but uptake NOT confirmed within ${args.uptakeTimeoutSeconds}s. deliveryState=${deliveryState}; track pendingHandle.obligationId.${needsSpawn ? " Spawn required." : ""}`,
     governance_warnings: governance.warnings.length > 0 ? governance.warnings : undefined,
     policy_violations:
       matchedPolicies.length > 0
@@ -625,6 +889,9 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     wake_attempted: wakeAttempted,
     wake_result: wakeResultStr,
     success: response.success,
+    delivery_state: deliveryState,
+    obligation_id: obligationId,
+    uptake_via: uptakeVia,
     governance_warnings_count: governance.warnings.length,
   });
 

--- a/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
+++ b/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
@@ -407,6 +407,10 @@ interface UptakeResult {
   ackAt?: string;
 }
 
+function runtimeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Poll task status until it transitions from 'created' to 'active' (claimed).
  * Returns confirmation of uptake or timeout.
@@ -445,13 +449,14 @@ async function waitForUptake(
     if (directiveId) {
       const ack = await db.collection(`tenants/${userId}/relay`)
         .where("reply_to", "==", directiveId)
-        .where("message_type", "==", "ACK")
-        .where("source", "==", expectedAckSource)
-        .where("target", "==", expectedAckTarget)
-        .limit(1)
         .get();
-      if (!ack.empty) {
-        const ackDoc = ack.docs[0];
+      const ackDoc = ack.docs.find((doc) => {
+        const ackData = doc.data();
+        return ackData.message_type === "ACK"
+          && ackData.source === expectedAckSource
+          && ackData.target === expectedAckTarget;
+      });
+      if (ackDoc) {
         const ackData = ackDoc.data();
         return {
           confirmed: true,
@@ -553,6 +558,22 @@ async function markUptakeEscalated(
         dispatchEscalationReason: reason,
       });
     }
+  });
+}
+
+async function markRuntimeFailure(
+  userId: string,
+  taskId: string,
+  obligationId: string,
+  reason: string,
+  error: unknown,
+): Promise<void> {
+  await markUptakeEscalated(userId, taskId, obligationId, reason);
+  await updateDispatchObligation(userId, obligationId, {
+    runtimeFailure: {
+      reason,
+      message: runtimeErrorMessage(error),
+    },
   });
 }
 
@@ -672,7 +693,43 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   );
 
   // ── 2. PRE-FLIGHT ──
-  const flight = await queryTargetState(auth.userId, args.target);
+  let flight: Awaited<ReturnType<typeof queryTargetState>>;
+  try {
+    flight = await queryTargetState(auth.userId, args.target);
+  } catch (error) {
+    await markRuntimeFailure(auth.userId, taskId, obligationId, "preflight_failed", error);
+    return jsonResult({
+      success: false,
+      taskId,
+      directiveId,
+      obligationId,
+      pendingHandle: {
+        obligationId,
+        taskId,
+        directiveId,
+        deliveryState: "escalated",
+        claimSlaSeconds: args.uptakeTimeoutSeconds,
+      },
+      deliveryState: "escalated",
+      idempotent: deduplicated || undefined,
+      targetState: "absent",
+      uptakeConfirmed: false,
+      heartbeatAge: "unknown",
+      action_required: "monitor_pending",
+      message: `Dispatch obligation stored for ${args.target}, but runtime preflight failed after persistence: ${runtimeErrorMessage(error)}. Track pendingHandle.obligationId for recovery.`,
+      governance_warnings: governance.warnings.length > 0 ? governance.warnings : undefined,
+      policy_violations:
+        matchedPolicies.length > 0
+          ? matchedPolicies.map((p) => ({
+              policyId: p.policyId,
+              policyName: p.policyName,
+              enforcement: p.enforcement,
+              severity: p.severity,
+              message: p.message,
+            }))
+          : undefined,
+    } satisfies DispatchResponse);
+  }
   await updateDispatchObligation(auth.userId, obligationId, {
     targetState: flight.targetState,
     preflightAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -694,12 +751,56 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
 
   if (flight.targetState !== "alive" && args.autoWake) {
     wakeAttempted = true;
-    const wake = await wakeTarget({
-      userId: auth.userId,
-      target: args.target,
-      waitForAlive: true,
-      callerSource: verifiedSource,
-    });
+    let wake: Awaited<ReturnType<typeof wakeTarget>>;
+    try {
+      wake = await wakeTarget({
+        userId: auth.userId,
+        target: args.target,
+        waitForAlive: true,
+        callerSource: verifiedSource,
+      });
+    } catch (error) {
+      await markRuntimeFailure(auth.userId, taskId, obligationId, "wake_failed", error);
+      await updateDispatchObligation(auth.userId, obligationId, {
+        targetState: currentTargetState,
+        wakeAttempted: true,
+        wakeResult: "timeout",
+        wakeAttemptedAt: admin.firestore.FieldValue.serverTimestamp(),
+      });
+      return jsonResult({
+        success: false,
+        taskId,
+        directiveId,
+        obligationId,
+        pendingHandle: {
+          obligationId,
+          taskId,
+          directiveId,
+          deliveryState: "escalated",
+          claimSlaSeconds: args.uptakeTimeoutSeconds,
+        },
+        deliveryState: "escalated",
+        idempotent: deduplicated || undefined,
+        targetState: currentTargetState,
+        uptakeConfirmed: false,
+        heartbeatAge: flight.heartbeatAge,
+        wakeAttempted: true,
+        wakeResult: "timeout",
+        action_required: "monitor_pending",
+        message: `Dispatch obligation stored for ${args.target}, but wake failed after persistence: ${runtimeErrorMessage(error)}. Track pendingHandle.obligationId for recovery.`,
+        governance_warnings: governance.warnings.length > 0 ? governance.warnings : undefined,
+        policy_violations:
+          matchedPolicies.length > 0
+            ? matchedPolicies.map((p) => ({
+                policyId: p.policyId,
+                policyName: p.policyName,
+                enforcement: p.enforcement,
+                severity: p.severity,
+                message: p.message,
+              }))
+            : undefined,
+      } satisfies DispatchResponse);
+    }
 
     // Map wake module outcomes to dispatch WakeResult type
     switch (wake.outcome) {

--- a/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
+++ b/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
@@ -415,6 +415,8 @@ async function waitForUptake(
   userId: string,
   taskId: string,
   directiveId: string | null,
+  expectedAckSource: string,
+  expectedAckTarget: string,
   timeoutSeconds: number,
 ): Promise<UptakeResult> {
   const db = getFirestore();
@@ -444,6 +446,8 @@ async function waitForUptake(
       const ack = await db.collection(`tenants/${userId}/relay`)
         .where("reply_to", "==", directiveId)
         .where("message_type", "==", "ACK")
+        .where("source", "==", expectedAckSource)
+        .where("target", "==", expectedAckTarget)
         .limit(1)
         .get();
       if (!ack.empty) {
@@ -655,8 +659,24 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     });
   }
 
-  // ── 1. PRE-FLIGHT ──
+  // ── 1. DURABLE OBLIGATION ──
+  // Persist the recoverable obligation before runtime assessment or wake.
+  // If preflight/wake fails, callers still get an idempotent handle to resume.
+  const { taskId, directiveId, obligationId, deduplicated, deliveryState: initialDeliveryState } = await sendTaskAndDirective(
+    auth,
+    args,
+    verifiedSource,
+    "absent",
+    false,
+    "skipped",
+  );
+
+  // ── 2. PRE-FLIGHT ──
   const flight = await queryTargetState(auth.userId, args.target);
+  await updateDispatchObligation(auth.userId, obligationId, {
+    targetState: flight.targetState,
+    preflightAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
 
   // Emit pre-flight telemetry
   emitEvent(auth.userId, {
@@ -667,7 +687,7 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     heartbeat_age_ms: flight.heartbeatAgeMs === Infinity ? -1 : flight.heartbeatAgeMs,
   });
 
-  // ── 2. AUTO-WAKE (if target is not alive and autoWake enabled) ──
+  // ── 3. AUTO-WAKE (if target is not alive and autoWake enabled) ──
   let wakeAttempted = false;
   let wakeResultStr: WakeResult = "skipped";
   let currentTargetState = flight.targetState;
@@ -716,9 +736,16 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
       wake_outcome: wake.outcome,
       debounce_remaining: wake.debounceRemainingSeconds,
     });
+
+    await updateDispatchObligation(auth.userId, obligationId, {
+      targetState: currentTargetState,
+      wakeAttempted,
+      wakeResult: wakeResultStr,
+      wakeAttemptedAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
   }
 
-  // ── 2.5. WAVE 16: TARGET SUGGESTION (advisory only, before send) ──
+  // ── 3.5. WAVE 16: TARGET SUGGESTION (advisory only) ──
   let suggestedTarget: string | undefined;
   let suggestionReason: string | undefined;
 
@@ -743,16 +770,6 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     // Non-blocking — continue with original target
   }
 
-  // ── 3. SEND (always — even if target is stale, task queues for later) ──
-  const { taskId, directiveId, obligationId, deduplicated, deliveryState: initialDeliveryState } = await sendTaskAndDirective(
-    auth,
-    args,
-    verifiedSource,
-    currentTargetState,
-    wakeAttempted,
-    wakeResultStr,
-  );
-
   // ── 4. UPTAKE WAIT ──
   let uptakeConfirmed = false;
   let uptakeVia: "claim" | "ack" | undefined;
@@ -763,7 +780,14 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   let deliveryState: DispatchDeliveryState = initialDeliveryState || (deduplicated ? "stored" : "notified");
 
   if (args.waitForUptake) {
-    const uptake = await waitForUptake(auth.userId, taskId, directiveId, args.uptakeTimeoutSeconds);
+    const uptake = await waitForUptake(
+      auth.userId,
+      taskId,
+      directiveId,
+      args.target,
+      verifiedSource,
+      args.uptakeTimeoutSeconds,
+    );
     uptakeConfirmed = uptake.confirmed;
     uptakeVia = uptake.via;
     claimedBy = uptake.claimedBy;
@@ -777,10 +801,8 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   } else {
     if (!deduplicated) {
       await updateDispatchObligation(auth.userId, obligationId, {
-        deliveryState: "stored",
         pendingReason: "uptake_wait_skipped",
       });
-      deliveryState = "stored";
     }
   }
 

--- a/services/mcp-server/src/tools/dispatch.ts
+++ b/services/mcp-server/src/tools/dispatch.ts
@@ -193,7 +193,7 @@ export const definitions = [
   },
   {
     name: "dispatch_dispatch",
-    description: "Dispatch work to a target program with enforced pre-flight checks, auto-wake, and uptake verification. Replaces the manual multi-step dispatch flow (create_task + send_directive + verify uptake) with a single atomic operation. Returns success only when the target has actually claimed the task.",
+    description: "Dispatch work to a target program with enforced pre-flight checks, durable obligation persistence, auto-wake, and uptake verification. Canonical dispatch API: returns success only when the target claims the task or ACKs the directive; otherwise returns a tracked pending handle.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -204,9 +204,10 @@ export const definitions = [
         priority: { type: "string", enum: ["low", "normal", "high"], default: "high", description: "Task priority (default: high)" },
         action: { type: "string", enum: ["interrupt", "sprint", "parallel", "queue", "backlog"], default: "interrupt", description: "Task action classification (default: interrupt)" },
         policy_mode: { type: "string", enum: ["normal", "supervised", "strict"], default: "normal", description: "Execution policy mode. normal: standard execution; supervised: requires approval before done; strict: governance warnings block dispatch (default: normal)" },
-        waitForUptake: { type: "boolean", default: true, description: "Wait for target to claim the task before returning (default: true). Set false to fire-and-forget." },
+        waitForUptake: { type: "boolean", default: true, description: "Wait for target to claim or ACK before returning (default: true). Set false only to store a pending obligation handle; response success remains false until confirmed uptake." },
         uptakeTimeoutSeconds: { type: "number", minimum: 5, maximum: 120, default: 45, description: "Seconds to wait for uptake confirmation (default: 45)" },
         autoWake: { type: "boolean", default: true, description: "Trigger wake daemon if target is stale/absent (default: true)" },
+        idempotency_key: { type: "string", maxLength: 100, description: "Optional idempotency key. Reuse returns the existing dispatch obligation instead of creating duplicate task/directive work." },
         threadId: { type: "string", description: "Optional conversation thread grouping" },
         projectId: { type: "string", description: "Optional project ID" },
         traceId: { type: "string", description: "Trace correlation ID" },

--- a/services/mcp-server/src/types/dispatch.ts
+++ b/services/mcp-server/src/types/dispatch.ts
@@ -13,6 +13,16 @@ export type TargetState = "alive" | "stale" | "absent";
 /** Wake attempt outcome */
 export type WakeResult = "success" | "timeout" | "not_spawnable" | "host_unreachable" | "skipped";
 
+/** Durable dispatch obligation state */
+export type DispatchDeliveryState =
+  | "stored"
+  | "wake-attempted"
+  | "notified"
+  | "claimed"
+  | "rejected"
+  | "escalated"
+  | "expired";
+
 /** Dispatch request — everything needed to dispatch work to a program */
 export interface DispatchRequest {
   /** Sending program ID */
@@ -41,6 +51,8 @@ export interface DispatchRequest {
   traceId?: string;
   spanId?: string;
   parentSpanId?: string;
+  /** Optional idempotency key preventing duplicate dispatch obligations/work */
+  idempotency_key?: string;
 }
 
 /** Spawn specification returned on failure for client-side recovery */
@@ -58,14 +70,34 @@ export interface DispatchResponse {
   taskId: string;
   /** Sent directive message ID (null if directive send failed) */
   directiveId: string | null;
+  /** Durable obligation ID for uptake tracking */
+  obligationId: string;
+  /** Current durable delivery state */
+  deliveryState: DispatchDeliveryState;
+  /** True when this response reused an existing idempotent obligation */
+  idempotent?: boolean;
+  /** Handle returned whenever dispatch has not yet reached claim/ACK uptake */
+  pendingHandle?: {
+    obligationId: string;
+    taskId: string;
+    directiveId: string | null;
+    deliveryState: DispatchDeliveryState;
+    claimSlaSeconds: number;
+  };
   /** Target liveness at dispatch time */
   targetState: TargetState;
   /** Whether the target claimed the task within the timeout */
   uptakeConfirmed: boolean;
+  /** How uptake was confirmed */
+  uptakeVia?: "claim" | "ack";
   /** Who claimed the task (program ID) */
   claimedBy?: string;
   /** When the task was claimed */
   claimedAt?: string;
+  /** ACK relay ID when uptake was confirmed by DIRECTIVE ACK */
+  ackId?: string;
+  /** ACK timestamp when uptake was confirmed by DIRECTIVE ACK */
+  ackAt?: string;
   /** Target's heartbeat age as human-readable string */
   heartbeatAge: string;
   /** Whether auto-wake was attempted */
@@ -73,7 +105,7 @@ export interface DispatchResponse {
   /** Wake daemon result */
   wakeResult?: WakeResult;
   /** Action required by caller (present on failure) */
-  action_required?: "spawn_target" | "retry" | "none" | "unquarantine";
+  action_required?: "spawn_target" | "retry" | "monitor_pending" | "none" | "unquarantine";
   /** Spawn spec for client-side recovery (present when action_required = spawn_target) */
   spawnSpec?: SpawnSpec;
   /** Human-readable message */


### PR DESCRIPTION
## Summary
- Make `dispatch_dispatch` persist a durable dispatch obligation linked to task + DIRECTIVE relay records.
- Return `success: true` only after task claim or DIRECTIVE ACK; otherwise return `pendingHandle`, `deliveryState`, and `action_required`.
- Add idempotency for dispatch obligations to prevent duplicate task/directive creation on retries.
- Track delivery states and telemetry fields for stored, wake-attempted, notified, claimed, rejected, escalated, and expired obligations.
- Document the server-side uptake contract and operator guidance.

## Verification
- `npm test -- --runInBand src/__tests__/control-plane-v2.test.ts`
- `npm run build`

## Review Gate
Stopping here for supervised ISO review before deploy/proof. No production deploy performed.

## Notes
- Existing `relay_send_message` remains asynchronous; this change scopes durable uptake semantics to `dispatch_dispatch`.
- Pre-existing untracked `services/mcp-server/scripts/verify-ws2-seat.mjs` was left untouched.