### PR TITLE
feat(dispatch): bound the get_tasks exhaustion scan (R3.6)

### DIFF
--- a/services/mcp-server/src/__tests__/get-tasks-scan-budget.test.ts
+++ b/services/mcp-server/src/__tests__/get-tasks-scan-budget.test.ts
@@ -229,4 +229,24 @@ describe("get_tasks scan budget — R3.6", () => {
     expect(parsed.degraded).toBe(false); // confirmed via peek, not a budget guess
     expect(parsed.degradedReason).toBeNull();
   });
+
+  it("R3.4 review finding: zero matches inside the budget plus a real match beyond it must not read as idle", async () => {
+    // Exactly the shape flagged in review: the raw candidates within the
+    // budget are entirely non-matching (the auto_archived-mirror population
+    // this budget exists to bound), and the one real match sits just past
+    // the cutoff. hasTasks must not be false here -- that would be
+    // indistinguishable from a genuinely verified-empty read (R3.4), and a
+    // caller following CLAUDE.md's boot protocol ("no work -> report idle")
+    // would falsely report idle with real work sitting past the cutoff.
+    const prefix = noiseRun(2200, 3000); // comfortably past the budget boundary
+    const realMatch = makeDoc("real-match", 1);
+    collectionDocs = [...prefix, realMatch];
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.degraded).toBe(true);
+    expect(parsed.count).toBe(0);
+    expect(parsed.hasTasks).not.toBe(false);
+  });
 });

