### PR TITLE
Fix dispatch caller-boundary timeout

### DIFF
--- a/services/mcp-server/docs/dispatch-uptake-contract.md
+++ b/services/mcp-server/docs/dispatch-uptake-contract.md
@@ -13,6 +13,8 @@ Actionable dispatch must never report `success: true` until one of these is obse
 
 If uptake is not observed, the API returns `success: false` with `pendingHandle`. Supervisors should track `pendingHandle.obligationId` instead of redispatching blindly.
 
+The server also maintains an internal caller-boundary deadline below the observed MCP proxy timeout. If wake/preflight work consumes that budget before claim SLA elapses, `dispatch_dispatch` returns `success: false` with the durable `pendingHandle` and `pendingReason: "caller_boundary_deadline"` rather than waiting for the outer transport to time out.
+
 ## Durable Records
 
 Each dispatch writes `tenants/{tenant}/dispatch_obligations/{obligationId}` with:
@@ -43,9 +45,9 @@ Callers may pass `idempotency_key`. Reusing the key returns the existing obligat
 
 ## Operating Guidance
 
-For absent or stale targets, keep `autoWake: true`. The server may wake or launch the target through the wake host, but senders must not inject into another program's attended terminal.
+For absent or stale targets, keep `autoWake: true`. The server may wake or launch the target through the wake host, but senders must not inject into another program's attended terminal. Dispatch wake triggers launch without waiting for heartbeat confirmation; uptake is proven by task claim or DIRECTIVE ACK.
 
-For busy targets, work remains queued as a task. A timeout from `dispatch_dispatch` is not a lost dispatch; it is an escalated pending obligation.
+For busy targets, work remains queued as a task. A claim-SLA timeout from `dispatch_dispatch` is not a lost dispatch; it is an escalated pending obligation. A caller-boundary timeout is not a claim-SLA miss and remains a monitored pending obligation.
 
 For `waitForUptake: false`, the response is intentionally not successful. It returns a tracked pending handle and `action_required: "monitor_pending"`.
 

--- a/services/mcp-server/docs/dispatch-uptake-contract.md
+++ b/services/mcp-server/docs/dispatch-uptake-contract.md
@@ -13,7 +13,7 @@ Actionable dispatch must never report `success: true` until one of these is obse
 
 If uptake is not observed, the API returns `success: false` with `pendingHandle`. Supervisors should track `pendingHandle.obligationId` instead of redispatching blindly.
 
-The server also maintains an internal caller-boundary deadline below the observed MCP proxy timeout. If wake/preflight work consumes that budget before claim SLA elapses, `dispatch_dispatch` returns `success: false` with the durable `pendingHandle` and `pendingReason: "caller_boundary_deadline"` rather than waiting for the outer transport to time out.
+The server also maintains an internal caller-boundary deadline below the observed MCP proxy timeout. If wake/preflight work consumes that budget before claim SLA elapses, `dispatch_dispatch` returns `success: false` with the durable `pendingHandle` and `pendingReason: "caller_boundary_deadline"` rather than waiting for the outer transport to time out. The default internal boundary is 45 seconds, leaving response margin under the observed 55-second MCP proxy boundary.
 
 ## Durable Records
 

