### PR TITLE
feat(gsp): authorize the gsp-sync CI identity for gsp_seed

### DIFF
--- a/services/mcp-server/src/modules/gsp.ts
+++ b/services/mcp-server/src/modules/gsp.ts
@@ -1087,8 +1087,13 @@ const GspSeedSchema = z.object({
 export async function gspSeedHandler(auth: AuthContext, rawArgs: unknown): Promise<ToolResult> {
   const args = GspSeedSchema.parse(rawArgs);
 
-  // Authorization: admin/orchestrator only
-  const authorizedPrograms = ["vector", "iso", "admin", "dispatcher"];
+  // Authorization: admin/orchestrator only.
+  // `gsp-sync` is the CI identity for the repo's GSP State Sync workflow. It is
+  // deliberately NOT an orchestrator: its key carries only [gsp.read, gsp.write],
+  // so the capability gate still denies it dispatch/state/keys/etc. Listing it
+  // here rather than widening its capabilities to "*" keeps a CI-resident
+  // credential scoped to governance-state writes and nothing else.
+  const authorizedPrograms = ["vector", "iso", "admin", "dispatcher", "gsp-sync"];
   const hasWildcard = auth.capabilities.includes("*");
 
   if (!authorizedPrograms.includes(auth.programId) && !hasWildcard) {


### PR DESCRIPTION
The grid repo's **GSP State Sync** workflow authenticates with a long-lived secret. That secret was orchestrator-grade, set `2026-03-06`, never rotated, and is now expired — the workflow has been red for weeks and governance state stopped syncing (I hand-backfilled 418 entries to repair the drift).

Replacing it needs an identity that can seed and **nothing else**. I minted `gsp-sync` with capabilities `[gsp.read, gsp.write]`. The capability gate correctly denies it everything else — but `gsp_seed` has a *second*, name-based gate:

```ts
const authorizedPrograms = ["vector", "iso", "admin", "dispatcher"];
const hasWildcard = auth.capabilities.includes("*");
```

A scoped key cannot pass that. The only two ways through were:

- grant the CI key `"*"` — full fleet access living in GitHub Actions. No.
- add the name.

Adding the name. This widens the *name* gate without widening *reach*: `gsp-sync` holds two capabilities, so everything outside GSP is still denied by capability.

### Verified against the live API with the minted key

| Call | Result |
|---|---|
| `gsp_seed` | authorized (was `UNAUTHORIZED` before this change) |
| `dispatch_create_task` | denied — `requires "dispatch.write" but key has [gsp.read, gsp.write]` |
| `state_get_program_state` | denied — `requires "state.read"` |
| `keys_create_key` | denied — `requires "keys.write"` |

Worth noting for later: this name allowlist duplicates the capability system and will keep needing edits. Gating on `gsp.write` instead would be the cleaner design, but that changes authz semantics for every existing holder, so I kept this change minimal rather than redesigning it here.