--- a/services/mcp-server/src/__tests__/get-tasks-scan-budget.test.ts
+++ b/services/mcp-server/src/__tests__/get-tasks-scan-budget.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression test: get_tasks exhaustion scan must be BOUNDED (R3.6).
+ *
+ * R3.2 (efd48f0.. -> 0d7f3b8, #392) made `hasTasks:false` reachable only
+ * through genuine exhaustion of the raw candidate stream (R3.4) -- correct,
+ * and the point. But the loop it introduced has no page budget and no
+ * timeout, and the population that forces a full scan (auto_archived:true
+ * relay mirrors, expired-TTL carry-forwards) grows monotonically and is
+ * never deleted. Proving "no work" -- the fleet's most frequent call --
+ * therefore gets slower every day, unbounded.
+ *
+ * FIX: bound the scan by Firestore round-trips (MAX_CANDIDATE_PAGES). When
+ * the budget is hit, the response says so honestly: hasMore:true (NEVER
+ * false -- a budget cutoff reporting exhaustion would be defect 3 again,
+ * wearing a fix's label) plus degraded:true/degradedReason, distinguishing
+ * "budget hit, unknown how much more" from a genuine "found `limit` matches,
+ * confirmed more exist" hasMore:true.
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn(), classifyTask: jest.fn(() => "standard") }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+jest.mock("../modules/github-sync.js", () => ({ syncTaskCreated: jest.fn() }));
+jest.mock("../webhooks/dispatcher-notify.js", () => ({ notifyDispatcher: jest.fn() }));
+
+type FakeDoc = { id: string; data: Record<string, unknown> };
+
+let collectionDocs: FakeDoc[] = [];
+let builtQueries: ReturnType<typeof buildQuery>[] = [];
+
+function makeDoc(id: string, createdAtMs: number, overrides: Record<string, unknown> = {}): FakeDoc {
+  return {
+    id,
+    data: {
+      type: "task",
+      title: `title-${id}`,
+      action: "queue",
+      priority: "normal",
+      status: "created",
+      source: "iso",
+      target: "basher",
+      requires_action: true,
+      auto_archived: false,
+      createdAt: { toDate: () => new Date(createdAtMs) },
+      ...overrides,
+    },
+  };
+}
+
+function toSnapshotDoc(doc: FakeDoc) {
+  return { id: doc.id, data: () => doc.data, ref: { id: doc.id }, exists: true };
+}
+
+function buildQuery() {
+  let afterId: string | undefined;
+  let lim = Infinity;
+
+  const query: any = {
+    where: jest.fn(() => query),
+    orderBy: jest.fn(() => query),
+    startAfter: jest.fn((cursorDoc: { id: string }) => {
+      afterId = cursorDoc.id;
+      return query;
+    }),
+    limit: jest.fn((n: number) => {
+      lim = n;
+      return query;
+    }),
+    get: jest.fn(async () => {
+      let pool = collectionDocs;
+      if (afterId) {
+        const idx = pool.findIndex((d) => d.id === afterId);
+        pool = idx >= 0 ? pool.slice(idx + 1) : pool;
+      }
+      const page = pool.slice(0, lim === Infinity ? pool.length : lim);
+      return { docs: page.map(toSnapshotDoc) };
+    }),
+    count: jest.fn(() => ({
+      get: jest.fn(async () => ({ data: () => ({ count: collectionDocs.length }) })),
+    })),
+  };
+  return query;
+}
+
+const mockDb = {
+  collection: jest.fn(() => {
+    const q = buildQuery();
+    builtQueries.push(q);
+    return q;
+  }),
+  doc: jest.fn((path: string) => {
+    const id = path.split("/").pop()!;
+    const found = collectionDocs.find((d) => d.id === id);
+    return {
+      get: jest.fn(async () => (found ? { ...toSnapshotDoc(found), exists: true } : { exists: false })),
+    };
+  }),
+  batch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn(() => Promise.resolve()) })),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-ts"),
+}));
+
+import { getTasksHandler } from "../modules/dispatch/tasks.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+function makeAuth(): AuthContext {
+  return {
+    userId: "u1",
+    programId: "basher",
+    apiKeyHash: "hash",
+    encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    capabilities: ["*"],
+    rateLimitTier: "internal",
+  } as AuthContext;
+}
+
+function noiseRun(count: number, startAtMs: number): FakeDoc[] {
+  // Non-matching (auto_archived:true) docs, mirroring relay.ts's
+  // never-deleted mirror population that forces the pathological scan.
+  return Array.from({ length: count }, (_, i) => makeDoc(`noise${startAtMs - i}`, startAtMs - i, { auto_archived: true }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  collectionDocs = [];
+  builtQueries = [];
+});
+
+describe("get_tasks scan budget — R3.6", () => {
+  it("the one-sided guarantee still rules: a budget cutoff sets hasMore:true, NEVER false, and marks degraded:true", async () => {
+    // 5000 non-matching raw candidates, nothing else. Large enough to
+    // guarantee the budget (whatever it is tuned to) is hit before the raw
+    // stream is exhausted.
+    collectionDocs = noiseRun(5000, 6000);
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.hasMore).toBe(true);
+    expect(parsed.degraded).toBe(true);
+    expect(typeof parsed.degradedReason).toBe("string");
+    expect(parsed.degradedReason.length).toBeGreaterThan(0);
+    expect(typeof parsed.cursor).toBe("string");
+    // hasTasks:false must NEVER be asserted off a budget cutoff -- it found
+    // zero matches so far, but that is not the same claim as "verified none".
+    expect(parsed.count).toBe(0);
+  });
+
+  it("bounds the number of Firestore round trips regardless of collection size", async () => {
+    collectionDocs = noiseRun(50000, 60000); // far larger than any reasonable budget
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.degraded).toBe(true);
+    // The whole point of R3.6: this must NOT scale with collection size.
+    expect(builtQueries[0].get.mock.calls.length).toBeLessThanOrEqual(15);
+    expect(builtQueries[0].get.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("a fixture that genuinely exhausts WITHIN budget still returns hasMore:false, degraded:false (both directions, explicitly)", async () => {
+    // Modest fixture, comfortably inside any reasonable per-call budget.
+    collectionDocs = noiseRun(500, 600);
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.hasTasks).toBe(false);
+    expect(parsed.count).toBe(0);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.degraded).toBe(false);
+    expect(parsed.degradedReason).toBeNull();
+    expect(parsed.cursor).toBeNull();
+  });
+
+  it("a small, ordinary read (well under budget, well under limit) is NOT marked degraded", async () => {
+    collectionDocs = Array.from({ length: 7 }, (_, i) => makeDoc(`t${7 - i}`, 7 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(7);
+    expect(parsed.hasMore).toBe(false);
+    expect(parsed.degraded).toBe(false);
+    expect(parsed.degradedReason).toBeNull();
+  });
+
+  it("matching rows beyond the budget: a budget-cut response returns hasMore:true + a working cursor, and paginating with it eventually reaches them", async () => {
+    // A large non-matching prefix that spans several budget-bounded calls,
+    // then real matches at the very tail (oldest).
+    const prefix = noiseRun(4500, 5000);
+    const matches = [
+      makeDoc("m1", 3, {}),
+      makeDoc("m2", 2, {}),
+      makeDoc("m3", 1, {}),
+    ];
+    collectionDocs = [...prefix, ...matches];
+
+    let cursor: string | undefined;
+    let found: string[] = [];
+    let hops = 0;
+    for (;;) {
+      hops++;
+      if (hops > 20) throw new Error("did not converge -- pagination is not making progress");
+      const r = JSON.parse(
+        (await getTasksHandler(makeAuth(), { limit: 10, status: "created", include_archived: false, cursor })).content[0].text as string
+      );
+      found = found.concat(r.tasks.map((t: { id: string }) => t.id));
+      if (!r.hasMore) break;
+      expect(typeof r.cursor).toBe("string");
+      cursor = r.cursor;
+    }
+
+    expect(found.sort()).toEqual(["m1", "m2", "m3"]);
+    expect(hops).toBeGreaterThan(1); // proves it actually took more than one budgeted call
+  });
+
+  it("preserves R3.2's matched-limit hasMore semantics: reaching `limit` matches within budget is NOT marked degraded", async () => {
+    collectionDocs = Array.from({ length: 25 }, (_, i) => makeDoc(`t${25 - i}`, 25 - i));
+
+    const result = await getTasksHandler(makeAuth(), { limit: 10, status: "created" });
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(parsed.count).toBe(10);
+    expect(parsed.hasMore).toBe(true);
+    expect(parsed.degraded).toBe(false); // confirmed via peek, not a budget guess
+    expect(parsed.degradedReason).toBeNull();
+  });
+});

--- a/services/mcp-server/src/modules/dispatch/tasks.ts
+++ b/services/mcp-server/src/modules/dispatch/tasks.ts
@@ -302,7 +302,17 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
 
   return jsonResult({
     success: true,
-    hasTasks: tasks.length > 0,
+    // R3.6 review fix: `degraded` means the scan stopped on a budget
+    // cutoff, not on exhaustion -- zero matches found so far is NOT the
+    // same claim as R3.4's "verified none". Biasing hasTasks true here
+    // preserves the existing boolean contract every current caller's
+    // `if (hasTasks)`/`if (!hasTasks)` check already relies on (no fleet-
+    // wide migration), at the cost of a caller reading ONLY `hasTasks`
+    // being unable to tell "confirmed work" from "budget cut, unconfirmed"
+    // apart -- both read true. That residual gap is a deliberate, narrower
+    // choice than a tri-state field; see PR discussion for why a tri-state
+    // was not picked unilaterally.
+    hasTasks: tasks.length > 0 || degraded,
     count: tasks.length,
     tasks,
     // Completeness signal (R3.1, preserved under R3.2): "I have seen
@@ -320,7 +330,11 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     // confused with hasMore itself.
     degraded,
     degradedReason,
-    message: tasks.length > 0 ? `Found ${tasks.length} task(s)` : "No tasks found",
+    message: tasks.length > 0
+      ? `Found ${tasks.length} task(s)`
+      : degraded
+        ? "Scan budget reached before any match was found — not verified empty, resume with the returned cursor"
+        : "No tasks found",
   });
 }
 

--- a/services/mcp-server/src/modules/dispatch/tasks.ts
+++ b/services/mcp-server/src/modules/dispatch/tasks.ts
@@ -40,6 +40,23 @@ const GetTasksSchema = z.object({
 // single page). Same rationale as schedule.ts's FALLBACK_PAGE_SIZE.
 const CANDIDATE_PAGE_SIZE = 200;
 
+// R3.6: the R3.2 exhaustion scan (below) had no bound. Proving "no work"
+// (R3.4) walks the entire raw candidate stream, and that population grows
+// monotonically and is never deleted -- relay.ts mirrors every non-RESULT
+// message with auto_archived:true, which the default read always rejects,
+// plus every expired-TTL carry-forward. The idle-program boot read is the
+// fleet's most frequent call, so this is the pathological case, and it was
+// getting slower every day. Measured live 2026-08-12 (post-R3.2 deploy):
+// totalCandidates:1402 for target:"iso" alone -- exhausting that today costs
+// ceil(1402/200)=8 page reads, comfortably inside this budget. At 10x growth
+// (~14020 candidates) a full exhaustive scan would cost ~71 page reads; this
+// budget caps it at 10, trading a truthful `degraded:true` partial result
+// for an ~86% cut in Firestore round trips on the hottest call in the
+// fleet. Bounded by PAGE COUNT rather than elapsed time: round-trip count is
+// the actual cost driver, and unlike wall-clock it is deterministic and
+// directly assertable in tests (see get-tasks-scan-budget.test.ts).
+const MAX_CANDIDATE_PAGES = 10;
+
 const CreateTaskSchema = z.object({
   title: z.string().max(200),
   instructions: z.string().max(32000).optional(),
@@ -163,8 +180,12 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
   const matchedDocs: admin.firestore.QueryDocumentSnapshot[] = [];
   let lastRawDoc: admin.firestore.QueryDocumentSnapshot | null = null;
   let hasMore = false;
+  let degraded = false;
+  let degradedReason: string | null = null;
+  let pagesRead = 0;
 
   for (;;) {
+    pagesRead++;
     const pageSnap = await cursorQuery.limit(CANDIDATE_PAGE_SIZE).get();
     if (pageSnap.docs.length === 0) {
       hasMore = false; // Raw stream exhausted with nothing left at all.
@@ -189,6 +210,19 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     }
     if (pageSnap.docs.length < CANDIDATE_PAGE_SIZE) {
       hasMore = false; // Short page: fewer matches than `limit` exist, period.
+      break;
+    }
+    if (pagesRead >= MAX_CANDIDATE_PAGES) {
+      // R3.6: budget exhausted before the raw stream was. This is NOT
+      // exhaustion, so the one-sided guarantee (R3.4) demands hasMore:true
+      // here, never false — a bounded scan that reported exhaustion would be
+      // defect 3 again, wearing a fix's label. `degraded` distinguishes this
+      // "budget hit, unknown how much more" case from the confirmed-via-peek
+      // "found `limit` matches, more exist" hasMore:true above, so a caller
+      // can tell a truncated read from a complete one.
+      hasMore = true;
+      degraded = true;
+      degradedReason = `Scan budget (${MAX_CANDIDATE_PAGES} pages of ${CANDIDATE_PAGE_SIZE}) reached before the raw candidate stream was exhausted; resume with the returned cursor.`;
       break;
     }
     cursorQuery = orderedQuery.startAfter(lastRawDoc);
@@ -280,6 +314,12 @@ export async function getTasksHandler(auth: AuthContext, rawArgs: unknown): Prom
     hasMore,
     cursor: nextCursor,
     totalCandidates,
+    // R3.6: distinguishes a bounded-scan cutoff (unknown how much more, just
+    // that the budget ran out) from a confirmed "found `limit` matches, more
+    // exist" hasMore:true. Deliberately not named anything that could be
+    // confused with hasMore itself.
+    degraded,
+    degradedReason,
     message: tasks.length > 0 ? `Found ${tasks.length} task(s)` : "No tasks found",
   });
 }


### PR DESCRIPTION
## What

Implements R3.6 from `grid/plans/ISO-plan-get-tasks-under-reports.md` §6 (`15d5fd0d`, origin/main). Repo: `rezzedai/cachebash`, `services/mcp-server/src/modules/dispatch/tasks.ts`, `getTasksHandler`.

R3.2 (`0d7f3b8`, #392, merged and deployed) made `hasTasks:false` reachable only through genuine exhaustion of the raw candidate stream (R3.4) — correct, and the point. But that loop had **no page budget and no timeout**. The population that forces a full scan grows monotonically and is never deleted: `relay.ts:266`/`:388` mirror every non-RESULT message with `auto_archived: true`, which the default read always rejects, and expired-TTL carry-forwards accumulate the same way. So the **idle-program boot read — the fleet's most frequent call — is the pathological case**, and it got slower every day the relay ran. Measured live right after the R3.2 deploy: `totalCandidates: 1402` for `target:"iso"` alone.

## Fix

`MAX_CANDIDATE_PAGES = 10` — a **Firestore-round-trip budget**, not a timeout. A hurried caller must never read a slow scan as "nothing there" (constraint 3; the exact failure #390 fixed for `schedule_list`), so the budget degrades to a truthful partial result rather than throwing.

**Budget chosen from evidence (constraint 2):**
- Today's worst-known population (1402 candidates, `target:"iso"`) exhausts in `ceil(1402/200) = 8` page reads — comfortably inside the budget of 10, so **no behavior change today**.
- At 10x growth (~14020 candidates), a full exhaustive scan would cost ~71 page reads. This budget caps it at 10 — an **~86% cut in Firestore round trips** on the hottest call in the fleet, traded for an honest `degraded:true` partial result instead of an ever-slower complete one.
- Bounded by **page count**, not elapsed time: round-trip count is the actual cost driver, and unlike wall-clock it's deterministic and directly assertable in tests (the mock-call-count technique from #392, reused here — `builtQueries[0].get.mock.calls.length`).

**Constraint 1 — the one-sided guarantee is non-negotiable at the cutoff.** A budget hit sets `hasMore: true`, **never** false — reporting exhaustion off a bounded scan would be defect 3 again, wearing a fix's label. No fixture in the test suite is large enough to ever flip that.

**`degraded` / `degradedReason`** (same reasoning as #390's `degraded` flag) distinguish "budget hit, unknown how much more" from the confirmed-via-peek "found `limit` matches, more exist" `hasMore:true` R3.2 already produces. Named so neither can be confused with `hasMore` itself; the two are asserted independently in tests.

**Constraint 4 unchanged** — filters (`requires_action`/`auto_archived`/`expiresAt`) stay client-side. Plan §2's absent-field trap (Firestore `where` doesn't match documents missing the field) is untouched.

**Constraint 5 — all three transports re-verified.** `rest.ts`'s only `callTool()`-bypass site is still `relay_mark_read` (unrelated to `get_tasks`); `get_tasks` continues to route through the shared handler on all three.

## DoD

- [x] Regression suite (6 tests, `get-tasks-scan-budget.test.ts`) built first, confirmed **RED** against R3.2-only code, **GREEN** after.
- [x] Budget-cut fixture (5000 non-matching candidates) → `hasMore:true`, `degraded:true`, non-empty `degradedReason`, usable `cursor` — never `hasMore:false`.
- [x] Round-trip count stays bounded regardless of collection size — 50,000-doc fixture asserted to cost `<=15` Firestore reads (well under what an unbounded scan would need).
- [x] A fixture that genuinely exhausts **within** budget still returns `hasMore:false`, `degraded:false` — both directions asserted explicitly.
- [x] An ordinary small read (well under budget and under `limit`) is not marked degraded.
- [x] A fixture whose matches sit beyond the budget converges to them across multiple budgeted calls via the cursor — asserted `hops > 1` so the test can't silently pass by completing in one shot.
- [x] R3.2's matched-limit `hasMore:true` (confirmed via the post-limit peek) is asserted distinct from a budget-driven one: `degraded:false` in that case.
- [x] Full suite: 780 passed, 21 pre-existing skips, 0 failures. `tsc --noEmit` clean.

## Merge note

cachebash `main`'s approving-review rule is unsatisfiable for Grid programs (all commit as `feelgreatfoodie`). Not self-approving — leaving for ISO to merge with `--admin` and record rationale, and to handle deployment (`gcloud run deploy --source .` from `services/mcp-server`, per the deploy-workflow finding in plan §6.1 — this repo has no CI/CD deploy job, so merging alone will not ship this).

Builds on R3.1 (`efd48f0`, #391) and R3.2 (`0d7f3b8`, #392) — does not re-implement `hasMore`/`cursor`/`totalCandidates`, only bounds the scan that produces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01774PGrjJJJgw7cb1DTBRLj