### PR TITLE
fix(relay): get_messages drains by default; broadcasts exempt from claim (R2.4)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -198,7 +198,7 @@ GET /v1/messages
 |-----------|------|----------|---------|-------------|
 | `sessionId` | string | **Yes** | — | Session ID to check |
 | `target` | string | No | — | Filter by target program |
-| `markAsRead` | boolean | No | `false` | Mark returned messages as read |
+| `markAsRead` | boolean | No | `true` | Drain matching messages (pending → delivered). Pass `false` for a non-destructive observer read of another program's inbox (see `/v1/interrupts/peek`). |
 | `message_type` | string | No | — | Filter by message type |
 | `priority` | string | No | — | Filter by priority |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,8 +99,8 @@ console.log(json.data.tasks); // ✅ [{...}, {...}]
 
 4. Program B (Claude Code session)
    ↓ Polls: get_messages(sessionId="B", target="B")
-   ↓ MCP server reads users/{uid}/relay where target="B" and read=false
-   ↓ Marks message as read (optional)
+   ↓ MCP server reads users/{uid}/relay where target="B" and status="pending"
+   ↓ Marks message as delivered (default; pass markAsRead:false to observe without claiming)
    ↓ Returns message to Program B
 
 5. Program B processes message

--- a/services/mcp-server/src/__tests__/get-messages-mark-as-read-default.test.ts
+++ b/services/mcp-server/src/__tests__/get-messages-mark-as-read-default.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Regression test: get_messages must drain by default (R2.4).
+ *
+ * Defect (plan grid/plans/ISO-plan-dispatch-defects-1-and-2.md §7): `markAsRead`
+ * defaulted to false, so CLAUDE.md's documented bare boot call --
+ * get_messages(sessionId: "{program}") -- and the wake nudge never drained
+ * anything. Messages stayed "pending" forever and re-served identically on
+ * every poll.
+ *
+ * FIX: flip the default to true. The one real risk this opens: a caller
+ * with broad visibility (legacy/mobile/dispatcher-tier keys) reading ANOTHER
+ * program's inbox would now silently claim it by default. Enumeration
+ * (recorded in the PR) found exactly one such call site
+ * (`GET /v1/interrupts/peek`), already hardcoded to markAsRead:false.
+ *
+ * SEPARATELY, this surfaced a real, confirmed bug: `dispatch()` writes a
+ * broadcast (target:"all") as a SINGLE relay doc with no per-recipient
+ * delivery state. Under the old default this was latent (nothing drained by
+ * default); flipping the default would make the FIRST reader silently
+ * swallow the broadcast for every other program it targeted, since the next
+ * reader's default query only sees status:"pending". Broadcasts are
+ * therefore exempted from the claim mutation entirely.
+ */
+
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+jest.mock("../modules/events.js", () => ({ emitEvent: jest.fn() }));
+jest.mock("../modules/analytics.js", () => ({ emitAnalyticsEvent: jest.fn() }));
+jest.mock("../middleware/gate.js", () => ({
+  verifySource: jest.fn((source: string) => source),
+  isAdmin: jest.fn(() => false),
+  logAudit: jest.fn(),
+  generateCorrelationId: jest.fn(() => "corr-1"),
+}));
+jest.mock("../modules/ack-compliance.js", () => ({ logDirective: jest.fn(), markDirectiveAcknowledged: jest.fn() }));
+jest.mock("../config/compliance.js", () => ({
+  getComplianceConfig: jest.fn(() => ({ idempotencyKey: { enforcement: "off" }, ackAudit: { enabled: false } })),
+}));
+
+type FakeData = Record<string, unknown>;
+let messages: Record<string, FakeData> = {};
+
+function makeMsg(id: string, overrides: FakeData = {}): void {
+  messages[id] = {
+    source: "iso",
+    target: "basher",
+    payload: `body-${id}`,
+    message_type: "DIRECTIVE",
+    status: "pending",
+    priority: "normal",
+    action: "queue",
+    createdAt: { toDate: () => new Date(2026, 0, 1) },
+    deliveryAttempts: 0,
+    ...overrides,
+  };
+}
+
+function toQueryDoc(id: string) {
+  return { id, ref: { id }, data: () => messages[id] };
+}
+
+function buildQuery() {
+  const wheres: Array<[string, string, unknown]> = [];
+  const query: any = {
+    where: jest.fn((field: string, op: string, value: unknown) => {
+      wheres.push([field, op, value]);
+      return query;
+    }),
+    orderBy: jest.fn(() => query),
+    get: jest.fn(async () => {
+      const ids = Object.keys(messages).filter((id) => {
+        const data = messages[id];
+        return wheres.every(([field, op, value]) => {
+          const actual = data[field];
+          if (op === "==") return actual === value;
+          if (op === "in") return Array.isArray(value) && (value as unknown[]).includes(actual);
+          return true;
+        });
+      });
+      return { docs: ids.map(toQueryDoc) };
+    }),
+  };
+  return query;
+}
+
+const mockDb = {
+  collection: jest.fn(() => buildQuery()),
+  runTransaction: jest.fn(async (fn: any) => {
+    const tx = {
+      get: jest.fn(async (ref: { id: string }) => ({
+        exists: !!messages[ref.id],
+        data: () => messages[ref.id],
+      })),
+      update: jest.fn((ref: { id: string }, patch: FakeData) => {
+        const current = messages[ref.id];
+        const next: FakeData = { ...current };
+        for (const [k, v] of Object.entries(patch)) {
+          next[k] = k === "deliveryAttempts" ? ((current.deliveryAttempts as number) || 0) + 1 : v;
+        }
+        messages[ref.id] = next;
+      }),
+    };
+    return fn(tx);
+  }),
+};
+
+jest.mock("../firebase/client.js", () => ({
+  getFirestore: jest.fn(() => mockDb),
+  serverTimestamp: jest.fn(() => "mock-ts"),
+}));
+
+import { getMessagesHandler } from "../modules/relay.js";
+import type { AuthContext } from "../auth/authValidator.js";
+
+function makeAuth(programId: string): AuthContext {
+  return {
+    userId: "u1",
+    programId,
+    apiKeyHash: "hash",
+    encryptionKey: Buffer.from("test-encryption-key-32-bytes!!!"),
+    capabilities: ["*"],
+    rateLimitTier: "internal",
+  } as AuthContext;
+}
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  messages = {};
+});
+
+describe("get_messages mark-as-read default — R2.4", () => {
+  it("a bare call (no markAsRead) now drains a direct pending message", async () => {
+    makeMsg("m1", { target: "basher" });
+
+    const res = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher" }));
+
+    expect(res.interrupts.map((m: any) => m.id)).toEqual(["m1"]);
+    expect(res.interrupts[0].status).toBe("delivered");
+    expect(messages.m1.status).toBe("delivered");
+    expect(messages.m1.deliveryAttempts).toBe(1);
+  });
+
+  it("an explicit markAsRead:false still does NOT drain — the observer path remains available", async () => {
+    makeMsg("m1", { target: "basher" });
+
+    const res = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher", markAsRead: false }));
+
+    expect(res.interrupts.map((m: any) => m.id)).toEqual(["m1"]);
+    expect(res.interrupts[0].status).toBe("pending");
+    expect(messages.m1.status).toBe("pending");
+    expect(messages.m1.deliveryAttempts).toBe(0);
+  });
+
+  it("includeDelivered:true still returns the body after a drain (ADR-013 unbroken)", async () => {
+    makeMsg("m1", { target: "basher" });
+
+    const first = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher" }));
+    expect(first.interrupts.map((m: any) => m.id)).toEqual(["m1"]);
+    expect(messages.m1.status).toBe("delivered");
+
+    const second = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher" }));
+    expect(second.interrupts).toEqual([]);
+
+    const reread = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher", includeDelivered: true }));
+    expect(reread.interrupts.map((m: any) => m.id)).toEqual(["m1"]);
+    expect(reread.interrupts[0].message).toBe("body-m1");
+    // Re-read must never re-claim.
+    expect(messages.m1.deliveryAttempts).toBe(1);
+  });
+
+  it("R2.4 broadcast exemption: target:'all' is never marked delivered, even with markAsRead:true, and deliveryAttempts never increments", async () => {
+    makeMsg("bcast", { target: "all", message_type: "STATUS" });
+
+    const res = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher", markAsRead: true }));
+
+    expect(res.interrupts.map((m: any) => m.id)).toEqual(["bcast"]);
+    expect(res.interrupts[0].status).toBe("pending");
+    expect(messages.bcast.status).toBe("pending");
+    expect(messages.bcast.deliveryAttempts).toBe(0);
+  });
+
+  it("R2.4 broadcast exemption: a broadcast survives being claimed by one recipient -- a different recipient still sees it as pending", async () => {
+    makeMsg("bcast", { target: "all", message_type: "STATUS" });
+
+    const first = parse(await getMessagesHandler(makeAuth("scalar"), { sessionId: "scalar" })); // bare, drains by default
+    expect(first.interrupts.map((m: any) => m.id)).toEqual(["bcast"]);
+    expect(messages.bcast.status).toBe("pending"); // unmutated
+
+    const second = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher" })); // different program, also bare
+    expect(second.interrupts.map((m: any) => m.id)).toEqual(["bcast"]);
+    expect(second.interrupts[0].status).toBe("pending");
+  });
+
+  it("a direct message and a broadcast in the same call: the direct message drains, the broadcast does not", async () => {
+    makeMsg("direct", { target: "basher" });
+    makeMsg("bcast", { target: "all", message_type: "STATUS" });
+
+    const res = parse(await getMessagesHandler(makeAuth("basher"), { sessionId: "basher" }));
+
+    const direct = res.interrupts.find((m: any) => m.id === "direct");
+    const bcast = res.interrupts.find((m: any) => m.id === "bcast");
+    expect(direct.status).toBe("delivered");
+    expect(bcast.status).toBe("pending");
+    expect(messages.direct.deliveryAttempts).toBe(1);
+    expect(messages.bcast.deliveryAttempts).toBe(0);
+  });
+});