--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -171,6 +171,7 @@ jest.mock("../firebase/client.js", () => ({
 beforeEach(() => {
   Object.keys(mockData).forEach(key => delete mockData[key]);
   queryFilterChains.length = 0;
+  delete process.env.DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS;
   jest.clearAllMocks();
 });
 
@@ -667,6 +668,98 @@ describe("Policy Modes", () => {
     expect(obligation.escalationReason).toBe("target_unavailable");
     expect(obligation.wakeAttempted).toBe(true);
     expect(obligation.wakeResult).toBe("timeout");
+  });
+
+  it("should confirm a claim that occurs during wake without an extra poll interval", async () => {
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockResolvedValueOnce({
+      targetState: "stale",
+      heartbeatAge: "30m",
+      heartbeatAgeMs: 30 * 60 * 1000,
+    });
+    wakeModule.wakeTarget.mockImplementationOnce(async () => {
+      const taskPath = Object.keys(mockData).find((key) => key.startsWith("tenants/test-user/tasks/"))!;
+      mockData[taskPath] = {
+        ...mockData[taskPath],
+        status: "active",
+        claimedBy: "builder-test",
+        claimedAt: admin.firestore.Timestamp.now(),
+      };
+      return {
+        outcome: "success",
+        targetState: "alive",
+        heartbeatAge: "1s",
+        heartbeatAgeMs: 1000,
+      };
+    });
+
+    const startedAt = Date.now();
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Claim during wake dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      autoWake: true,
+      idempotency_key: "claim-during-wake-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+    expect(data.success).toBe(true);
+    expect(data.uptakeConfirmed).toBe(true);
+    expect(data.uptakeVia).toBe("claim");
+    expect(data.claimedBy).toBe("builder-test");
+    expect(wakeModule.wakeTarget).toHaveBeenCalledWith(expect.objectContaining({
+      waitForAlive: false,
+    }));
+  });
+
+  it("should return a pending handle before the caller boundary timeout", async () => {
+    process.env.DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS = "50";
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockResolvedValueOnce({
+      targetState: "stale",
+      heartbeatAge: "30m",
+      heartbeatAgeMs: 30 * 60 * 1000,
+    });
+    wakeModule.wakeTarget.mockImplementationOnce(() =>
+      new Promise((resolve) => setTimeout(() => resolve({
+        outcome: "success",
+        targetState: "alive",
+        heartbeatAge: "1s",
+        heartbeatAgeMs: 1000,
+      }), 75))
+    );
+
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Caller boundary dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      autoWake: true,
+      idempotency_key: "caller-boundary-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.success).toBe(false);
+    expect(data.uptakeConfirmed).toBe(false);
+    expect(data.deliveryState).toBe("notified");
+    expect(data.action_required).toBe("monitor_pending");
+    expect(data.pendingHandle).toMatchObject({
+      obligationId: "dispatch:caller-boundary-contract-1",
+      taskId: data.taskId,
+      directiveId: data.directiveId,
+      deliveryState: "notified",
+    });
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:caller-boundary-contract-1"];
+    expect(obligation.deliveryState).toBe("notified");
+    expect(obligation.pendingReason).toBe("caller_boundary_deadline");
+    expect(obligation.escalationReason).toBeUndefined();
   });
 
   it("should return a pending handle when preflight throws after durable persistence", async () => {

--- a/services/mcp-server/src/__tests__/control-plane-v2.test.ts
+++ b/services/mcp-server/src/__tests__/control-plane-v2.test.ts
@@ -733,6 +733,7 @@ describe("Policy Modes", () => {
       }), 75))
     );
 
+    const startedAt = Date.now();
     const result = await dispatchHandler(mockAuth, {
       source: "iso",
       target: "builder-test",
@@ -745,6 +746,7 @@ describe("Policy Modes", () => {
     });
 
     const data = JSON.parse(result.content[0].text);
+    expect(Date.now() - startedAt).toBeLessThan(125);
     expect(data.success).toBe(false);
     expect(data.uptakeConfirmed).toBe(false);
     expect(data.deliveryState).toBe("notified");
@@ -760,6 +762,49 @@ describe("Policy Modes", () => {
     expect(obligation.deliveryState).toBe("notified");
     expect(obligation.pendingReason).toBe("caller_boundary_deadline");
     expect(obligation.escalationReason).toBeUndefined();
+  });
+
+  it("should return a pending handle when preflight exhausts the caller boundary", async () => {
+    process.env.DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS = "50";
+    const wakeModule = require("../modules/wake/index.js");
+    wakeModule.queryTargetState.mockImplementationOnce(() =>
+      new Promise((resolve) => setTimeout(() => resolve({
+        targetState: "alive",
+        heartbeatAge: "1s",
+        heartbeatAgeMs: 1000,
+      }), 75))
+    );
+
+    const startedAt = Date.now();
+    const result = await dispatchHandler(mockAuth, {
+      source: "iso",
+      target: "builder-test",
+      title: "Slow preflight dispatch",
+      policy_mode: "normal",
+      waitForUptake: true,
+      uptakeTimeoutSeconds: 5,
+      autoWake: true,
+      idempotency_key: "slow-preflight-contract-1",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(Date.now() - startedAt).toBeLessThan(125);
+    expect(data.success).toBe(false);
+    expect(data.uptakeConfirmed).toBe(false);
+    expect(data.deliveryState).toBe("notified");
+    expect(data.action_required).toBe("monitor_pending");
+    expect(data.pendingHandle).toMatchObject({
+      obligationId: "dispatch:slow-preflight-contract-1",
+      taskId: data.taskId,
+      directiveId: data.directiveId,
+      deliveryState: "notified",
+    });
+
+    const obligation = mockData["tenants/test-user/dispatch_obligations/dispatch:slow-preflight-contract-1"];
+    expect(obligation.deliveryState).toBe("notified");
+    expect(obligation.pendingReason).toBe("caller_boundary_deadline");
+    expect(obligation.escalationReason).toBeUndefined();
+    expect(wakeModule.wakeTarget).not.toHaveBeenCalled();
   });
 
   it("should return a pending handle when preflight throws after durable persistence", async () => {

--- a/services/mcp-server/src/__tests__/transport-config.test.ts
+++ b/services/mcp-server/src/__tests__/transport-config.test.ts
@@ -25,13 +25,13 @@ describe('Transport Configuration', () => {
     it('dispatch caller boundary fits within observed MCP proxy timeout', () => {
       // dispatch_dispatch must return confirmed uptake or a durable pending handle
       // before the outer MCP proxy timeout observed in production.
-      const DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS = 50_000;
+      const DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS = 45_000;
       const OBSERVED_MCP_PROXY_TIMEOUT_MS = 55_000;
       expect(DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS).toBeLessThan(OBSERVED_MCP_PROXY_TIMEOUT_MS);
     });
 
     it('transport response queue exceeds dispatch caller boundary', () => {
-      const DISPATCH_MAX_SECONDS = 50;
+      const DISPATCH_MAX_SECONDS = 45;
       const RESPONSE_QUEUE_TIMEOUT_MS = 120_000;
       expect(RESPONSE_QUEUE_TIMEOUT_MS).toBeGreaterThan(DISPATCH_MAX_SECONDS * 1000);
     });

--- a/services/mcp-server/src/__tests__/transport-config.test.ts
+++ b/services/mcp-server/src/__tests__/transport-config.test.ts
@@ -1,9 +1,8 @@
 /**
  * Transport Configuration Tests
  *
- * Verifies that the Streamable HTTP transport is configured with adequate
- * timeouts for long-running tools (e.g., dispatch with 45s uptake wait,
- * large Firestore metrics queries).
+ * Verifies that timeout assumptions stay explicit for long-running tools
+ * and the observed MCP caller/proxy boundary.
  *
  * Also verifies that MCP handler lookup resolves tool aliases correctly.
  */
@@ -23,10 +22,16 @@ import { TOOL_HANDLERS } from '../tools/index';
 
 describe('Transport Configuration', () => {
   describe('responseQueueTimeout adequacy', () => {
-    it('dispatch uptake timeout (45s) fits within response queue timeout', () => {
-      // dispatch_dispatch waits up to 45s for uptake + 30s for wake = ~75s
-      // The transport responseQueueTimeout must exceed the maximum tool execution time
-      const DISPATCH_MAX_SECONDS = 45 + 30; // uptake + wake
+    it('dispatch caller boundary fits within observed MCP proxy timeout', () => {
+      // dispatch_dispatch must return confirmed uptake or a durable pending handle
+      // before the outer MCP proxy timeout observed in production.
+      const DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS = 50_000;
+      const OBSERVED_MCP_PROXY_TIMEOUT_MS = 55_000;
+      expect(DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS).toBeLessThan(OBSERVED_MCP_PROXY_TIMEOUT_MS);
+    });
+
+    it('transport response queue exceeds dispatch caller boundary', () => {
+      const DISPATCH_MAX_SECONDS = 50;
       const RESPONSE_QUEUE_TIMEOUT_MS = 120_000;
       expect(RESPONSE_QUEUE_TIMEOUT_MS).toBeGreaterThan(DISPATCH_MAX_SECONDS * 1000);
     });

--- a/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
+++ b/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
@@ -42,7 +42,7 @@ const UPTAKE_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_UPTAKE_TIMEOUT_SECONDS = 45;
 
 /** Keep dispatch responses inside the observed 55s MCP proxy boundary. */
-const DEFAULT_CALLER_BOUNDARY_TIMEOUT_MS = 50_000;
+const DEFAULT_CALLER_BOUNDARY_TIMEOUT_MS = 45_000;
 
 const DispatchSchema = z.object({
   source: z.string().max(100),
@@ -517,6 +517,16 @@ async function updateDispatchObligation(
   }, { merge: true });
 }
 
+function annotateDispatchObligation(
+  userId: string,
+  obligationId: string,
+  patch: Record<string, unknown>,
+): void {
+  updateDispatchObligation(userId, obligationId, patch).catch((error) => {
+    console.warn(`[Dispatch] Failed to annotate obligation ${obligationId}:`, error);
+  });
+}
+
 async function markUptakeClaimed(
   userId: string,
   taskId: string,
@@ -609,6 +619,64 @@ async function markRuntimeFailure(
       message: runtimeErrorMessage(error),
     },
   });
+}
+
+function callerBoundaryPendingResponse(params: {
+  auth: AuthContext;
+  args: z.infer<typeof DispatchSchema>;
+  taskId: string;
+  directiveId: string | null;
+  obligationId: string;
+  deliveryState: DispatchDeliveryState;
+  targetState: TargetState;
+  heartbeatAge: string;
+  deduplicated?: boolean;
+  wakeAttempted?: boolean;
+  wakeResult?: WakeResult;
+  governanceWarnings: string[];
+  matchedPolicies: Awaited<ReturnType<typeof evaluatePolicies>>;
+  message: string;
+}): ToolResult {
+  annotateDispatchObligation(params.auth.userId, params.obligationId, {
+    pendingReason: "caller_boundary_deadline",
+    callerBoundaryDeadlineAt: admin.firestore.FieldValue.serverTimestamp(),
+    wakeAttempted: params.wakeAttempted || undefined,
+    wakeResult: params.wakeResult || undefined,
+  });
+
+  return jsonResult({
+    success: false,
+    taskId: params.taskId,
+    directiveId: params.directiveId,
+    obligationId: params.obligationId,
+    pendingHandle: {
+      obligationId: params.obligationId,
+      taskId: params.taskId,
+      directiveId: params.directiveId,
+      deliveryState: params.deliveryState,
+      claimSlaSeconds: params.args.uptakeTimeoutSeconds,
+    },
+    deliveryState: params.deliveryState,
+    idempotent: params.deduplicated || undefined,
+    targetState: params.targetState,
+    uptakeConfirmed: false,
+    heartbeatAge: params.heartbeatAge,
+    wakeAttempted: params.wakeAttempted || undefined,
+    wakeResult: params.wakeResult,
+    action_required: "monitor_pending",
+    message: params.message,
+    governance_warnings: params.governanceWarnings.length > 0 ? params.governanceWarnings : undefined,
+    policy_violations:
+      params.matchedPolicies.length > 0
+        ? params.matchedPolicies.map((p) => ({
+            policyId: p.policyId,
+            policyName: p.policyName,
+            enforcement: p.enforcement,
+            severity: p.severity,
+            message: p.message,
+          }))
+        : undefined,
+  } satisfies DispatchResponse);
 }
 
 // ─── MAIN HANDLER ────────────────────────────────────────────────────────────
@@ -730,7 +798,28 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   // ── 2. PRE-FLIGHT ──
   let flight: Awaited<ReturnType<typeof queryTargetState>>;
   try {
-    flight = await queryTargetState(auth.userId, args.target);
+    const preflightBudgetMs = callerBoundaryDeadlineMs - Date.now();
+    const preflight = await withTimeout(
+      queryTargetState(auth.userId, args.target),
+      preflightBudgetMs,
+    );
+    if (!preflight) {
+      return callerBoundaryPendingResponse({
+        auth,
+        args,
+        taskId,
+        directiveId,
+        obligationId,
+        deliveryState: initialDeliveryState || (deduplicated ? "stored" : "notified"),
+        targetState: "absent",
+        heartbeatAge: "unknown",
+        deduplicated,
+        governanceWarnings: governance.warnings,
+        matchedPolicies,
+        message: `Dispatch obligation stored for ${args.target}, but runtime preflight exceeded the caller boundary. Track pendingHandle.obligationId for recovery.`,
+      });
+    }
+    flight = preflight;
   } catch (error) {
     await markRuntimeFailure(auth.userId, taskId, obligationId, "preflight_failed", error);
     return jsonResult({
@@ -788,12 +877,35 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     wakeAttempted = true;
     let wake: Awaited<ReturnType<typeof wakeTarget>>;
     try {
-      wake = await wakeTarget({
-        userId: auth.userId,
-        target: args.target,
-        waitForAlive: false,
-        callerSource: verifiedSource,
-      });
+      const wakeBudgetMs = callerBoundaryDeadlineMs - Date.now();
+      const wakeResponse = await withTimeout(
+        wakeTarget({
+          userId: auth.userId,
+          target: args.target,
+          waitForAlive: false,
+          callerSource: verifiedSource,
+        }),
+        wakeBudgetMs,
+      );
+      if (!wakeResponse) {
+        return callerBoundaryPendingResponse({
+          auth,
+          args,
+          taskId,
+          directiveId,
+          obligationId,
+          deliveryState: initialDeliveryState || (deduplicated ? "stored" : "notified"),
+          targetState: currentTargetState,
+          heartbeatAge: flight.heartbeatAge,
+          deduplicated,
+          wakeAttempted: true,
+          wakeResult: "timeout",
+          governanceWarnings: governance.warnings,
+          matchedPolicies,
+          message: `Dispatch obligation stored for ${args.target}, but wake exceeded the caller boundary. Track pendingHandle.obligationId for recovery.`,
+        });
+      }
+      wake = wakeResponse;
     } catch (error) {
       await markRuntimeFailure(auth.userId, taskId, obligationId, "wake_failed", error);
       await updateDispatchObligation(auth.userId, obligationId, {
@@ -948,7 +1060,7 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   }
 
   if (!uptakeConfirmed && args.waitForUptake && uptakeTimedOutBy === "caller_boundary") {
-    await updateDispatchObligation(auth.userId, obligationId, {
+    annotateDispatchObligation(auth.userId, obligationId, {
       pendingReason: "caller_boundary_deadline",
       callerBoundaryDeadlineAt: admin.firestore.FieldValue.serverTimestamp(),
     });

--- a/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
+++ b/services/mcp-server/src/modules/dispatch/dispatchHandler.ts
@@ -41,6 +41,9 @@ const UPTAKE_POLL_INTERVAL_MS = 5_000;
 /** Default uptake timeout */
 const DEFAULT_UPTAKE_TIMEOUT_SECONDS = 45;
 
+/** Keep dispatch responses inside the observed 55s MCP proxy boundary. */
+const DEFAULT_CALLER_BOUNDARY_TIMEOUT_MS = 50_000;
+
 const DispatchSchema = z.object({
   source: z.string().max(100),
   target: z.string().max(100),
@@ -400,6 +403,7 @@ async function sendTaskAndDirective(
 
 interface UptakeResult {
   confirmed: boolean;
+  timedOutBy?: "claim_sla" | "caller_boundary";
   via?: "claim" | "ack";
   claimedBy?: string;
   claimedAt?: string;
@@ -407,8 +411,31 @@ interface UptakeResult {
   ackAt?: string;
 }
 
+function getCallerBoundaryTimeoutMs(): number {
+  const configured = Number(process.env.DISPATCH_CALLER_BOUNDARY_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_CALLER_BOUNDARY_TIMEOUT_MS;
+}
+
 function runtimeErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  if (timeoutMs <= 0) return undefined;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 /**
@@ -421,19 +448,18 @@ async function waitForUptake(
   directiveId: string | null,
   expectedAckSource: string,
   expectedAckTarget: string,
-  timeoutSeconds: number,
+  claimDeadlineMs: number,
+  callerBoundaryDeadlineMs: number,
 ): Promise<UptakeResult> {
   const db = getFirestore();
   const taskRef = db.doc(`tenants/${userId}/tasks/${taskId}`);
-  const deadline = Date.now() + timeoutSeconds * 1000;
+  const waitDeadlineMs = Math.min(claimDeadlineMs, callerBoundaryDeadlineMs);
 
-  while (Date.now() < deadline) {
-    await sleep(UPTAKE_POLL_INTERVAL_MS);
-
+  while (true) {
     const doc = await taskRef.get();
     if (!doc.exists) {
       // Task was deleted — unusual, bail out
-      return { confirmed: false };
+      return { confirmed: false, timedOutBy: Date.now() >= callerBoundaryDeadlineMs ? "caller_boundary" : "claim_sla" };
     }
 
     const data = doc.data()!;
@@ -466,9 +492,17 @@ async function waitForUptake(
         };
       }
     }
-  }
 
-  return { confirmed: false };
+    const now = Date.now();
+    if (now >= waitDeadlineMs) {
+      return {
+        confirmed: false,
+        timedOutBy: now >= callerBoundaryDeadlineMs ? "caller_boundary" : "claim_sla",
+      };
+    }
+
+    await sleep(Math.min(UPTAKE_POLL_INTERVAL_MS, waitDeadlineMs - now));
+  }
 }
 
 async function updateDispatchObligation(
@@ -581,6 +615,7 @@ async function markRuntimeFailure(
 
 export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
   const args = DispatchSchema.parse(rawArgs);
+  const callerBoundaryDeadlineMs = Date.now() + getCallerBoundaryTimeoutMs();
 
   // Enforce source identity
   const verifiedSource = verifySource(args.source, auth, "mcp");
@@ -756,7 +791,7 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
       wake = await wakeTarget({
         userId: auth.userId,
         target: args.target,
-        waitForAlive: true,
+        waitForAlive: false,
         callerSource: verifiedSource,
       });
     } catch (error) {
@@ -851,11 +886,12 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   let suggestionReason: string | undefined;
 
   try {
-    const suggestion = await suggestBetterTarget(auth.userId, {
+    const suggestionBudgetMs = Math.min(1_000, callerBoundaryDeadlineMs - Date.now());
+    const suggestion = await withTimeout(suggestBetterTarget(auth.userId, {
       currentTarget: args.target,
       taskType: "task", // Default type
       title: args.title,
-    });
+    }), suggestionBudgetMs);
 
     if (suggestion) {
       suggestedTarget = suggestion.programId;
@@ -879,17 +915,21 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
   let ackId: string | undefined;
   let ackAt: string | undefined;
   let deliveryState: DispatchDeliveryState = initialDeliveryState || (deduplicated ? "stored" : "notified");
+  let uptakeTimedOutBy: "claim_sla" | "caller_boundary" | undefined;
 
   if (args.waitForUptake) {
+    const claimDeadlineMs = Date.now() + args.uptakeTimeoutSeconds * 1000;
     const uptake = await waitForUptake(
       auth.userId,
       taskId,
       directiveId,
       args.target,
       verifiedSource,
-      args.uptakeTimeoutSeconds,
+      claimDeadlineMs,
+      callerBoundaryDeadlineMs,
     );
     uptakeConfirmed = uptake.confirmed;
+    uptakeTimedOutBy = uptake.timedOutBy;
     uptakeVia = uptake.via;
     claimedBy = uptake.claimedBy;
     claimedAt = uptake.claimedAt;
@@ -907,7 +947,14 @@ export async function dispatchHandler(auth: AuthContext, rawArgs: unknown): Prom
     }
   }
 
-  if (!uptakeConfirmed && args.waitForUptake) {
+  if (!uptakeConfirmed && args.waitForUptake && uptakeTimedOutBy === "caller_boundary") {
+    await updateDispatchObligation(auth.userId, obligationId, {
+      pendingReason: "caller_boundary_deadline",
+      callerBoundaryDeadlineAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+  }
+
+  if (!uptakeConfirmed && args.waitForUptake && uptakeTimedOutBy !== "caller_boundary") {
     const escalationReason = targetPaused
       ? "target_paused"
       : targetQuarantined


### PR DESCRIPTION
## Summary
- Bound dispatch uptake waiting to an internal 50s caller-boundary deadline below the observed 55s MCP proxy timeout.
- Stop waiting for wake heartbeat confirmation inside dispatch; wake launches, then claim/ACK remains the uptake proof.
- Check task claim/ACK immediately before sleeping, so claims that happen during wake are returned without an extra 5s polling delay.
- Return a durable pending handle with `pendingReason: caller_boundary_deadline` when the caller boundary is exhausted before claim SLA, without falsely escalating the claim SLA.
- Bound advisory target suggestion to the caller deadline and update the dispatch contract docs.

## Diagnosis
Production proof created the durable obligation/task/directive and the detached target claimed/ACKed successfully, but the MCP caller crossed its 55s proxy timeout. The server path could spend wake confirmation time before starting uptake polling, then always slept one polling interval before checking for an already-claimed task. That made actual caller response time depend on wake/poll sequencing rather than the outer MCP deadline.

## Verification
- `npm test -- --runInBand src/__tests__/control-plane-v2.test.ts` -> PASS, 23 tests
- `npm test -- --runInBand src/__tests__/transport-config.test.ts` -> PASS, 7 tests
- `npm run build` -> PASS

No merge/deploy/proof performed; stopping at supervised review gate.