### PR TITLE
feat(dispatch): get_tasks limit bounds MATCHING rows, not candidates (R3.2)

### DIFF
--- a/services/mcp-server/src/__tests__/get-tasks-matching-rows-pagination.test.ts
+++ b/services/mcp-server/src/__tests__/get-tasks-matching-rows-pagination.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Regression test: get_tasks `limit` must bound MATCHING rows, not raw
+ * candidates (R3.2/R3.3/R3.4/R3.5/§4.1 — PDR-dispatch-layer-silent-absence
+ * §Defect 3, plan grid/plans/ISO-plan-get-tasks-under-reports.md).
+ *
+ * Today (pre-fix): `.orderBy("createdAt","desc").limit(args.limit).get()`
+ * caps the raw Firestore candidates considered, THEN requires_action /
+ * auto_archived / expiresAt filter in application code on the already
+ * capped page. A queue where matching rows are sparse or buried past the
+ * newest `limit` candidates under-reports or reports empty even though
+ * matches exist deeper in the collection.
+ *
+ * SCOPE: this covers the PROVEN cap mechanism only. It is explicitly NOT a
+ * fix for defect 3's second, unproven mechanism (query-vs-point-read
+ * divergence observed live, §0 of the plan) — pagination does nothing for
+ * that, and VECTOR's ruling is that these tests alone must not be read as
+ * closing defect 3. See the PR description.
+ *
+ * Also covers §4.1: `total` (candidate count, R3.1) is renamed to
+ * `totalCandidates` so its name matches what it has always measured.
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn(), classifyTask: jest.fn(() => "standard") }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+jest.mock("../modules/github-sync.js", () => ({ syncTaskCreated: jest.fn() }));
+jest.mock("../webhooks/dispatcher-notify.js", () => ({ notifyDispatcher: jest.fn() }));
+
+type FakeDoc = {
+  id: string;
+  data: Record<string, unknown>;
+};
+
+let collectionDocs: FakeDoc[] = []; // newest-first, as Firestore orderBy("createdAt","desc") would return
+let builtQueries: ReturnType<typeof buildQuery>[] = [];
+
+function makeDoc(id: string, createdAtMs: number, overrides: Record<string, unknown> = {}): FakeDoc {
+  return {
+    id,
+    data: {
+      type: "task",
+      title: `title-${id}`,
+      action: "queue",
+      priority: "normal",
+      status: "created",
+      source: "iso",
+      target: "basher",
+      requires_action: true,
+      auto_archived: false,
+      createdAt: { toDate: () => new Date(createdAtMs) },
+      ...overrides,
+    },
+  };
+}
+
+function toSnapshotDoc(doc: FakeDoc) {
+  return { id: doc.id, data: () => doc.data, ref: { id: doc.id }, exists: true };
+}
+
+function buildQuery() {
+  let afterId: string | undefined;
+  let lim = Infinity;
+
+  const query: any = {
+    where: jest.fn(() => query),
+    orderBy: jest.fn(() => query),
+    startAfter: jest.fn((cursorDoc: { id: string }) => {
+      afterId = cursorDoc.id;
+      return query;
+    }),
+    limit: jest.fn((n: number) => {
+      lim = n;
+      return query;
+    }),
+    get: jest.fn(async () => {
+      let pool = collectionDocs;
+      if (afterId) {
+        const idx = pool.findIndex((d) => d.id === afterId);
+        pool = idx >= 0 ? pool.slice(idx + 1) : pool;
+      }
+      const page = pool.slice(0, lim === Infinity ? pool.length : lim);
+      return { docs: page.map(toSnapshotDoc) };
+    }),
+    count: jest.fn(() => ({
+      get: jest.fn(async () => ({ data: () => ({ count: collectionDocs.length }) })),
+    })),
+  };
+  return query;
+}
+
+const mockDb = {
+  collection: jest.fn(() => {
+    const q = buildQuery();
+    builtQueries.push(q);
+    return q;
+  }),
+  doc: jest.fn((path: string) => {
+    const id = path.split("/").pop()!;
+    const found = collectionDocs.find((d) => d.id === id);
+    return {
+      get: jest.fn(async () => (found ? { ...toSnapshotDoc(found), exists: true } : { exists: false })),
+    };
+  }),
+  batch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn(() => Promise.resolve()) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-ts"),
+}));
+
+import { getTasksHandler } from "../modules/dispatch/tasks.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+function makeAuth(): AuthContext {
+  return {
+    userId: "u1",
+    programId: "basher",
+    apiKeyHash: "hash",
+    encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    capabilities: ["*"],
+    rateLimitTier: "internal",
+  } as AuthContext;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  collectionDocs = [];
+  builtQueries = [];
+});
+
+describe("get_tasks matching-rows pagination — R3.2/R3.3/R3.4/R3.5/§4.1", () => {
+  it("R3.2/R3.3/R3.7: a single matching row buried past hundreds of non-matching raw candidates is still found (multi-page proof)", async () => {
+    // 500 non-matching (auto_archived:true, filtered out) newest docs, then
+    // ONE matching doc as the very oldest. Old behaviour (`limit` caps raw
+    // candidates at args.limit, here 10) never sees past the newest 10 --
+    // permanently invisible. This also forces the internal page-size loop to
+    // run more than once, proven below via builtQueries[0].get call count.
+    const docs: FakeDoc[] = [];
+    for (let i = 0; i < 500; i++) {
+      docs.push(makeDoc(`noise${i}`, 1000 - i, { auto_archived: true }));
+    }
+    docs.push(makeDoc("buried-match", 1, { auto_archived: false }));
+    collectionDocs = docs;
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.hasTasks).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.tasks[0].id).toBe("buried-match");
+    // Proves the fix actually paginates the raw candidate stream rather than
+    // fetching one larger-but-still-fixed page.
+    expect(builtQueries[0].get.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("R3.4: hasTasks:false is reachable only after the raw candidate stream is exhausted, never from a single short page", async () => {
+    // Every one of 500 raw candidates is filtered out. The old cap-then-filter
+    // code would already report count:0 after just the first `limit`-sized
+    // page; this must keep scanning to genuine exhaustion before concluding
+    // hasTasks:false.
+    const docs: FakeDoc[] = [];
+    for (let i = 0; i < 500; i++) {
+      docs.push(makeDoc(`noise${i}`, 1000 - i, { auto_archived: true }));
+    }
+    collectionDocs = docs;
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.hasTasks).toBe(false);
+    expect(parsed.count).toBe(0);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.cursor).toBeNull();
+    expect(builtQueries[0].get.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("R3.5: raising limit is not required to see deep matches -- a fixture that broke the old max(50) ceiling now succeeds at the default limit", async () => {
+    // 200 non-matching newest docs (well past the OLD hard ceiling of 50),
+    // then 3 matching docs. limit stays at the schema default (10).
+    const docs: FakeDoc[] = [];
+    for (let i = 0; i < 200; i++) {
+      docs.push(makeDoc(`noise${i}`, 1000 - i, { auto_archived: true }));
+    }
+    docs.push(makeDoc("m1", 3, { auto_archived: false }));
+    docs.push(makeDoc("m2", 2, { auto_archived: false }));
+    docs.push(makeDoc("m3", 1, { auto_archived: false }));
+    collectionDocs = docs;
+
+    const result = await getTasksHandler(makeAuth(), { status: "created", include_archived: false }); // default limit=10
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(3);
+    expect(parsed.tasks.map((t: { id: string }) => t.id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("DoD 2: more matching rows than the limit returns hasMore:true and a usable cursor", async () => {
+    collectionDocs = Array.from({ length: 25 }, (_, i) => makeDoc(`t${25 - i}`, 25 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(true);
+    expect(typeof parsed.cursor).toBe("string");
+  });
+
+  it("DoD 5: a response under its own limit is reachable only when the result is genuinely complete", async () => {
+    collectionDocs = Array.from({ length: 7 }, (_, i) => makeDoc(`t${7 - i}`, 7 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(7);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.cursor).toBeNull();
+  });
+
+  it("hasMore is exactly false on the exact-limit boundary when nothing remains beyond it (peek, not a hardcoded value)", async () => {
+    collectionDocs = Array.from({ length: 10 }, (_, i) => makeDoc(`t${10 - i}`, 10 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.cursor).toBeNull();
+  });
+
+  it("DoD 4: a limit sweep (10/25/50) over an unchanging queue returns monotonic, consistent, prefix-stable counts", async () => {
+    collectionDocs = Array.from({ length: 60 }, (_, i) => makeDoc(`t${60 - i}`, 60 - i));
+
+    const r10 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 10, status: "created" })).content[0].text as string);
+    const r25 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 25, status: "created" })).content[0].text as string);
+    const r50 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 50, status: "created" })).content[0].text as string);
+
+    expect(r10.count).toBe(10);
+    expect(r25.count).toBe(25);
+    expect(r50.count).toBe(50);
+    const ids10 = r10.tasks.map((t: { id: string }) => t.id);
+    const ids25 = r25.tasks.map((t: { id: string }) => t.id);
+    const ids50 = r50.tasks.map((t: { id: string }) => t.id);
+    expect(ids25.slice(0, 10)).toEqual(ids10);
+    expect(ids50.slice(0, 25)).toEqual(ids25);
+  });
+
+  it("absent-field regression: docs lacking requires_action/auto_archived/expiresAt are still returned across a multi-page scan", async () => {
+    const docs: FakeDoc[] = [];
+    for (let i = 0; i < 300; i++) {
+      docs.push(makeDoc(`noise${i}`, 1000 - i, { auto_archived: true }));
+    }
+    // Legacy docs: field absent entirely (not merely false/true).
+    for (let i = 0; i < 5; i++) {
+      const d = makeDoc(`legacy${i}`, 10 - i);
+      delete d.data.requires_action;
+      delete d.data.auto_archived;
+      docs.push(d);
+    }
+    collectionDocs = docs;
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", requires_action: null, include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(5);
+    expect(parsed.tasks.map((t: { id: string }) => t.id).sort()).toEqual(["legacy0", "legacy1", "legacy2", "legacy3", "legacy4"]);
+  });
+
+  it("the cursor round-trips across the new pagination path: no overlap, correct continuation, eventual exhaustion", async () => {
+    collectionDocs = Array.from({ length: 25 }, (_, i) => makeDoc(`t${25 - i}`, 25 - i));
+
+    const page1 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 10, status: "created" })).content[0].text as string);
+    expect(page1.hasMore).toBe(true);
+    const page2 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: page1.cursor })).content[0].text as string);
+    expect(page2.tasks.map((t: { id: string }) => t.id)).not.toEqual(expect.arrayContaining(page1.tasks.map((t: { id: string }) => t.id)));
+    expect(page2.hasMore).toBe(true);
+    const page3 = JSON.parse((await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: page2.cursor })).content[0].text as string);
+    expect(page3.count).toBe(5);
+    expect(page3.hasMore).toBe(false);
+  });
+
+  it("§4.1: the candidate count field is named totalCandidates, not total, and total is not present", async () => {
+    collectionDocs = Array.from({ length: 12 }, (_, i) => makeDoc(`t${12 - i}`, 12 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 5, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.totalCandidates).toBe(12);
+    expect(parsed.total).toBeUndefined();
+  });
+
+  it("an unknown or expired cursor is rejected explicitly, not silently restarted from page one", async () => {
+    collectionDocs = Array.from({ length: 5 }, (_, i) => makeDoc(`t${5 - i}`, 5 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", cursor: "does-not-exist" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/cursor/i);
+  });
+});

--- a/services/mcp-server/src/modules/dispatch/tasks.ts
+++ b/services/mcp-server/src/modules/dispatch/tasks.ts
@@ -34,6 +34,12 @@ const GetTasksSchema = z.object({
   cursor: z.string().optional(),
 });
 
+// R3.2: internal Firestore page size for the raw-candidate scan, independent
+// of the public `limit` (capped at 50 -- R3.5 forbids raising that ceiling
+// to fix under-reporting; pagination is the correct fix, not a bigger
+// single page). Same rationale as schedule.ts's FALLBACK_PAGE_SIZE.
+const CANDIDATE_PAGE_SIZE = 200;
+
 const CreateTaskSchema = z.object({
   title: z.string().max(200),
   instructions: z.string().max(32000).optional(),
@@ -120,51 +126,80 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
   }
   // No target + legacy/mobile/dispatcher: no filter (see everything in tenant)
 
-  let orderedQuery = query.orderBy("createdAt", "desc");
+  const orderedQuery = query.orderBy("createdAt", "desc");
 
-  // R3.1: resume exactly after the last doc of the previous page's raw window.
+  // R3.1/R3.2: resume exactly after the last raw candidate the previous page
+  // examined (whether it matched or not).
+  let cursorQuery: admin.firestore.Query = orderedQuery;
   if (args.cursor) {
     const cursorDoc = await db.doc(`tenants/${auth.userId}/tasks/${args.cursor}`).get();
     if (!cursorDoc.exists) {
       return jsonResult({ success: false, error: "Invalid or expired cursor" });
     }
-    orderedQuery = orderedQuery.startAfter(cursorDoc);
+    cursorQuery = orderedQuery.startAfter(cursorDoc);
   }
 
-  // R3.1: fetch one candidate beyond the page to get an honest completeness
-  // signal. This is deliberately scoped to the RAW CANDIDATE window (pre the
-  // requires_action/auto_archived/expiresAt filter below) — it does NOT fix
-  // the cap mechanism where `limit` bounds candidates considered rather than
-  // matching rows returned (that is R3.2, out of scope here; see PR
-  // description). What it does guarantee: if more matching rows than `limit`
-  // exist, they are necessarily a subset of more raw candidates than `limit`,
-  // so hasMore is true whenever that happens — the two DoD directions this
-  // task requires both hold structurally, independent of R3.2.
-  const snapshot = await orderedQuery.limit(args.limit + 1).get();
-  const hasMore = snapshot.docs.length > args.limit;
-  const windowDocs = snapshot.docs.slice(0, args.limit);
-  const nextCursor = hasMore ? windowDocs[windowDocs.length - 1].id : null;
+  function passesPostCapFilters(data: admin.firestore.DocumentData): boolean {
+    // Filter by requires_action: null = no filter, true/false = exact match
+    if (args.requires_action !== null) {
+      const reqAction = data.requires_action ?? true; // default true for legacy tasks
+      if (reqAction !== args.requires_action) return false;
+    }
+    // Filter out auto-archived unless explicitly included
+    if (!args.include_archived && data.auto_archived === true) return false;
+    // Filter out expired tasks (TTL-based auto-archive on read)
+    if (data.expiresAt) {
+      const expires = data.expiresAt.toDate ? data.expiresAt.toDate() : new Date(data.expiresAt);
+      if (expires < new Date()) return false;
+    }
+    return true;
+  }
+
+  // R3.2: `limit` must bound MATCHING rows, not raw candidates. Page through
+  // the raw candidate stream applying the post-cap predicates above until
+  // `limit` matching rows are collected or the stream is genuinely
+  // exhausted. R3.3/R3.4: "no work" (hasTasks:false) is reachable only
+  // through that exhaustion — never inferred from a single short page.
+  const matchedDocs: admin.firestore.QueryDocumentSnapshot[] = [];
+  let lastRawDoc: admin.firestore.QueryDocumentSnapshot | null = null;
+  let hasMore = false;
+
+  for (;;) {
+    const pageSnap = await cursorQuery.limit(CANDIDATE_PAGE_SIZE).get();
+    if (pageSnap.docs.length === 0) {
+      hasMore = false; // Raw stream exhausted with nothing left at all.
+      break;
+    }
+    for (const doc of pageSnap.docs) {
+      lastRawDoc = doc;
+      if (passesPostCapFilters(doc.data())) {
+        matchedDocs.push(doc);
+        if (matchedDocs.length === args.limit) break;
+      }
+    }
+    if (matchedDocs.length === args.limit) {
+      // R3.1's one-sided guarantee, preserved under R3.2: peek exactly one
+      // more raw candidate beyond the last one examined. hasMore can be a
+      // false positive (that candidate turns out not to match) but never a
+      // false negative — hasMore:false is reached only via this peek coming
+      // back empty, or the stream exhausting outright above/below.
+      const peek = await orderedQuery.startAfter(lastRawDoc).limit(1).get();
+      hasMore = peek.docs.length > 0;
+      break;
+    }
+    if (pageSnap.docs.length < CANDIDATE_PAGE_SIZE) {
+      hasMore = false; // Short page: fewer matches than `limit` exist, period.
+      break;
+    }
+    cursorQuery = orderedQuery.startAfter(lastRawDoc);
+  }
+
+  const nextCursor = hasMore && lastRawDoc ? lastRawDoc.id : null;
 
   // Track informational tasks for auto-archive (fire-and-forget)
   const autoArchiveRefs: admin.firestore.DocumentReference[] = [];
 
-  const tasks = windowDocs
-    .filter((doc) => {
-      const data = doc.data();
-      // Filter by requires_action: null = no filter, true/false = exact match
-      if (args.requires_action !== null) {
-        const reqAction = data.requires_action ?? true; // default true for legacy tasks
-        if (reqAction !== args.requires_action) return false;
-      }
-      // Filter out auto-archived unless explicitly included
-      if (!args.include_archived && data.auto_archived === true) return false;
-      // Filter out expired tasks (TTL-based auto-archive on read)
-      if (data.expiresAt) {
-        const expires = data.expiresAt.toDate ? data.expiresAt.toDate() : new Date(data.expiresAt);
-        if (expires < new Date()) return false;
-      }
-      return true;
-    })
+  const tasks = matchedDocs
     .map((doc) => {
       const data = doc.data();
       const decrypted = decryptTaskFields(data, auth.encryptionKey);
@@ -216,16 +251,19 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     batch.commit().catch((err: unknown) => console.error("[AutoArchive] Failed:", err));
   }
 
-  // R3.1: best-effort total candidate count ("where affordable") — same
-  // population hasMore/cursor paginate over (server-side filters only), NOT
-  // the matching-row count. A missing index or other count() failure must
-  // not fail the read; omit total rather than throw.
-  let total: number | null = null;
+  // §4.1: renamed from `total` to `totalCandidates` — it has always measured
+  // raw candidates matching the server-side status/type/target filters only
+  // (best-effort, "where affordable"), never the matching-row count. Under
+  // R3.1 that was internally consistent but the field name didn't say so;
+  // R3.2 makes what `limit` bounds explicit throughout, so the rename lands
+  // here rather than costing a separate cycle. A count() failure (e.g. a
+  // missing index) must not fail the read.
+  let totalCandidates: number | null = null;
   try {
     const countSnapshot = await query.count().get();
-    total = countSnapshot.data().count;
+    totalCandidates = countSnapshot.data().count;
   } catch {
-    total = null;
+    totalCandidates = null;
   }
 
   return jsonResult({
@@ -233,15 +271,15 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     hasTasks: tasks.length > 0,
     count: tasks.length,
     tasks,
-    // R3.1 — completeness signal: "I have seen everything" is now something
-    // this response STATES (hasMore/cursor), never something inferred from
-    // count() alone. Does not stop rows disappearing (defect 3's unproven
-    // second mechanism) and does not fix the cap-vs-matching-rows mechanism
-    // (proven, R3.2) — both remain open; this only makes a short result say
-    // it is short.
+    // Completeness signal (R3.1, preserved under R3.2): "I have seen
+    // everything" is something this response STATES, never inferred from
+    // count() alone. `limit` now bounds matching rows (R3.2), so a response
+    // under its own limit is reachable only when the read is genuinely
+    // complete. This still does not close defect 3's unproven second
+    // mechanism (query-vs-point-read divergence) — see PR description.
     hasMore,
     cursor: nextCursor,
-    total,
+    totalCandidates,
     message: tasks.length > 0 ? `Found ${tasks.length} task(s)` : "No tasks found",
   });
 }


### PR DESCRIPTION
## What

Implements R3.2 + R3.3 + R3.4 + R3.5 + §4.1 from `grid/plans/ISO-plan-get-tasks-under-reports.md` (rezzedai/grid, read in full before starting). Shared handler: `services/mcp-server/src/modules/dispatch/tasks.ts`, `getTasksHandler`.

Today's bug (plan §1): `.orderBy("createdAt","desc").limit(args.limit).get()` caps raw Firestore **candidates**, then `requires_action`/`auto_archived`/`expiresAt` filter in application code on the already-capped page. `limit` bounds candidates considered, not matching rows returned — a queue with sparse or buried matches under-reports or reports empty even when matches exist deeper in the collection, and `max(50)` was a hard, permanent ceiling beyond which rows were simply invisible.

**R3.2** — Loops the raw candidate stream (internal page size `CANDIDATE_PAGE_SIZE = 200`, independent of the public `limit<=50`) applying the same post-cap predicates, until `limit` matching rows are collected or the stream is genuinely exhausted.

**R3.3/R3.4** — `hasTasks:false` is now reachable only through that exhaustion. "Does this program have work" no longer depends on the caller passing a wide enough `limit`, and is never inferred from a single short page.

**R3.5** — Did not raise the default `limit` or the schema's `max(50)`. The ceiling on what a single response can return is unchanged; what changed is that `limit` now bounds matching rows, and pagination (via `cursor`) reaches arbitrarily deep regardless.

**§4.1** — Renamed `total` → `totalCandidates`. It has always measured raw candidates matching the server-side status/type/target filters (best-effort via `count()`), never matching rows. `{count:10, total:47}` used to read as "47 match"; it never meant that.

**Constraint 2 preserved** — the three post-cap filters (`requires_action`, `auto_archived`, `expiresAt`) are still applied client-side, NOT moved into Firestore `where` clauses. Firestore `where` doesn't match documents where the field is absent, and legacy docs lack all three (read as `?? true`, `|| false`, and "no TTL" respectively) — moving them server-side without a verified backfill would silently drop exactly the long-lived carry-forwards this defect already hides. Pagination is correct regardless of field presence, which is why it's the specified fix.

**Constraint 1 preserved — R3.1's one-sided `hasMore` guarantee.** After collecting `limit` matches, one extra raw candidate is peeked (`orderedQuery.startAfter(lastRawDoc).limit(1)`); `hasMore` may be a false positive (peeked candidate turns out not to match) but is **never** a false negative — `hasMore:false` is reachable only via that peek coming back empty or the stream exhausting outright. Cursor semantics are unchanged from R3.1: last raw candidate examined, resumed via `startAfter(fresh docSnapshot)`.

## CRITICAL SCOPE BOUNDARY — this does NOT close defect 3

VECTOR's ruling (2026-08-11T17:39Z), restated in plan §4 DoD item 9: **pagination tests alone must not accept defect 3.** This PR closes the **proven cap mechanism only** (plan §1). Defect 3's second, unproven mechanism (plan §0) — an identical `get_tasks` call seconds apart returning different row counts, with `get_task_by_id` finding a row the query omitted — is **untouched**. Leading hypothesis (not established): query-path read consistency / index lag. Pagination does nothing for it.

**DoD item 10 (asymmetry test):** I could not force this deterministically in the mocked-Firestore jest harness this repo's existing tests use (see `get-tasks-target-filter.test.ts`, `schedule.test.ts` for the established pattern) — the mock always returns internally consistent data, so a test asserting "point-read finds what the query omitted" would only prove the mock does what I told it to, not that the real mechanism is guarded against. Per the plan's explicit instruction, stating this plainly rather than either fabricating a hollow test or silently dropping the requirement. Acceptance of the second mechanism should be gated on production observation (instrumenting the server path, per plan §0), not on this suite.

## DoD

- [x] Regression suite (11 tests, `get-tasks-matching-rows-pagination.test.ts`) built first. The 5 tests requiring R3.2's pagination loop confirmed **RED** against R3.1-only code (buried match past 500 non-matching candidates not found, `hasTasks:false` returned before exhaustion, deep match past the old 50-ceiling missed, absent-field docs past 300 raw candidates missed, `totalCandidates` didn't exist) — **GREEN** after.
- [x] Fixture with a single matching row buried past hundreds of non-matching raw candidates — found; asserted via `builtQueries[0].get.mock.calls.length > 1` that this required genuine multi-page traversal, not just a bigger single page.
- [x] Wide `createdAt` range, oldest row returned — same fixture, oldest doc is the buried match.
- [x] Limit sweep 10/25/50 over an unchanging queue — monotonic, prefix-stable (`ids25.slice(0,10) === ids10`, etc.).
- [x] A response under its own limit is reachable only when genuinely complete — including the exact-limit boundary via a real peek (not a hardcoded `hasMore`).
- [x] Absent-field regression — legacy docs missing all three fields, past 300 raw noise candidates, still returned.
- [x] A program booting against a non-empty (but sparse/buried) queue never reports idle.
- [x] `hasTasks:false` only from a fully exhausted scan (500 raw candidates, zero matches, `builtQueries[0].get` called >1 time).
- [x] Cursor round-trips through the new pagination path (no overlap, correct continuation, eventual exhaustion).
- [x] Unknown/expired cursor rejected explicitly, not silently restarted.
- [x] Did not validate by absence of recurrence — acceptance is the deterministic fixtures above plus the mechanism, not a quiet-observation window.
- [x] All three transports re-verified: `rest.ts`'s only `callTool()`-bypass site is `relay_mark_read` (line 431); `get_tasks`/`create_task`/etc. all route through `callTool()` → shared handler, unchanged from R3.1's finding.

Full suite: 774 passed, 21 pre-existing skips, 0 failures. `tsc --noEmit` clean.

## Merge note

cachebash `main` requires an approving review no Grid program can give (all commit as `feelgreatfoodie`; GitHub forbids self-approval). Not self-approving — leaving for ISO to merge with `--admin` and record rationale.

Builds on R3.1 (`efd48f0`, #391) — does not re-implement `hasMore`/`cursor`, only changes what `limit` bounds and what feeds them.

Plan context: `grid/plans/ISO-plan-get-tasks-under-reports.md` (`75d20100`), §0, §3, §4, §4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01774PGrjJJJgw7cb1DTBRLj