--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -532,7 +532,10 @@ describe("ADR-013 Participant-Scoped Durable Relay Reads", () => {
 
       const afterClaim = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
       expect(afterClaim.status).toBe("pending"); // never mutated
-      expect(afterClaim.deliveryAttempts).toBe(0); // never incremented
+      // The m4 fixture never sets deliveryAttempts, and increment() never ran
+      // (that's the point) -- so the field was never created. Assert
+      // absence-or-zero rather than assume the field exists.
+      expect(afterClaim.deliveryAttempts ?? 0).toBe(0); // never incremented
 
       // Re-poll: m4 is still pending, so it re-serves. This is the intended
       // trade-off for a schema with no per-recipient delivery state -- a
@@ -549,7 +552,7 @@ describe("ADR-013 Participant-Scoped Durable Relay Reads", () => {
       expect(m4.status).toBe("pending");
 
       const afterReread = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
-      expect(afterReread.deliveryAttempts).toBe(0); // still never claimed
+      expect(afterReread.deliveryAttempts ?? 0).toBe(0); // still never claimed
     });
 
     it("includeDelivered read-only poll returns pending + delivered bodies, own target only", async () => {

--- a/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
+++ b/services/mcp-server/src/__tests__/integration/relay-delivery.test.ts
@@ -520,29 +520,36 @@ describe("ADR-013 Participant-Scoped Durable Relay Reads", () => {
   });
 
   describe("get_messages — includeDelivered (Option C)", () => {
-    it("delivered re-read returns bodies and does NOT re-claim", async () => {
+    it("delivered re-read returns bodies and does NOT re-claim; a broadcast claim attempt is a no-op (R2.4)", async () => {
       const auth = makeAuth(userId, "scalar");
 
-      // First poll claims the pending broadcast + nothing else for scalar
+      // m4 is a broadcast (target:"all"). R2.4: broadcasts are exempt from
+      // the claim mutation entirely -- a single doc backs every recipient,
+      // so marking it delivered on the first claim would make that reader
+      // silently swallow it for every other program the broadcast targeted.
       const first = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true }) as never);
       expect(first.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
 
       const afterClaim = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
-      expect(afterClaim.status).toBe("delivered");
-      expect(afterClaim.deliveryAttempts).toBe(1);
+      expect(afterClaim.status).toBe("pending"); // never mutated
+      expect(afterClaim.deliveryAttempts).toBe(0); // never incremented
 
-      // Default re-poll: empty inbox (pending window closed) — unchanged behavior
+      // Re-poll: m4 is still pending, so it re-serves. This is the intended
+      // trade-off for a schema with no per-recipient delivery state -- a
+      // broadcast always re-serves rather than risk vanishing for whoever
+      // hasn't read it yet.
       const second = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true }) as never);
-      expect(second.interrupts).toEqual([]);
+      expect(second.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
 
-      // includeDelivered re-opens the body read without re-claiming
+      // includeDelivered still surfaces m1 (already delivered) alongside m4.
       const reread = parse(await getMessagesHandler(auth, { sessionId: "scalar", markAsRead: true, includeDelivered: true }) as never);
       expect(reread.interrupts.map((m: any) => m.id).sort()).toEqual(["m1", "m4"]);
       const m4 = reread.interrupts.find((m: any) => m.id === "m4");
       expect(m4.message).toBe("broadcast-body");
+      expect(m4.status).toBe("pending");
 
       const afterReread = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
-      expect(afterReread.deliveryAttempts).toBe(1); // no re-claim
+      expect(afterReread.deliveryAttempts).toBe(0); // still never claimed
     });
 
     it("includeDelivered read-only poll returns pending + delivered bodies, own target only", async () => {
@@ -555,9 +562,57 @@ describe("ADR-013 Participant-Scoped Durable Relay Reads", () => {
       expect(m1.status).toBe("delivered");
     });
 
-    it("default behavior unchanged: pending only", async () => {
+    it("R2.4: default now drains -- a bare call claims a pending direct message but leaves the broadcast pending", async () => {
+      // Extra direct message for scalar, isolated to this test.
+      await db.collection(`tenants/${userId}/relay`).doc("m6").set({
+        source: "iso", target: "scalar", payload: "direct-body", message_type: "DIRECTIVE",
+        status: "pending", threadId: "t-other2", priority: "normal", action: "queue",
+        createdAt: ts("2026-06-09T10:05:00Z"),
+      });
+
       const res = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar" }) as never);
+      expect(res.interrupts.map((m: any) => m.id).sort()).toEqual(["m4", "m6"]);
+
+      const m6 = res.interrupts.find((m: any) => m.id === "m6");
+      expect(m6.status).toBe("delivered");
+      const m4 = res.interrupts.find((m: any) => m.id === "m4");
+      expect(m4.status).toBe("pending");
+
+      const afterM6 = (await db.doc(`tenants/${userId}/relay/m6`).get()).data()!;
+      expect(afterM6.status).toBe("delivered");
+      expect(afterM6.deliveryAttempts).toBe(1);
+      const afterM4 = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
+      expect(afterM4.status).toBe("pending");
+      expect(afterM4.deliveryAttempts || 0).toBe(0);
+
+      // A second bare call no longer returns m6 (drained) but still returns m4 (broadcast).
+      const second = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar" }) as never);
+      expect(second.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
+    });
+
+    it("R2.4: markAsRead:false is still the non-destructive observer path", async () => {
+      const res = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar", markAsRead: false }) as never);
       expect(res.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
+
+      const afterRead = (await db.doc(`tenants/${userId}/relay/m4`).get()).data()!;
+      expect(afterRead.status).toBe("pending");
+    });
+
+    it("R2.4: a broadcast survives being read by one recipient -- a different recipient still sees it", async () => {
+      // scalar reads (and, per R2.4, does not claim) the broadcast first.
+      const scalarRead = parse(await getMessagesHandler(makeAuth(userId, "scalar"), { sessionId: "scalar" }) as never);
+      expect(scalarRead.interrupts.map((m: any) => m.id)).toEqual(["m4"]);
+
+      // basher, a different broadcast recipient, still sees it as pending —
+      // this is the exact swallow-bug R2.4's broadcast exemption prevents.
+      // (basher also has m5 pending on its own thread, drained normally.)
+      const basherRead = parse(await getMessagesHandler(makeAuth(userId, "basher"), { sessionId: "basher" }) as never);
+      const ids = basherRead.interrupts.map((m: any) => m.id).sort();
+      expect(ids).toEqual(["m4", "m5"]);
+      const m4ForBasher = basherRead.interrupts.find((m: any) => m.id === "m4");
+      expect(m4ForBasher.status).toBe("pending");
+      const m5ForBasher = basherRead.interrupts.find((m: any) => m.id === "m5");
+      expect(m5ForBasher.status).toBe("delivered");
     });
   });
 

--- a/services/mcp-server/src/iso/toolDefinitions.ts
+++ b/services/mcp-server/src/iso/toolDefinitions.ts
@@ -19,13 +19,13 @@ export const ISO_TOOL_DEFINITIONS = [
   },
   {
     name: "relay_get_messages",
-    description: "Check for pending messages from programs",
+    description: "Check for pending messages from programs. Default call DRAINS the caller's own inbox (matching messages transition to delivered). Fleet-supervision reads of another program's inbox MUST pass markAsRead:false explicitly.",
     inputSchema: {
       type: "object" as const,
       properties: {
         sessionId: { type: "string", description: "Session ID to check messages for" },
         target: { type: "string", description: "Target program ID to filter by" },
-        markAsRead: { type: "boolean", default: false },
+        markAsRead: { type: "boolean", default: true, description: "Default true: drains matching messages. Pass false to observe without claiming." },
         message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"], description: "Filter by message type" },
         priority: { type: "string", enum: ["low", "normal", "high"], description: "Filter by priority level" },
       },

--- a/services/mcp-server/src/modules/relay.ts
+++ b/services/mcp-server/src/modules/relay.ts
@@ -52,7 +52,14 @@ const SendMessageSchema = z.object({
 const GetMessagesSchema = z.object({
   sessionId: z.string(),
   target: z.string().max(100).optional(),
-  markAsRead: z.boolean().default(false),
+  // R2.4: default flipped true -- CLAUDE.md's boot protocol and the wake
+  // nudge both call this bare, and a bare call is documented as the inbox
+  // read. A non-draining read is retained as an explicit opt-out for
+  // observer callers (dashboards, fleet monitors, audits) that must not
+  // silently claim an inbox they don't own -- see getMessagesHandler for
+  // the broadcast exemption that keeps the drain safe for multi-recipient
+  // messages regardless of this default.
+  markAsRead: z.boolean().default(true),
   includeDelivered: z.boolean().default(false),
   message_type: z.enum(["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"]).optional(),
   priority: z.enum(["low", "normal", "high"]).optional(),
@@ -512,13 +519,27 @@ export async function getMessagesHandler(auth: AuthContext, rawArgs: unknown): P
       for (const { ref, id, fresh } of freshDocs) {
         if (!fresh.exists) continue;
         const data = fresh.data()!;
+        // R2.4: a broadcast (target:"all") is ONE relay doc read by every
+        // recipient -- there is no per-recipient delivery state in this
+        // schema. Marking it "delivered" on the first claim would make that
+        // reader silently swallow it for every other program the broadcast
+        // targeted, since the next reader's default query only sees
+        // status:"pending". Broadcasts are therefore exempt from the claim
+        // mutation entirely (never transition, deliveryAttempts never
+        // increments) and are always returned read-only, regardless of
+        // markAsRead. This is the same drain-is-safe reasoning as direct
+        // messages, applied to the one case where a single doc has more
+        // than one true recipient.
+        const isBroadcast = data.target === "all";
 
-        if (data.status === "pending") {
+        if (data.status === "pending" && !isBroadcast) {
           tx.update(ref, {
             status: "delivered",
             deliveredAt: admin.firestore.FieldValue.serverTimestamp(),
             deliveryAttempts: admin.firestore.FieldValue.increment(1),
           });
+        } else if (data.status === "pending" && isBroadcast) {
+          // Return it, but never mutate it or count it as a delivery attempt.
         } else if (!(args.includeDelivered && data.status === "delivered")) {
           // Only pending docs are claimable; delivered docs are returned
           // read-only when includeDelivered is set, all others skipped.
@@ -530,7 +551,7 @@ export async function getMessagesHandler(auth: AuthContext, rawArgs: unknown): P
           message: relayBody(data),
           source: data.source,
           message_type: data.message_type,
-          status: data.status === "pending" ? "delivered" : data.status,
+          status: (data.status === "pending" && !isBroadcast) ? "delivered" : data.status,
           action: data.action,
           priority: data.priority,
           context: data.context || null,

--- a/services/mcp-server/src/tools/relay.ts
+++ b/services/mcp-server/src/tools/relay.ts
@@ -42,13 +42,13 @@ export const definitions = [
   },
   {
     name: "relay_get_messages",
-    description: "Check for pending messages from programs. Set includeDelivered to re-read already-claimed message bodies. Replaces get_interrupts.",
+    description: "Check for pending messages from programs. Default call DRAINS your inbox (matching messages transition to delivered). Observer callers reading another program's inbox (dashboards, fleet monitors, audits) MUST pass markAsRead:false explicitly or they will silently claim messages the owner has not yet seen. Set includeDelivered to re-read already-claimed message bodies. Replaces get_interrupts.",
     inputSchema: {
       type: "object" as const,
       properties: {
         sessionId: { type: "string" },
         target: { type: "string", description: "Filter by target program ID" },
-        markAsRead: { type: "boolean", default: false },
+        markAsRead: { type: "boolean", default: true, description: "Default true: drains matching messages (pending -> delivered). Pass false for a non-destructive observer read." },
         includeDelivered: { type: "boolean", default: false, description: "Also return already-delivered messages (bodies re-readable; never re-claims). Default false." },
         message_type: { type: "string", enum: ["PING", "PONG", "HANDSHAKE", "DIRECTIVE", "STATUS", "ACK", "QUERY", "RESULT"], description: "Filter by message type" },
         priority: { type: "string", enum: ["low", "normal", "high"], description: "Filter by priority level" },


### PR DESCRIPTION
## What

Repo: `rezzedai/cachebash`, `services/mcp-server/src/modules/relay.ts`. Implements R2.4 per `grid/plans/ISO-plan-dispatch-defects-1-and-2.md` §7 (`85df6699`, origin/main).

`GetMessagesSchema.markAsRead` defaulted to `false`, and `getMessagesHandler` returns a read-only projection **before** any mutation. CLAUDE.md's documented boot call — `get_messages(sessionId: "{program}")` — and the recurring wake nudge both call it bare. Neither drained anything: messages stayed `pending` forever and re-served identically on every poll. VECTOR's ruling: flip the default — the same failure class as R1.1's TTL, "a protocol whose documented form silently does not drain is not a protocol."

## Caller enumeration (repo-wide, not just `services/mcp-server`)

| Site | Classification | Action |
|---|---|---|
| MCP stdio (`tools/relay.ts` → `relay_get_messages`) | INBOX — documented self-poll pattern (`docs/architecture.md`) | Wants new default. No change. |
| REST `GET /v1/messages` (`rest.ts:448`) | INBOX — bare passthrough of query params | Wants new default. No change. |
| REST `GET /v1/interrupts/peek` (`rest.ts:854`) | OBSERVER | **Already** hardcodes `markAsRead:false`. Unaffected by the flip — the dedicated safe path already exists. |
| `isoServer.ts` (`relay_get_messages` → `getMessagesHandler`) | Direct passthrough | Verified (not assumed) that `getMessagesHandler`'s existing target enforcement already restricts `"iso"`-classed program keys to `target === auth.programId \|\| target === "all"` — `"iso"` is **not** in the `legacy`/`mobile`/`dispatcher` exemption list, so a standard ISO call cannot cross-read another program's targeted inbox regardless of `markAsRead`. |
| Dashboard/monitor/cron/UI | — | **None found.** Grepped the whole repo (not just mcp-server) for `get_messages`/`getMessagesHandler`. `apps/web/src/app/overview/page.tsx` mentions `get_messages` only inside a documentation string, not a call. Direct `getMessagesHandler()` callers are limited to the three transports plus test files. |

Asserted zero additional observer sites needing an explicit-false annotation — stated with where I looked, per the task's instruction that "an asserted zero is fine, an assumed one is not."

## A real bug, found and fixed along the way

`dispatch()` (`dispatchHandler.ts`, `sendTaskAndDirective`) writes a relay doc with `target: args.target` **directly**, bypassing `sendMessageHandler`'s `resolveTargetsAsync` group-resolution/fan-out. So `dispatch(target:"all", ...)` creates **one** relay doc with `target:"all"` literally — confirmed via source, and via the existing integration fixture (`m4` in `relay-delivery.test.ts`), which was already exercising exactly this shape without the test author realizing its implication.

Flipping the default without addressing this would have made the **first program to bare-read its inbox silently swallow that broadcast for every other program it targeted** — Firestore has no per-recipient delivery state on a single doc, and every subsequent reader's default query only sees `status:"pending"`.

**Fix:** broadcast (`target:"all"`) docs are exempt from the claim transaction's mutation entirely. They're still returned to every caller; `status` and `deliveryAttempts` never change, regardless of `markAsRead`. This is a narrowing (fewer docs get mutated), not a widening — target enforcement (what a caller can *see*) is untouched; only whether reading a broadcast also *claims* it changes.

## Constraints

1. **No second retention path.** `includeDelivered:true` still re-opens delivered bodies per ADR-013, still never re-claims — unchanged.
2. **Target enforcement unchanged.** The broadcast exemption narrows mutation, doesn't widen visibility.
3. **Broadcast behavior checked and stated** (see above), not shipped unnoticed.
4. **CLAUDE.md wording** is now correct by default as documented (bare call drains) — **not edited here**, different repo; noting it for ISO to land in `grid/`.

## DoD

- [x] Regression suite (6 tests, `get-messages-mark-as-read-default.test.ts`) built first. Confirmed **RED** by git-stashing the relay.ts/tools/relay.ts/toolDefinitions.ts changes back to original and re-running — 4 of 6 failed exactly as expected. **GREEN** after restoring.
- [x] A bare call drains a direct message; `deliveryAttempts` increments; a second bare call returns empty for that message.
- [x] Explicit `markAsRead:false` still does not drain.
- [x] `includeDelivered:true` still returns the body after a drain (ADR-013 unbroken).
- [x] Broadcast never marked delivered even with `markAsRead:true`; `deliveryAttempts` never increments; still returned.
- [x] A broadcast survives being read by one recipient — a **different** recipient still sees it pending (the exact swallow-bug scenario).
- [x] Direct + broadcast in the same call handled independently.
- [x] Caller enumeration recorded above, per-site, with the observer decision and where I looked for others.

**Integration suite** (`__tests__/integration/relay-delivery.test.ts`): updated 3 existing assertions that encoded the swallow-bug as expected behavior (`m4` becoming `"delivered"`, a second poll returning empty), and added 3 new tests for the drain-by-default path, the explicit-false path, and the second-recipient-still-sees-it case. **I could not run this suite locally** — no Java runtime available for the Firestore emulator in this sandbox. Stating that plainly rather than claiming a pass I didn't observe. `tsc --noEmit` is clean on the updated file. **CI or a Java-equipped environment should run `test:integration` before merge** — flagging this explicitly since I can't self-certify it.

Full standard unit suite (`jest.config.js`): 787 passed, 21 pre-existing skips, 0 failures. `tsc --noEmit` clean.

## Merge note

Do not self-approve — cachebash `main`'s approving-review rule is unsatisfiable for Grid programs. Open PR, report back; ISO merges with `--admin`, records rationale, and hand-deploys (no CI/CD deploy job in this repo).

Also updated `docs/api-reference.md` and `docs/architecture.md` to reflect the new default (same repo — not `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01774PGrjJJJgw7cb1DTBRLj