### PR TITLE
feat(dispatch): get_tasks completeness signal — hasMore, cursor, total (R3.1)

### DIFF
--- a/services/mcp-server/src/__tests__/get-tasks-completeness-signal.test.ts
+++ b/services/mcp-server/src/__tests__/get-tasks-completeness-signal.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression test: get_tasks must say when a result is short (R3.1).
+ *
+ * Defect 3 (PDR-dispatch-layer-silent-absence, §Defect 3): the response from
+ * get_tasks carries no hasMore, no cursor, no total. A caller cannot tell
+ * "I have seen everything" from "this is what survived" -- the two shapes
+ * are byte-identical.
+ *
+ * SCOPE: this covers R3.1 only -- an incomplete result must SAY so. It does
+ * NOT fix the cap mechanism (R3.2: today `limit` bounds candidates
+ * considered in Firestore, then requires_action/auto_archived/expiresAt
+ * filter client-side on the already-capped page, so `tasks.length` can be
+ * under `limit` even when more matching rows exist beyond the window).
+ * `hasMore`/`cursor` here are honest about the RAW CANDIDATE window, not
+ * about matching rows -- see the PR description for why that is still
+ * sufficient to satisfy the DoD below.
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn(), classifyTask: jest.fn(() => "standard") }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+jest.mock("../modules/github-sync.js", () => ({ syncTaskCreated: jest.fn() }));
+jest.mock("../webhooks/dispatcher-notify.js", () => ({ notifyDispatcher: jest.fn() }));
+
+type FakeDoc = {
+  id: string;
+  createdAtMs: number;
+  data: Record<string, unknown>;
+};
+
+// In-memory Firestore stand-in. `docs` is the full, already-ordered
+// (newest-first) collection. The mock query chain implements .where() as a
+// no-op filter recorder (existing tests already assert on where() calls
+// elsewhere; here we only need it to not crash), honors .startAfter(),
+// .limit(), and .count(), and reproduces the real cap-then-filter shape:
+// `.get()` returns exactly the first N (post-startAfter) raw docs, full stop
+// -- filtering by requires_action/auto_archived/expiresAt happens in the
+// handler itself, same as production.
+let collectionDocs: FakeDoc[] = [];
+
+function makeDoc(id: string, createdAtMs: number, overrides: Record<string, unknown> = {}): FakeDoc {
+  return {
+    id,
+    createdAtMs,
+    data: {
+      type: "task",
+      title: `title-${id}`,
+      action: "queue",
+      priority: "normal",
+      status: "created",
+      source: "iso",
+      target: "basher",
+      requires_action: true,
+      auto_archived: false,
+      createdAt: { toDate: () => new Date(createdAtMs) },
+      ...overrides,
+    },
+  };
+}
+
+function toSnapshotDoc(doc: FakeDoc) {
+  return {
+    id: doc.id,
+    data: () => doc.data,
+    ref: { id: doc.id },
+    exists: true,
+  };
+}
+
+function buildQuery(startAfterId?: string) {
+  let afterId = startAfterId;
+  let lim = Infinity;
+
+  const query: any = {
+    where: jest.fn(() => query),
+    orderBy: jest.fn(() => query),
+    startAfter: jest.fn((cursorDoc: { id: string }) => {
+      afterId = cursorDoc.id;
+      return query;
+    }),
+    limit: jest.fn((n: number) => {
+      lim = n;
+      return query;
+    }),
+    get: jest.fn(async () => {
+      let pool = collectionDocs; // already newest-first
+      if (afterId) {
+        const idx = pool.findIndex((d) => d.id === afterId);
+        pool = idx >= 0 ? pool.slice(idx + 1) : pool;
+      }
+      const page = pool.slice(0, lim === Infinity ? pool.length : lim);
+      return { docs: page.map(toSnapshotDoc) };
+    }),
+    count: jest.fn(() => ({
+      get: jest.fn(async () => ({ data: () => ({ count: collectionDocs.length }) })),
+    })),
+  };
+  return query;
+}
+
+const mockDb = {
+  collection: jest.fn(() => buildQuery()),
+  doc: jest.fn((path: string) => {
+    const id = path.split("/").pop()!;
+    const found = collectionDocs.find((d) => d.id === id);
+    return {
+      get: jest.fn(async () => (found ? { ...toSnapshotDoc(found), exists: true } : { exists: false })),
+    };
+  }),
+  batch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn(() => Promise.resolve()) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-ts"),
+}));
+
+import { getTasksHandler } from "../modules/dispatch/tasks.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+function makeAuth(): AuthContext {
+  return {
+    userId: "u1",
+    programId: "basher",
+    apiKeyHash: "hash",
+    encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    capabilities: ["*"],
+    rateLimitTier: "internal",
+  } as AuthContext;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  collectionDocs = [];
+  mockDb.collection.mockImplementation(() => buildQuery());
+});
+
+describe("get_tasks completeness signal — R3.1", () => {
+  it("a queue with more matching rows than the limit returns hasMore:true and a usable cursor", async () => {
+    // 15 rows, newest first, limit 10 -> 5 rows beyond the window.
+    collectionDocs = Array.from({ length: 15 }, (_, i) => makeDoc(`t${15 - i}`, 15 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(true);
+    expect(typeof parsed.cursor).toBe("string");
+    expect(parsed.cursor).not.toBeNull();
+  });
+
+  it("a genuinely complete read returns hasMore:false and a null cursor", async () => {
+    // Only 7 rows exist total, well under the limit of 10 -> nothing beyond.
+    collectionDocs = Array.from({ length: 7 }, (_, i) => makeDoc(`t${7 - i}`, 7 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(7);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.cursor).toBeNull();
+  });
+
+  it("an exact-limit read (rows == limit, nothing beyond) also returns hasMore:false", async () => {
+    // Guards the boundary: count()==limit must not be mistaken for "more exist".
+    collectionDocs = Array.from({ length: 10 }, (_, i) => makeDoc(`t${10 - i}`, 10 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.cursor).toBeNull();
+  });
+
+  it("the cursor round-trips: feeding it back returns the NEXT rows, not the same ones", async () => {
+    collectionDocs = Array.from({ length: 25 }, (_, i) => makeDoc(`t${25 - i}`, 25 - i));
+
+    const page1 = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed1 = JSON.parse((page1.content[0] as { text: string }).text);
+    expect(parsed1.hasMore).toBe(true);
+    const page1Ids = parsed1.tasks.map((t: { id: string }) => t.id);
+
+    const page2 = await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: parsed1.cursor });
+    const parsed2 = JSON.parse((page2.content[0] as { text: string }).text);
+    const page2Ids = parsed2.tasks.map((t: { id: string }) => t.id);
+
+    // No overlap between the two pages.
+    expect(page2Ids.some((id: string) => page1Ids.includes(id))).toBe(false);
+    // Page 2 picks up immediately where page 1 left off (t15 was the 11th-newest).
+    expect(page2Ids[0]).toBe("t15");
+    expect(parsed2.hasMore).toBe(true);
+
+    const page3 = await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: parsed2.cursor });
+    const parsed3 = JSON.parse((page3.content[0] as { text: string }).text);
+    // 25 total, 20 consumed by pages 1-2 -> 5 remain, exhausted now.
+    expect(parsed3.count).toBe(5);
+    expect(parsed3.hasMore).toBe(false);
+    expect(parsed3.cursor).toBeNull();
+  });
+
+  it("absent-field docs (legacy, no requires_action/auto_archived/expiresAt) still count toward hasMore", async () => {
+    // Regression guard: the peek must operate on RAW candidates, not on the
+    // post-filter set, so legacy docs missing these fields don't skew hasMore.
+    collectionDocs = Array.from({ length: 12 }, (_, i) =>
+      makeDoc(`t${12 - i}`, 12 - i, { requires_action: undefined, auto_archived: undefined })
+    );
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", requires_action: null });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(true);
+  });
+
+  it("an unknown or expired cursor is rejected explicitly, not silently restarted from page one", async () => {
+    collectionDocs = Array.from({ length: 5 }, (_, i) => makeDoc(`t${5 - i}`, 5 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: "does-not-exist" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/cursor/i);
+  });
+});

--- a/services/mcp-server/src/modules/dispatch/tasks.ts
+++ b/services/mcp-server/src/modules/dispatch/tasks.ts
@@ -29,6 +29,9 @@ const GetTasksSchema = z.object({
   include_archived: z.boolean().default(false),
   // Default false: omit instruction bodies to keep boot payloads small. Fetch full body via get_task_by_id.
   include_instructions: z.boolean().default(false),
+  // R3.1: opaque continuation cursor from a prior response's `cursor` field.
+  // Resumes the raw candidate scan exactly where that page's window ended.
+  cursor: z.string().optional(),
 });
 
 const CreateTaskSchema = z.object({
@@ -117,12 +120,35 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
   }
   // No target + legacy/mobile/dispatcher: no filter (see everything in tenant)
 
-  const snapshot = await query.orderBy("createdAt", "desc").limit(args.limit).get();
+  let orderedQuery = query.orderBy("createdAt", "desc");
+
+  // R3.1: resume exactly after the last doc of the previous page's raw window.
+  if (args.cursor) {
+    const cursorDoc = await db.doc(`tenants/${auth.userId}/tasks/${args.cursor}`).get();
+    if (!cursorDoc.exists) {
+      return jsonResult({ success: false, error: "Invalid or expired cursor" });
+    }
+    orderedQuery = orderedQuery.startAfter(cursorDoc);
+  }
+
+  // R3.1: fetch one candidate beyond the page to get an honest completeness
+  // signal. This is deliberately scoped to the RAW CANDIDATE window (pre the
+  // requires_action/auto_archived/expiresAt filter below) — it does NOT fix
+  // the cap mechanism where `limit` bounds candidates considered rather than
+  // matching rows returned (that is R3.2, out of scope here; see PR
+  // description). What it does guarantee: if more matching rows than `limit`
+  // exist, they are necessarily a subset of more raw candidates than `limit`,
+  // so hasMore is true whenever that happens — the two DoD directions this
+  // task requires both hold structurally, independent of R3.2.
+  const snapshot = await orderedQuery.limit(args.limit + 1).get();
+  const hasMore = snapshot.docs.length > args.limit;
+  const windowDocs = snapshot.docs.slice(0, args.limit);
+  const nextCursor = hasMore ? windowDocs[windowDocs.length - 1].id : null;
 
   // Track informational tasks for auto-archive (fire-and-forget)
   const autoArchiveRefs: admin.firestore.DocumentReference[] = [];
 
-  const tasks = snapshot.docs
+  const tasks = windowDocs
     .filter((doc) => {
       const data = doc.data();
       // Filter by requires_action: null = no filter, true/false = exact match
@@ -190,11 +216,32 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     batch.commit().catch((err: unknown) => console.error("[AutoArchive] Failed:", err));
   }
 
+  // R3.1: best-effort total candidate count ("where affordable") — same
+  // population hasMore/cursor paginate over (server-side filters only), NOT
+  // the matching-row count. A missing index or other count() failure must
+  // not fail the read; omit total rather than throw.
+  let total: number | null = null;
+  try {
+    const countSnapshot = await query.count().get();
+    total = countSnapshot.data().count;
+  } catch {
+    total = null;
+  }
+
   return jsonResult({
     success: true,
     hasTasks: tasks.length > 0,
     count: tasks.length,
     tasks,
+    // R3.1 — completeness signal: "I have seen everything" is now something
+    // this response STATES (hasMore/cursor), never something inferred from
+    // count() alone. Does not stop rows disappearing (defect 3's unproven
+    // second mechanism) and does not fix the cap-vs-matching-rows mechanism
+    // (proven, R3.2) — both remain open; this only makes a short result say
+    // it is short.
+    hasMore,
+    cursor: nextCursor,
+    total,
     message: tasks.length > 0 ? `Found ${tasks.length} task(s)` : "No tasks found",
   });
 }


### PR DESCRIPTION
## What

Adds a positive completeness signal to `dispatch_get_tasks` (`getTasksHandler`, `services/mcp-server/src/modules/dispatch/tasks.ts`) so a short result **SAYS** it is short instead of being byte-identical to a complete one:

- `hasMore: boolean`
- `cursor: string | null` — opaque continuation token (last returned doc's ID)
- `total: number | null` — best-effort raw candidate count via `count()`, never blocks the read on failure

Mechanism: fetch `limit + 1` raw candidates instead of `limit` (a one-row peek beyond the page). `hasMore = docs.length > limit`. The cursor resumes via Firestore's native `startAfter(docSnapshot)`, fetched fresh from `tenants/{uid}/tasks/{cursor}` — avoids any same-timestamp tie-break ambiguity a field-value cursor would have.

## CRITICAL SCOPE BOUNDARY — this does NOT fix defect 3

Per the task's explicit instruction: **do not claim this fixes defect 3, and do not let this PR imply it.** There are two mechanisms and this PR addresses neither:

1. **PROVEN (cap):** `orderBy("createdAt","desc").limit(args.limit).get()` runs in Firestore, then `requires_action`/`auto_archived`/`expiresAt` filter in **application code** on the already-capped page. `schema max(50)` is a hard ceiling. **Untouched by this PR.**
2. **UNPROVEN (second):** an identical call seconds apart returned different row counts (one row present via `get_task_by_id` but absent from `get_tasks`). Leading hypothesis is query-path read consistency. Still a hypothesis. **Untouched by this PR.**

This PR makes short results **honest**. It does not stop rows disappearing.

Why `hasMore`/`cursor` are still sound despite not fixing the cap mechanism: they're honest about the **raw candidate window**, not about matching rows. But structurally, if more matching rows than `limit` exist, they're necessarily a subset of more raw candidates than `limit` — so `hasMore` is true whenever that happens. Both DoD directions hold regardless of R3.2's status.

Explicitly out of scope per instructions: raising the default `limit`, raising the `max(50)` ceiling (that's R3.5 — moves the cliff, doesn't remove it; ceiling removal belongs with pagination work, not this change), and R3.2 (candidates vs matching-rows) itself.

## DoD

- [x] Regression suite (6 tests, `get-tasks-completeness-signal.test.ts`) built first, confirmed **RED** against unfixed code, **GREEN** after.
- [x] Queue with more matching rows than `limit` → `hasMore: true` + usable cursor.
- [x] Genuinely complete read → `hasMore: false` (asserted both directions — includes the exact-`limit`-boundary case, since a field hardcoded `false` would pass a one-sided test).
- [x] Cursor round-trips: feeding it back returns the NEXT rows, not the same ones (3-page test: no overlap, correct continuation point, eventual exhaustion).
- [x] Absent-field regression: legacy docs missing `requires_action`/`auto_archived` still count toward `hasMore` (peek operates on raw candidates, not the post-filter set).
- [x] Unknown/expired cursor rejected explicitly (`success: false`), not silently restarted from page one.
- [x] **All three transports** verified by reading each call site, not assumed:
  - `src/tools/dispatch.ts` registers `dispatch_get_tasks: getTasksHandler` (MCP stdio via `index.ts`)
  - `src/transport/rest.ts:369` routes `GET /v1/tasks` through `callTool(auth, req, "get_tasks", query)` → same handler; response passed through `restResponse` unmodified
  - `src/iso/isoServer.ts` maps `dispatch_get_tasks: getTasksHandler` in `ISO_TOOL_HANDLERS`; `const result = await handler(...)` returned unmodified
  - All three share the identical module-level handler — a fix here propagates without per-transport changes.

Full suite: 763 passed, 21 pre-existing skips, 0 failures. `tsc --noEmit` clean.

## Merge note

cachebash `main` requires an approving review no Grid program can give (all commit as `feelgreatfoodie`; GitHub forbids self-approval). Per instructions, not self-approving — leaving for ISO to merge with `--admin` and record rationale.

Plan context: `grid/plans/ISO-plan-get-tasks-under-reports.md` (`0928bfa4`, amended `ac66bbed`), section 0 and DoD item 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01774PGrjJJJgw7cb1DTBRLj